### PR TITLE
[NPU] Support shared expert dual stream optimization and fix DP Attention compatibility

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/cmo.py
+++ b/python/sglang/srt/hardware_backend/npu/cmo.py
@@ -2,6 +2,18 @@ import torch
 
 cmo_stream = None
 
+conv1d_stream = None
+cache_update_stream = None
+# The total number of cores varies across different device types and needs to be adjusted accordingly.
+# The default core number here is set to that of the Ascend A3 (24 cores).
+CORE_NUM_FOR_CONV1D = 15
+CORE_NUM_FOR_CACHE_UPDATE = 9
+
+share_stream = None
+routed_stream = None
+CORE_NUM_FOR_SHARE = 8
+CORE_NUM_FOR_ROUTED = 16
+
 
 def get_cmo_stream():
     """
@@ -52,3 +64,85 @@ def wait_cmo_stream():
     if stream is not None:
         cur_stream = torch.npu.current_stream()
         cur_stream.wait_stream(stream)
+
+
+def get_or_create_cache_update_stream():
+    global cache_update_stream
+    if cache_update_stream is None:
+        cache_update_stream = torch.npu.Stream()
+        torch.npu.set_stream_limit(
+            cache_update_stream,
+            CORE_NUM_FOR_CACHE_UPDATE,
+            CORE_NUM_FOR_CACHE_UPDATE * 2,
+        )
+    return cache_update_stream
+
+
+def get_or_create_conv1d_stream():
+    global conv1d_stream
+    if conv1d_stream is None:
+        conv1d_stream = torch.npu.Stream()
+        torch.npu.set_stream_limit(
+            conv1d_stream, CORE_NUM_FOR_CONV1D, CORE_NUM_FOR_CONV1D * 2
+        )
+    return conv1d_stream
+
+
+def get_share_stream():
+    global share_stream
+    return share_stream
+
+
+def set_share_stream(stream):
+    global share_stream
+    share_stream = stream
+    torch.npu.set_stream_limit(share_stream, CORE_NUM_FOR_SHARE, CORE_NUM_FOR_SHARE * 2)
+
+
+def get_routed_stream():
+    global routed_stream
+    return routed_stream
+
+
+def set_routed_stream(stream):
+    global routed_stream
+    routed_stream = stream
+    torch.npu.set_stream_limit(
+        routed_stream, CORE_NUM_FOR_ROUTED, CORE_NUM_FOR_ROUTED * 2
+    )
+
+
+def wait_share_stream():
+    stream = get_share_stream()
+    if stream is not None:
+        cur_stream = torch.npu.current_stream()
+        cur_stream.wait_stream(stream)
+
+
+def wait_routed_stream():
+    stream = get_routed_stream()
+    if stream is not None:
+        cur_stream = torch.npu.current_stream()
+        cur_stream.wait_stream(stream)
+
+
+def shared_expert_on_independent_stream(hidden_states, forward_func):
+    stream = get_share_stream()
+    if stream is None:
+        stream = torch.npu.Stream()
+        set_share_stream(stream)
+    stream.wait_stream(torch.npu.current_stream())
+    with torch.npu.stream(stream):
+        shared_output = forward_func(hidden_states)
+        return shared_output
+
+
+def routed_expert_on_independent_stream(hidden_states, topk_output, forward_func):
+    stream = get_routed_stream()
+    if stream is None:
+        stream = torch.npu.Stream()
+        set_routed_stream(stream)
+    stream.wait_stream(torch.npu.current_stream())
+    with torch.npu.stream(stream):
+        routed_output = forward_func(hidden_states, topk_output)
+        return routed_output

--- a/python/sglang/srt/hardware_backend/npu/cmo.py
+++ b/python/sglang/srt/hardware_backend/npu/cmo.py
@@ -66,28 +66,6 @@ def wait_cmo_stream():
         cur_stream.wait_stream(stream)
 
 
-def get_or_create_cache_update_stream():
-    global cache_update_stream
-    if cache_update_stream is None:
-        cache_update_stream = torch.npu.Stream()
-        torch.npu.set_stream_limit(
-            cache_update_stream,
-            CORE_NUM_FOR_CACHE_UPDATE,
-            CORE_NUM_FOR_CACHE_UPDATE * 2,
-        )
-    return cache_update_stream
-
-
-def get_or_create_conv1d_stream():
-    global conv1d_stream
-    if conv1d_stream is None:
-        conv1d_stream = torch.npu.Stream()
-        torch.npu.set_stream_limit(
-            conv1d_stream, CORE_NUM_FOR_CONV1D, CORE_NUM_FOR_CONV1D * 2
-        )
-    return conv1d_stream
-
-
 def get_share_stream():
     global share_stream
     return share_stream

--- a/python/sglang/srt/hardware_backend/npu/cmo.py
+++ b/python/sglang/srt/hardware_backend/npu/cmo.py
@@ -146,3 +146,14 @@ def routed_expert_on_independent_stream(hidden_states, topk_output, forward_func
     with torch.npu.stream(stream):
         routed_output = forward_func(hidden_states, topk_output)
         return routed_output
+
+
+def moe_core_on_independent_stream(dispatch_output, forward_func):
+    stream = get_routed_stream()
+    if stream is None:
+        stream = torch.npu.Stream()
+        set_routed_stream(stream)
+    stream.wait_stream(torch.npu.current_stream())
+    with torch.npu.stream(stream):
+        combine_input = forward_func(dispatch_output)
+        return combine_input

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -89,9 +89,20 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
     is_cuda,
+    is_npu,
     make_layers,
     use_intel_amx_backend,
 )
+
+if is_npu():
+    from sglang.srt.hardware_backend.npu.cmo import (
+        shared_expert_on_independent_stream,
+        routed_expert_on_independent_stream,
+        wait_share_stream,
+        wait_routed_stream,
+    )
+
+from sglang.srt.environ import envs
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 logger = logging.getLogger(__name__)
@@ -266,11 +277,22 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         return shared_output
 
     def _forward_deepep(self, hidden_states: torch.Tensor, forward_batch: ForwardBatch):
+        enable_dual_stream = (
+            is_npu()
+            and envs.SGLANG_NPU_USE_MULTI_STREAM.get()
+            and forward_batch.forward_mode.is_cuda_graph()
+        )
+        enable_routed_stream = enable_dual_stream and not is_dp_attention_enabled()
         shared_output = None
         if hidden_states.shape[0] > 0:
             # router_logits: (num_tokens, n_experts)
             router_logits, _ = self.gate(hidden_states)
-            shared_output = self._forward_shared_experts(hidden_states)
+            if enable_dual_stream:
+                shared_output = shared_expert_on_independent_stream(
+                    hidden_states, self._forward_shared_experts
+                )
+            else:
+                shared_output = self._forward_shared_experts(hidden_states)
             topk_output = self.topk(
                 hidden_states,
                 router_logits,
@@ -285,10 +307,19 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             )
         else:
             topk_output = self.topk.empty_topk_output(hidden_states.device)
-        final_hidden_states = self.experts(
-            hidden_states=hidden_states,
-            topk_output=topk_output,
-        )
+        if enable_routed_stream:
+            final_hidden_states = routed_expert_on_independent_stream(
+                hidden_states, topk_output, self.experts
+            )
+            wait_routed_stream()
+            wait_share_stream()
+        else:
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states,
+                topk_output=topk_output,
+            )
+            if enable_dual_stream:
+                wait_share_stream()
 
         if shared_output is not None:
             final_hidden_states.add_(shared_output)

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -330,8 +330,6 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                 hidden_states=hidden_states,
                 topk_output=topk_output,
             )
-            if enable_dual_stream:
-                wait_share_stream()
 
         if shared_output is not None:
             final_hidden_states.add_(shared_output)

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -98,6 +98,7 @@ if is_npu():
     from sglang.srt.hardware_backend.npu.cmo import (
         shared_expert_on_independent_stream,
         routed_expert_on_independent_stream,
+        moe_core_on_independent_stream,
         wait_share_stream,
         wait_routed_stream,
     )
@@ -283,6 +284,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             and forward_batch.forward_mode.is_cuda_graph()
         )
         enable_routed_stream = enable_dual_stream and not is_dp_attention_enabled()
+        enable_dp_split_stream = enable_dual_stream and is_dp_attention_enabled()
         shared_output = None
         if hidden_states.shape[0] > 0:
             # router_logits: (num_tokens, n_experts)
@@ -312,6 +314,16 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                 hidden_states, topk_output, self.experts
             )
             wait_routed_stream()
+            wait_share_stream()
+        elif enable_dp_split_stream:
+            dispatch_output = self.experts.dispatch(hidden_states, topk_output)
+            combine_input = moe_core_on_independent_stream(
+                dispatch_output, self.experts.run_moe_core
+            )
+            wait_routed_stream()
+            final_hidden_states = self.experts.dispatcher.combine(
+                combine_input=combine_input,
+            )
             wait_share_stream()
         else:
             final_hidden_states = self.experts(

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -97,10 +97,7 @@ from sglang.srt.utils import (
 if is_npu():
     from sglang.srt.hardware_backend.npu.cmo import (
         shared_expert_on_independent_stream,
-        routed_expert_on_independent_stream,
-        moe_core_on_independent_stream,
         wait_share_stream,
-        wait_routed_stream,
     )
 
 from sglang.srt.environ import envs
@@ -283,8 +280,6 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             and envs.SGLANG_NPU_USE_MULTI_STREAM.get()
             and forward_batch.forward_mode.is_cuda_graph()
         )
-        enable_routed_stream = enable_dual_stream and not is_dp_attention_enabled()
-        enable_dp_split_stream = enable_dual_stream and is_dp_attention_enabled()
         shared_output = None
         if hidden_states.shape[0] > 0:
             # router_logits: (num_tokens, n_experts)
@@ -309,27 +304,12 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             )
         else:
             topk_output = self.topk.empty_topk_output(hidden_states.device)
-        if enable_routed_stream:
-            final_hidden_states = routed_expert_on_independent_stream(
-                hidden_states, topk_output, self.experts
-            )
-            wait_routed_stream()
+        final_hidden_states = self.experts(
+            hidden_states=hidden_states,
+            topk_output=topk_output,
+        )
+        if enable_dual_stream:
             wait_share_stream()
-        elif enable_dp_split_stream:
-            dispatch_output = self.experts.dispatch(hidden_states, topk_output)
-            combine_input = moe_core_on_independent_stream(
-                dispatch_output, self.experts.run_moe_core
-            )
-            wait_routed_stream()
-            final_hidden_states = self.experts.dispatcher.combine(
-                combine_input=combine_input,
-            )
-            wait_share_stream()
-        else:
-            final_hidden_states = self.experts(
-                hidden_states=hidden_states,
-                topk_output=topk_output,
-            )
 
         if shared_output is not None:
             final_hidden_states.add_(shared_output)


### PR DESCRIPTION
## Motivation

On NPU, the shared expert and routed expert in MoE models are executed sequentially on the same stream, leaving compute resources underutilized. This PR introduces a dual stream optimization that overlaps shared expert computation with routed expert computation on independent NPU streams, and resolves the HCCL deadlock issue when DP Attention is enabled alongside dual stream.

## Modifications

### 1. Shared Expert Dual Stream Optimization
- Added shared_expert_on_independent_stream and routed_expert_on_independent_stream in cmo.py to offload shared/routed expert computation to independent NPU streams with dedicated core allocation (8 cores for shared, 16 cores for routed).
- Modified Qwen2MoeModel._forward_deepep to execute shared expert and routed expert on separate streams in parallel when SGLANG_NPU_USE_MULTI_STREAM is enabled during CUDA graph mode.

### 2. Fix DP Attention + Dual Stream Deadlock
When DP Attention is enabled, dp_gather / dp_scatter (HCCL operations) run on the main stream, while deepep_dispatch / deepep_combine (also HCCL operations) run on the routed stream. Parallel HCCL operations on different streams cause communication channel conflicts and deadlock.

The fix introduces a three-stage split strategy for DP mode:

- dispatch (HCCL) stays on the main stream
- expert compute (pure computation) runs on the routed stream
- combine (HCCL) returns to the main stream
This ensures all HCCL operations execute serially on the main stream while still overlapping the pure computation parts (shared expert + expert compute) across streams.

Added moe_core_on_independent_stream in cmo.py to support offloading only the compute portion of routed experts.

## Accuracy Tests

```
# dual stream moe
export SGLANG_NPU_USE_MULTI_STREAM=1

MODEL_PATH=/home/weights/Qwen3.6-35B-A3B

python3 -m sglang.launch_server \
    --model-path  ${MODEL_PATH} \
    --attention-backend ascend \
    --device npu \
    --tp-size 4 \
    --ep-size 4 \
    --chunked-prefill-size -1 --max-prefill-tokens 17500 \
    --disable-radix-cache \
    --trust-remote-code \
    --host 127.0.0.1 --max-running-requests 128 \
    --mem-fraction-static 0.8 \
    --port 9903 \
    --cuda-graph-bs 2 4 6 8 12 16 20 24 28 32 36 48 52 54 56 60 64 \
    --enable-multimodal --moe-a2a-backend deepep --deepep-mode auto \
    --mm-attention-backend ascend_attn  \
    --dtype bfloat16 --mamba-ssm-dtype bfloat16 --max-total-tokens 320000  \
    --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
    --base-gpu-id 12 \
    --max-mamba-cache-size 128 \
    --dp-size 2 --enable-dp-attention --enable-dp-lm-head \
```

GSM8K accuracy test:

```
+-----------------+-----------+----------+----------+-------+---------+---------+
| Model           | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+=================+===========+==========+==========+=======+=========+=========+
| Qwen3.6-35B-A3B | gsm8k     | mean_acc | main     |   256 |  0.9766 | default |
+-----------------+-----------+----------+----------+-------+---------+---------+
```

## Speed Tests and Profiling

Benchmarked on Qwen2.5-MoE with --dp-size 2 --enable-dp-attention --enable-dp-lm-head , 128 concurrent requests:

Metric | Dual Stream Disabled | This PR | Improvement
-- | -- | -- | --
throughput (req/s) | 1.72 | 1.91 | +11.0%
Output token throughput (tok/s) | 2580.73 | 2868.83 | +11.2%
Total token throughput (tok/s) | 8602.42 | 9562.76 | +11.2%
Mean E2E Latency (ms) | 57695 | 52973 | -8.2%
Mean TTFT (ms) | 14646 | 13708 | -6.4%
Mean TPOT (ms) | 28.72 | 26.19 | -8.8%


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
