### PR TITLE
NPU can use piece cuda graph when the piece cuda graph is explicitly declared

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5390,19 +5390,14 @@ class ServerArgs:
             help="Enable debug mode for torch compile",
         )
         parser.add_argument(
-            "--enable-piecewise-cuda-graph",
-            action="store_true",
-            help="Optimize the model with piecewise cuda graph for extend/prefill only.",
-        )
-        parser.add_argument(
             "--disable-piecewise-cuda-graph",
             action="store_true",
             help="Disable piecewise cuda graph for extend/prefill.",
         )
         parser.add_argument(
             "--enable-piecewise-cuda-graph",
-            action=DeprecatedAction,
-            help="Deprecated: Piecewise cuda graph is enabled by default. Use --enforce-piecewise-cuda-graph to skip auto-disable conditions.",
+            action="store_true",
+            help="Optimize the model with piecewise cuda graph for extend/prefill only.",
         )
         parser.add_argument(
             "--enforce-piecewise-cuda-graph",


### PR DESCRIPTION
…declared

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

NPU can use piece cuda graph when the piece cuda graph is explicitly declared

## Modifications

NPU can use piece cuda graph when the piece cuda graph is explicitly declared

## Accuracy Tests

```
python3 -m sglang.launch_server   --model-path /home/weights/Qwen3-4B   --trust-remote-code   --attention-backend ascend   --device npu   --mem-fraction-static 0.7   --disable-cuda-graph   --disable-radix-cache   --port 8889   --base-gpu-id 10
```
![不带参数启动](https://github.com/user-attachments/assets/1424e591-ea1d-4447-a78f-2ac7bb76ed70)


```
python3 -m sglang.launch_server   --model-path /home/weights/Qwen3-4B   --trust-remote-code   --attention-backend ascend   --device npu   --mem-fraction-static 0.7   --disable-cuda-graph   --disable-radix-cache   --port 8889   --base-gpu-id 10 --enable-piecewise-cuda-graph --piecewise-cuda-graph-tokens 64
```

![带参数启动](https://github.com/user-attachments/assets/9c40e824-f975-4263-b8d0-aa6a7926c983)


curl is ok

```
curl --location 'http://127.0.0.1:8889/generate' --header 'Content-Type: application/json' --data '{
    "text": "The capital of France is",
    "sampling_params": {
        "temperature": 0,
        "max_new_tokens": 50
    }
}'
```

![Snipaste_2026-03-28_18-30-58](https://github.com/user-attachments/assets/d7d454cb-a1b4-45d9-aa15-0e73295259de)



## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
