### PR TITLE
[NPU] fix some npu error with OffloaderV2

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/utils.py
+++ b/python/sglang/srt/hardware_backend/npu/utils.py
@@ -170,6 +170,10 @@ def npu_format_cast(
         )
         return tensor
 
+    # Skip format cast for meta tensors (used in offloader)
+    if tensor.device.type == "meta":
+        return tensor
+
     return torch.ops.npu.npu_format_cast(tensor, acl_format.value)
 
 

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -317,7 +317,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         if _is_npu:
             for weight_name in ["w13_weight", "w2_weight"]:
                 weight = getattr(layer, weight_name)
-                weight.data = weight.data.transpose(1, 2)
+                weight.data = weight.data.transpose(1, 2).contiguous()
                 weight.data = npu_format_cast(weight.data)
 
         return

--- a/python/sglang/srt/utils/offloader.py
+++ b/python/sglang/srt/utils/offloader.py
@@ -452,6 +452,10 @@ def _move_param_to_meta(module, param_name):
             data=new_data,
             requires_grad=False,
         )
+        if hasattr(old_param, "weihgt_loader"):
+            new_param.weight_loader = old_param.weight_loader
+        else:
+            new_param.weight_loader = lambda *args, **kwargs: None
     else:
         raise ValueError(f"Unknown {old_param_type=} {old_param=}")
 

--- a/test/registered/ascend/basic_function/offloading/test_npu_offload_modes.py
+++ b/test/registered/ascend/basic_function/offloading/test_npu_offload_modes.py
@@ -1,0 +1,104 @@
+import unittest
+from urllib.parse import urlparse
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import DEEPSEEK_CODER_V2_LITE_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=800, suite="nightly-2-npu-a3", nightly=True)
+
+TEST_MODEL_MATRIX = {
+    DEEPSEEK_CODER_V2_LITE_WEIGHTS_PATH,
+}
+
+
+class TestAscendOffloadModes(CustomTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.models = TEST_MODEL_MATRIX
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.url = urlparse(DEFAULT_URL_FOR_TEST)
+        cls.common_args = [
+            "--trust-remote-code",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            0.9,
+            "--attention-backend",
+            "ascend",
+            "--offload-group-size",
+            4,
+            "--offload-num-in-group",
+            1,
+            "--offload-prefetch-step",
+            1,
+            "--dp-size",
+            2,
+        ]
+
+    def run_a_test(self, offload_mode, additional_args=None):
+        """Run test for a specific offload mode."""
+        for model in self.models:
+            with self.subTest(model=model, offload_mode=offload_mode):
+                print(f"##=== Testing {offload_mode} offload: {model} ===##")
+
+                args = [
+                    *self.common_args,
+                    "--offload-mode",
+                    offload_mode,
+                ]
+
+                if additional_args:
+                    args.extend(additional_args)
+
+                process = popen_launch_server(
+                    model,
+                    self.base_url,
+                    timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                    other_args=args,
+                )
+
+                try:
+                    # Check if server is running (basic functionality test)
+                    response = requests.post(
+                        f"{DEFAULT_URL_FOR_TEST}/generate",
+                        json={
+                            "text": "Where is the capital of France?",
+                            "sampling_params": {
+                                "temperature": 0,
+                                "max_new_tokens": 32,
+                            },
+                        },
+                    )
+                    self.assertEqual(
+                        response.status_code,
+                        200,
+                        f"The request status code is not 200, server failed to respond for {offload_mode}",
+                    )
+                    self.assertIn(
+                        "Paris",
+                        response.text,
+                        f"The inference result does not include Paris, server failed to respond for {offload_mode}",
+                    )
+                finally:
+                    kill_process_tree(process.pid)
+
+    def test_offload_mode_cpu(self):
+        """Test offload mode: cpu"""
+        self.run_a_test("cpu")
+
+    def test_offload_mode_sharded_gpu(self):
+        """Test offload mode: sharded_gpu"""
+        self.run_a_test("sharded_gpu")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
when set --offload-mode=meta or sharded_gpu in feature offloaderV2, it doesn't work with npu.Then I fix some error to support those features in npu.
## Modifications

<!-- Detail the changes made in this pull request. -->
1.fix attr weight_loader of params missing in func _move_param_to_meta
2.Skip format cast for meta tensors
3.process tensor to be contiguous

**For this configuration:**
python -m sglang.launch_server \
--model-path /home/weights/deepseekv3-lite-base-latest \
--host 127.0.0.1 \
--port 8080 \
--attention-backend ascend \
--mem-fraction-static 0.9 \
--base-gpu-id 14 \
--tp 1 \
--dp 2 \
--offload-num-in-group 1 \
--offload-prefetch-step 1 \
--offload-mode sharded_gpu \
--offload-group-size 4 \
--disable-cuda-graph \

curl --location 'http://127.0.0.1:8080/generate' --header 'Content-Type:application/json' --data '{"text": "The captial of France is", "sampling_params": {"temperature": 0, "max_new_tokens": 20}}

**Before:**
<img width="1245" height="527" alt="image" src="https://github.com/user-attachments/assets/cc5907c4-497c-4833-8b18-c009bae66ea5" />
**After the first modification:**
<img width="1254" height="646" alt="image" src="https://github.com/user-attachments/assets/c86af792-3aa2-4c00-9b83-a402da56ec26" />
**After the second modification:**
<img width="988" height="441" alt="image" src="https://github.com/user-attachments/assets/8e133418-0ad6-4fbe-8312-57a0af9d31de" />
**After the third modification:**
the output is nomal
<img width="1251" height="300" alt="image" src="https://github.com/user-attachments/assets/b25c3fe0-a9df-43b5-9d03-8041fb5bfb16" />

the third modification sovled another  OffloaderV1 Accuracy error
When forwarding, torch.Tensor.to(device) changes the layout of non-contiguous tensors, causing an accuracy error in the **MoE model in offloaderV1 mode on TP2**.
For this configuration
<img width="422" height="164" alt="image" src="https://github.com/user-attachments/assets/3a3dfe22-5d3a-4a64-97e6-2d175ea21667" />
curl --location 'http://127.0.0.1:8080/generate' --header 'Content-Type:application/json' --data '{"text": "The captial of France is", "sampling_params": {"temperature": 0, "max_new_tokens": 20}}'
before
<img width="1263" height="286" alt="image" src="https://github.com/user-attachments/assets/4efe513e-7fa0-4aa4-b3a1-ab72e8101aaa" />
after
<img width="1263" height="270" alt="image" src="https://github.com/user-attachments/assets/97ebe5f6-9ddc-4c83-9ca1-7b01a4e7a01f" />

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

