### PR TITLE
[NPU] fix rope_theta get error for baichuan2-13b-chat model

### DIFF
--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -159,9 +159,7 @@ def get_rope_config(config):
     rope_params = getattr(config, "rope_parameters", None)
     if rope_params is not None:
         return rope_params["rope_theta"], rope_params
-    rope_theta = getattr(config, "rope_theta", 10000)
-    rope_scaling = getattr(config, "rope_scaling", None)
-    return rope_theta, rope_scaling
+    return getattr(config, "rope_theta", 10000), getattr(config, "rope_scaling", None)
 
 
 def _patch_text_config(parent_config: PretrainedConfig, text_config):

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -159,7 +159,9 @@ def get_rope_config(config):
     rope_params = getattr(config, "rope_parameters", None)
     if rope_params is not None:
         return rope_params["rope_theta"], rope_params
-    return config.rope_theta, getattr(config, "rope_scaling", None)
+    rope_theta = getattr(config, "rope_theta", 10000)
+    rope_scaling = getattr(config, "rope_scaling", None)
+    return rope_theta, rope_scaling
 
 
 def _patch_text_config(parent_config: PretrainedConfig, text_config):


### PR DESCRIPTION
## Motivation

PR https://github.com/sgl-project/sglang/pull/21135 use function `get_rope_config()` to directly get `config.rope_theta`, while in model `baichuan-inc/Baichuan2-13B-Chat`, its `config.json` doesn't have this attribute.

<img width="588" height="209" alt="image" src="https://github.com/user-attachments/assets/75e8d508-9849-4505-bc1d-6a3e5c2ad60c" />

Affected trust-remote-code models:
Baichuan2-13B-Chat

## Modifications

in function `get_rope_config()`, provide a reasonable default(10000) value when `rope_theta` is missing

## Accuracy Tests


## Benchmarking and Profiling


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
