### PR TITLE
[BugFix] Fix IndexError in req_index_to_mamba_index_mapping for PD disaggregation with hybrid mamba models

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -221,6 +221,38 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
             speculative_num_draft_tokens=speculative_num_draft_tokens,
         )
 
+        # req_index_to_mamba_index_mapping must cover all possible req_pool_idx values,
+        # which range from [0, size + pre_alloc_size). The _init_mamba_pool above may
+        # create a smaller mapping (sized by effective_mamba_size / mamba_size) to save
+        # mamba cache memory, but the mapping table itself must be large enough to avoid
+        # index-out-of-bounds when req_pool_idx >= effective_mamba_size.
+        mapping_size = size + pre_alloc_size
+        if self.req_index_to_mamba_index_mapping.shape[0] < mapping_size:
+            new_mapping = torch.zeros(
+                mapping_size, dtype=torch.int32, device=self.device
+            )
+            new_mapping[: self.req_index_to_mamba_index_mapping.shape[0]] = (
+                self.req_index_to_mamba_index_mapping
+            )
+            self.req_index_to_mamba_index_mapping = new_mapping
+        if self.enable_mamba_extra_buffer:
+            if (
+                self.req_index_to_mamba_ping_pong_track_buffer_mapping.shape[0]
+                < mapping_size
+            ):
+                new_pp_mapping = torch.zeros(
+                    (mapping_size, self.mamba_ping_pong_track_buffer_size),
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                old_size = self.req_index_to_mamba_ping_pong_track_buffer_mapping.shape[
+                    0
+                ]
+                new_pp_mapping[:old_size] = (
+                    self.req_index_to_mamba_ping_pong_track_buffer_mapping
+                )
+                self.req_index_to_mamba_ping_pong_track_buffer_mapping = new_pp_mapping
+
     def clear(self):
         self.free_slots = list(range(self.size + self.pre_alloc_size))
         self.mamba_pool.clear()


### PR DESCRIPTION
## Motivation

In PD disaggregation decode mode with hybrid mamba models (e.g., Qwen3.5-MoE), when `max_mamba_cache_size` is smaller than `size + pre_alloc_size`, the system crashes with:

```
File "/sglang/python/sglang/srt/disaggregation/decode.py", line 737, in pop_preallocated
    self.req_to_token_pool.req_index_to_mamba_index_mapping[
IndexError: index 32 is out of bounds for dimension 0 with size 32
```

**Root cause**: `DecodeReqToTokenPool` extends `free_slots` to `size + pre_alloc_size`, so `req_pool_idx` can range from `[0, size + pre_alloc_size)`. However, `_init_mamba_pool` creates `req_index_to_mamba_index_mapping` with size `effective_mamba_size = min(mamba_size, size + pre_alloc_size)`, which can be smaller than `size + pre_alloc_size`. When `req_pool_idx >= effective_mamba_size`, the index is out of bounds.

For example, with `--max-running-requests 64 --dp-size 2`:
- `free_slots` range: `[0, 64)`
- `max_mamba_cache_size`: 64 // 2 = 32
- `effective_mamba_size`: min(32, 64) = 32
- `req_index_to_mamba_index_mapping` size: 32 → crash when `req_pool_idx = 32`

## Modifications

In `HybridMambaDecodeReqToTokenPool.__init__`, after calling `_init_mamba_pool`, extend `req_index_to_mamba_index_mapping` and `req_index_to_mamba_ping_pong_track_buffer_mapping` to size `size + pre_alloc_size` if they are smaller.

This decouples the mapping table size from the mamba pool size:
- `MambaPool.size` stays at `effective_mamba_size` (respects user's memory limit)
- Mapping tables are extended to cover all possible `req_pool_idx` values (fixes the out-of-bounds error)

## Accuracy Tests

No impact. This fix only extends the size of mapping tables (negligible `int32` tensors) to prevent out-of-bounds access. The mamba pool capacity and allocation logic remain unchanged.

## Speed Tests and Profiling

No impact. The mapping table extension happens once during initialization, with zero runtime overhead.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
