### PR TITLE
[NPU] fix some error with OffloaderV1

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -157,9 +157,9 @@ def forward_mla_prepare_npu(
 ):
     # Ensure v_kc and w_vc are on the same device as hidden_states
     # These are tensor attributes, note nn.Parameter. so they need special handling(For OffloaderV1)
-    if m.w_kc is not None:
+    if m.w_kc is not None and m.w_kc.device != hidden_states.device:
         m.w_kc = m.w_kc.to(hidden_states.device, non_blocking=True)
-    if m.w_vc is not None:
+    if m.w_vc is not None and m.w_vc.device != hidden_states.device:
         m.w_vc = m.w_vc.to(hidden_states.device, non_blocking=True)
 
     if is_mla_preprocess_enabled():

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -155,6 +155,13 @@ def forward_mla_prepare_npu(
     zero_allocator: "BumpAllocator",
     layer_scatter_modes,
 ):
+    # Ensure v_kc and w_vc are on the same device as hidden_states
+    # These are tensor attributes, note nn.Parameter. so they need special handling(For OffloaderV1)
+    if m.w_kc is not None:
+        m.w_kc = m.w_kc.to(hidden_states.device, non_blocking=True)
+    if m.w_vc is not None:
+        m.w_vc = m.w_vc.to(hidden_states.device, non_blocking=True)
+
     if is_mla_preprocess_enabled():
         if not hasattr(m, "mla_preprocess"):
             m.mla_preprocess = NPUFusedMLAPreprocess(

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -381,7 +381,7 @@ class TopK(MultiPlatformOp):
         from sglang.srt.hardware_backend.npu.moe.topk import fused_topk_npu
 
         # Ensure correction_bias is on the same device as hidden_states(For OffloaderV1)
-        if self.topk_config.correction_bias is not None:
+        if self.topk_config.correction_bias is not None and self.topk_config.correction_bias.device != hidden_states.device:
             self.topk_config.correction_bias = self.topk_config.correction_bias.to(
                 hidden_states.device, non_blocking=True
             )

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -380,6 +380,12 @@ class TopK(MultiPlatformOp):
 
         from sglang.srt.hardware_backend.npu.moe.topk import fused_topk_npu
 
+        # Ensure correction_bias is on the same device as hidden_states(For OffloaderV1)
+        if self.topk_config.correction_bias is not None:
+            self.topk_config.correction_bias = self.topk_config.correction_bias.to(
+                hidden_states.device, non_blocking=True
+            )
+
         return fused_topk_npu(
             hidden_states=hidden_states,
             router_logits=router_logits,

--- a/python/sglang/srt/utils/offloader.py
+++ b/python/sglang/srt/utils/offloader.py
@@ -135,12 +135,14 @@ class OffloaderV1(BaseOffloader):
 
             def forward(*args, **kwargs):
                 module.forward = original_forward
-                device_state = {
-                    # here we blindly call `to(device)`
-                    # if the parameter is already on the device, it will be a no-op
-                    k: v.to(device, non_blocking=True)
-                    for k, v in module.state_dict().items()
-                }
+                device_state = {}
+                seen_params = set()
+                for name, param in module.named_parameters():
+                    if param not in seen_params:
+                        device_state[name] = param.to(device, non_blocking=True)
+                        seen_params.add(param)
+                for name, buffer in module.named_buffers():
+                    device_state[name] = buffer.to(device, non_blocking=True)
                 output = functional_call(module, device_state, args=args, kwargs=kwargs)
                 module.forward = forward
                 return output


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
when set --cpu-offload-gb in feature offloaderV1, it doesn't work with npu. Then I fix some error to support those features in npu.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
Comparison with Other Models, DeepSeek has a special design, Some tensors are not nn.Parameter and will not be covered by the device processing logic of OffloaderV1.
<img width="709" height="254" alt="image" src="https://github.com/user-attachments/assets/cbaab1e5-4781-4f45-81ff-394cb9133a1e" />
so these issues have been fixed：
1- The correction_bias device mismatch issue in TopK was resolved by adding device processing code to the TopK.forward_npu function.
2- functional_call does not support duplicate keys. The forward method of OffloaderV1 was modified to use named_parameters() and the seen_params set to avoid repeated processing of bound parameters.
3- The w_kc and w_vc device mismatch issue in MLA was resolved by adding device processing code to the forward_mla_prepare_npu function.

For this configuration:
python -m sglang.launch_server \
--model-path /home/weights/deepseekv3-lite-base-latest \
--host 127.0.0.1 \
--port 8080 \
--attention-backend ascend \
--mem-fraction-static 0.9 \
--base-gpu-id 14 \
--tp 1 \
--dp 1 \
--cpu-offload-gb 1 \
--disable-cuda-graph \

curl --location 'http://127.0.0.1:8080/generate' --header 'Content-Type:application/json' --data '{"text": "The captial of France is", "sampling_params": {"temperature": 0, "max_new_tokens": 20}}

**Before**
<img width="1251" height="397" alt="image" src="https://github.com/user-attachments/assets/91cfd837-d78b-45fd-acc8-6bd6295be2b3" />

After the first modification:
<img width="1239" height="532" alt="image" src="https://github.com/user-attachments/assets/f0dc1be9-9917-4240-a1a1-7a1abc18d47d" />
After the second modification:
<img width="1228" height="517" alt="image" src="https://github.com/user-attachments/assets/49014675-9eda-439c-9388-fd74da0b6f73" />
After the third modification，it can perform inference properly without any error reported.
<img width="1253" height="325" alt="image" src="https://github.com/user-attachments/assets/18009f3f-56d4-4f79-9a79-9d54ec358853" />
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
