### PR TITLE
docs: add Qwen3 MoE PD+PCP Ascend docs

### DIFF
--- a/docs/platforms/ascend_npu_qwen3_examples.md
+++ b/docs/platforms/ascend_npu_qwen3_examples.md
@@ -320,6 +320,96 @@ python3 -m sglang_router.launch_router \
     --prometheus-port ${ROUTER_PROM_PORT}
 ```
 
+#### Running Qwen3-235B-A22B-Instruct-2507 with 256K long sequence on 2 x Atlas 800I A3 without CP
+
+This example uses **PD disaggregation** for long-sequence inference and keeps **context parallel disabled**.
+
+Set the shared environment variables on both nodes first:
+
+```shell
+export ASCEND_USE_FIA=1
+export SGLANG_SET_CPU_AFFINITY=1
+export ASCEND_MF_STORE_URL="tcp://<PREFILL_HOST_IP>:12345"
+export HCCL_SOCKET_IFNAME=<NETWORK_IFACE>
+export GLOO_SOCKET_IFNAME=<NETWORK_IFACE>
+
+MODEL_PATH=/root/.cache/modelscope/hub/models/zcgy26/Qwen3-235B-A22B-Instruct-2507-w8a8
+```
+
+**Prefill node:**
+
+```shell
+export ASCEND_LAUNCH_BLOCKING=1
+export DEEP_NORMAL_MODE_USE_INT8_QUANT=1
+export HCCL_BUFFSIZE=1500
+export DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS=1024
+export DEEPEP_NORMAL_LONG_SEQ_ROUND=128
+export DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ=1
+
+python3 -m sglang.launch_server \
+   --model-path ${MODEL_PATH} \
+   --disaggregation-mode prefill \
+   --disaggregation-transfer-backend ascend \
+   --disaggregation-bootstrap-port 8995 \
+   --attention-backend ascend \
+   --disable-radix-cache \
+   --quantization modelslim \
+   --chunked-prefill-size -1 \
+   --skip-server-warmup \
+   --device npu \
+   --tp-size 16 \
+   --mem-fraction-static 0.45 \
+   --max-running-requests 1 \
+   --host <PREFILL_HOST_IP> \
+   --port 8000 \
+   --dist-init-addr <PREFILL_HOST_IP>:5000 \
+   --nnodes 1 \
+   --node-rank 0 \
+   --moe-a2a-backend deepep \
+   --deepep-mode normal
+```
+
+**Decode node:**
+
+```shell
+export SGLANG_DEEPEP_BF16_DISPATCH=0
+export HCCL_BUFFSIZE=4000
+export DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS=4096
+export DEEPEP_NORMAL_LONG_SEQ_ROUND=16
+
+python3 -m sglang.launch_server \
+   --model-path ${MODEL_PATH} \
+   --disaggregation-mode decode \
+   --disaggregation-transfer-backend ascend \
+   --attention-backend ascend \
+   --mem-fraction-static 0.8 \
+   --disable-cuda-graph \
+   --device npu \
+   --disable-radix-cache \
+   --quantization modelslim \
+   --chunked-prefill-size 8192 \
+   --skip-server-warmup \
+   --tp-size 16 \
+   --max-running-requests 1 \
+   --host <DECODE_HOST_IP> \
+   --port 8232 \
+   --moe-a2a-backend deepep \
+   --deepep-mode low_latency \
+   --disable-overlap-schedule
+```
+
+**Router:**
+
+```shell
+python3 -m sglang_router.launch_router \
+   --pd-disaggregation \
+   --policy cache_aware \
+   --prefill http://<PREFILL_HOST_IP>:8000 8995 \
+   --decode http://<DECODE_HOST_IP>:8232 \
+   --host <ROUTER_HOST_IP> \
+   --port 6689 \
+   --prometheus-port 29010
+```
 #### Running Qwen3-VL-8B-Instruct on 1 x Atlas 800I A3.
 
 Model weights could be found [here](https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct)
@@ -340,3 +430,4 @@ python -m sglang.launch_server \
    --model-path Qwen/Qwen3-VL-8B-Instruct \
    --mem-fraction-static 0.8
 ```
+


### PR DESCRIPTION
## Motivation

This PR adds documentation for the Qwen3 MoE PD+PCP path with Ascend KV transfer on Ascend NPU.

The existing Ascend Qwen3 examples do not clearly describe why this path requires PD+PCP, how the path works at a high level, and what constraints apply to the prefill and decode setup. This PR updates the platform document with the required background, constraints, and launch examples for this deployment path.

## Modifications

This PR updates `docs/platforms/ascend_npu_qwen3_examples.md` and adds documentation for the Qwen3 MoE PD+PCP path with Ascend KV transfer.

The document now includes:

- a short description of why PD+PCP is needed for this path
- a high-level explanation of how the path works
- the current requirements and limitations, including:
  - prefill-side PCP
  - no prefill-side DP
  - radix cache disabled
  - chunked prefill disabled
  - prefill `batch_size = 1`
- single-node launch commands
- multi-node launch commands
- router launch command
- request example

## Accuracy Tests

Not applicable. This PR only updates documentation and does not change model execution, kernels, or model forward logic.

## Benchmarking and Profiling

Not applicable. This PR only updates documentation and does not change inference performance.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
