### PR TITLE
Add barriers for shared memory in DP and non-DP attention

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1600,6 +1600,8 @@ class Scheduler(
                 and has_shm_features(recv_reqs)
             ):
                 barrier(group=self.tp_cpu_group)
+            if self.server_args.enable_dp_attention and has_shm_features(recv_reqs):
+                barrier(group=self.attn_tp_cpu_group)
             for req in recv_reqs:
                 unwrap_shm_features(req)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1579,20 +1579,21 @@ class Scheduler(
         # so that ShmPointerMMData metadata (not full tensor data) is what
         # gets serialized during broadcast_pyobj.
         if recv_reqs:
-            # Barrier for the non-DP-attention path only: there is a single
-            # broadcast_pyobj on tp_cpu_group where the source rank returns
-            # the original objects immediately while other ranks are still in
-            # pickle.loads (-> __setstate__ -> shm_open).  Without a barrier
-            # the source can call materialize() / shm_unlink before others
-            # open the segment.  recv_reqs is consistent across all ranks
-            # here (same broadcast), so the guard is deadlock-free.
+            # Both paths share the same race: the broadcast source rank
+            # returns the original objects immediately while receiver ranks
+            # are still in pickle.loads (-> __setstate__ -> shm_open).
+            # Without a barrier the source can call materialize() /
+            # shm_unlink before receivers open the segment.
             #
-            # Under DP-attention no barrier is needed: the control_reqs
-            # broadcast on tp_cpu_group (step 3) is a collective that forces
-            # every rank to complete the earlier attn_tp / attn_cp work_reqs
-            # deserializations (steps 1-2, which call shm_open) before any
-            # rank returns from step 3.  POSIX guarantees shm_unlink only
-            # removes the name; already-open handles stay valid.
+            # Non-DP-attention: a single broadcast_pyobj on tp_cpu_group,
+            # so a barrier on tp_cpu_group closes the race.
+            #
+            # DP-attention: work_reqs are broadcast on attn_tp_cpu_group
+            # (and optionally attn_cp_cpu_group), not on tp_cpu_group.
+            # The later control_reqs broadcast on tp_cpu_group is on a
+            # different group and does not guarantee that attn_tp receiver
+            # ranks have completed shm_open.  An explicit barrier on
+            # attn_tp_cpu_group is therefore required when attn_tp_size > 1.
             if (
                 not self.server_args.enable_dp_attention
                 and self.tp_size > 1
@@ -1600,7 +1601,12 @@ class Scheduler(
                 and has_shm_features(recv_reqs)
             ):
                 barrier(group=self.tp_cpu_group)
-            if self.server_args.enable_dp_attention and has_shm_features(recv_reqs):
+            if (
+                self.server_args.enable_dp_attention
+                and has_shm_features(recv_reqs)
+                and self.model_config.is_multimodal
+                and self.attn_tp_size > 1
+            ):
                 barrier(group=self.attn_tp_cpu_group)
             for req in recv_reqs:
                 unwrap_shm_features(req)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #23022.

When serving a multimodal model (e.g. Qwen2-VL, Qwen3.5-VL) with PD disaggregation and dp_size > 1 + --enable-dp-attention, the scheduler crashes with FileNotFoundError on POSIX shared memory segments for DP1+ ranks.

Root Cause: Under DP-attention, work_reqs are broadcast on attn_tp_cpu_group (not tp_cpu_group). The broadcast source rank returns immediately and calls materialize() / shm_unlink(), while receiver ranks are still in pickle.loads → __setstate__ → shm_open. The existing barrier only covered the non-DP-attention path. The later control_reqs broadcast on tp_cpu_group is a different process group and does not guarantee that attn_tp receiver ranks have completed shm_open.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
