### PR TITLE
Add HiCache NPU new test cases

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -25,7 +25,7 @@ jobs:
   hicache-npu-new-1-npu-a3:
     runs-on: linux-aarch64-a3-1
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260605
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -23,10 +23,6 @@ jobs:
   # ==================== HiCache NPU New Test Cases ====================
   # HiCache functional tests - 1 NPU
   hicache-npu-new-1-npu-a3:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       contains(github.event.pull_request.changed_files, 'test/registered/ascend/basic_function/HiCache_npu_new/'))
     runs-on: linux-aarch64-a3-1
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
@@ -92,10 +88,6 @@ jobs:
 
   # HiCache functional tests - 4 NPU
   hicache-npu-new-4-npu-a3:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       contains(github.event.pull_request.changed_files, 'test/registered/ascend/basic_function/HiCache_npu_new/'))
     runs-on: linux-aarch64-a3-4
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,156 @@
+name: Single Test (NPU)
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+      - "test/registered/ascend/basic_function/HiCache_npu_new/**"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (branch, tag, or SHA) to test. If not provided, uses the default branch.'
+        required: false
+        type: string
+        default: ''
+
+concurrency:
+  group: single-test-npu-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ==================== HiCache NPU New Test Cases ====================
+  # HiCache functional tests - 1 NPU
+  hicache-npu-new-1-npu-a3:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.changed_files, 'test/registered/ascend/basic_function/HiCache_npu_new/'))
+    runs-on: linux-aarch64-a3-1
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
+    strategy:
+      fail-fast: false
+      matrix:
+        test_case:
+          # 1 NPU test cases
+          - test_npu_hicache_kv_events.py
+          - test_npu_hicache_3fs_backend.py
+          - test_npu_hicache_storage_file_backend.py
+          - test_npu_hicache_runtime_attach_detach.py
+          # EAGLE tests (skipped for now)
+          # - test_npu_hicache_eagle_variant.py
+          # - test_npu_hicache_spec_file_storage.py
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Mark repository safe
+        run: |
+          git config --system --add safe.directory ${GITHUB_WORKSPACE}
+
+      - name: Install dependencies
+        env:
+          TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+          PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+          UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+          GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+          RUSTUP_DIST_SERVER: "https://rsproxy.cn"
+          RUSTUP_UPDATE_ROOT: "https://rsproxy.cn/rustup"
+        run: |
+          # speed up by using infra cache services
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host "${CACHING_URL}"
+
+          bash scripts/ci/npu/npu_ci_install_dependency.sh a3
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          # copy gsm8k dataset
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+      - name: Print Log Information
+        run: |
+          bash scripts/ci/npu/npu_log_print.sh
+
+      - name: Run test - ${{ matrix.test_case }}
+        timeout-minutes: 60
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          SGLANG_IS_IN_CI: true
+          HF_ENDPOINT: https://hf-mirror.com
+          TORCH_EXTENSIONS_DIR: /tmp/torch_extensions
+          PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+          STREAMS_PER_DEVICE: 32
+        run: |
+          cd test/registered/ascend/basic_function/HiCache_npu_new
+          python3 -m pytest ${{ matrix.test_case }} -v --tb=short
+
+  # HiCache functional tests - 4 NPU
+  hicache-npu-new-4-npu-a3:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.changed_files, 'test/registered/ascend/basic_function/HiCache_npu_new/'))
+    runs-on: linux-aarch64-a3-4
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
+    strategy:
+      fail-fast: false
+      matrix:
+        test_case:
+          # 4 NPU test cases
+          - test_npu_hicache_large_model.py
+          - test_npu_pp_with_hicache.py
+          - test_npu_hicache_mooncake_backend.py
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Mark repository safe
+        run: |
+          git config --system --add safe.directory ${GITHUB_WORKSPACE}
+
+      - name: Install dependencies
+        env:
+          TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+          PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+          UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+          GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+          RUSTUP_DIST_SERVER: "https://rsproxy.cn"
+          RUSTUP_UPDATE_ROOT: "https://rsproxy.cn/rustup"
+        run: |
+          # speed up by using infra cache services
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host "${CACHING_URL}"
+
+          bash scripts/ci/npu/npu_ci_install_dependency.sh a3
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          # copy gsm8k dataset
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+      - name: Print Log Information
+        run: |
+          bash scripts/ci/npu/npu_log_print.sh
+
+      - name: Run test - ${{ matrix.test_case }}
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          SGLANG_IS_IN_CI: true
+          HF_ENDPOINT: https://hf-mirror.com
+          TORCH_EXTENSIONS_DIR: /tmp/torch_extensions
+          PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+          STREAMS_PER_DEVICE: 32
+        run: |
+          cd test/registered/ascend/basic_function/HiCache_npu_new
+          python3 -m pytest ${{ matrix.test_case }} -v --tb=short

--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,9 @@ tl_out/
 work_dirs/
 *.csv
 
+# Trae IDE config
+.trae/
+
 !logo.png
 !docs_new/images/*.png
 
@@ -276,3 +279,4 @@ sgl-kernel/csrc/**/*_musa/
 *.ply
 *.npz
 artifacts/
+.claude/scheduled_tasks.lock

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_3fs_backend.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_3fs_backend.py
@@ -232,8 +232,9 @@ class TestNPUHf3fsBackendAccuracy(NPUHiCacheStorage3FSBackendBaseMixin, CustomTe
 
     def test_eval_accuracy(self):
         """Test eval accuracy with cache persistence across cache flushes."""
-        import requests
         from types import SimpleNamespace
+
+        import requests
 
         print("\n=== Testing Eval Accuracy with HF3FS Cache ===")
 

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_3fs_backend.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_3fs_backend.py
@@ -1,0 +1,282 @@
+"""
+Benchmark tests for HiCache Storage with 3FS backend on Ascend NPU.
+
+Tests HF3FS distributed storage backend with different memory layouts
+and accuracy validation after cache flush.
+
+NPU-specific adaptations:
+- --attention-backend ascend
+- --disable-cuda-graph
+- --hicache-io-backend kernel_ascend
+- --hicache-mem-layout page_first_direct
+
+Usage:
+    python3 -m pytest test/registered/ascend/basic_function/HiCache/test_npu_hicache_3fs_backend.py -v
+"""
+
+import json
+import os
+import unittest
+
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+from sglang.utils import wait_for_http_ready
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class NPUHiCacheStorage3FSBackendBaseMixin:
+    """Base mixin class with common setup and utilities for NPU 3FS backend tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        import tempfile
+
+        cls.temp_dir = tempfile.mkdtemp()
+        cls.model = cls._get_model_name()
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        cls.process = cls._launch_server_with_hicache()
+        cls._wait_for_server_ready(process=cls.process)
+
+        print(f"Test server launched successfully at {cls.base_url}")
+
+    @classmethod
+    def tearDownClass(cls):
+        import shutil
+
+        if hasattr(cls, "process") and cls.process:
+            from sglang.srt.utils import kill_process_tree
+
+            kill_process_tree(cls.process.pid)
+
+        if hasattr(cls, "temp_dir"):
+            shutil.rmtree(cls.temp_dir, ignore_errors=True)
+
+    @classmethod
+    def _get_model_name(cls):
+        return QWEN3_8B_WEIGHTS_PATH
+
+    @classmethod
+    def _launch_server_with_hicache(cls):
+        hf3fs_config = {
+            "file_path_prefix": os.path.join(cls.temp_dir, "hicache"),
+            "file_size": 1024 * 1024 * 1024 * 2,
+            "numjobs": 2,
+            "entries": 8,
+            "use_mock_hf3fs_client": True,
+            "hicache_storage_pass_prefix_keys": True,
+        }
+
+        config_file = os.path.join(cls.temp_dir, "hf3fs_config.json")
+        with open(config_file, "w") as f:
+            json.dump(hf3fs_config, f, indent=2)
+
+        server_args, env_vars = cls._get_additional_server_args_and_env()
+
+        final_server_args = []
+        for k, v in server_args.items():
+            if isinstance(v, bool):
+                final_server_args.append(str(k))
+            else:
+                final_server_args.append(str(k))
+                final_server_args.append(str(v))
+
+        print(f"final_server_args: {final_server_args}")
+
+        env_vars = {
+            **os.environ,
+            **env_vars,
+            "SGLANG_HICACHE_HF3FS_CONFIG_PATH": config_file,
+            "SGLANG_ENABLE_DETERMINISTIC_INFERENCE": "1",
+        }
+
+        return popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=final_server_args,
+            env=env_vars,
+        )
+
+    @classmethod
+    def _wait_for_server_ready(cls, timeout: int = 60, process=None) -> bool:
+        wait_for_http_ready(
+            url=f"{cls.base_url}/health",
+            timeout=timeout,
+            process=process,
+        )
+        return True
+
+    @classmethod
+    def _get_additional_server_args_and_env(cls):
+        hf3fs_config = {
+            "file_path_prefix": os.path.join(cls.temp_dir, "hicache"),
+            "file_size": 1024 * 1024 * 1024 * 2,
+            "numjobs": 2,
+            "entries": 8,
+            "use_mock_hf3fs_client": True,
+            "hicache_storage_pass_prefix_keys": True,
+        }
+
+        server_args = {
+            "--tp-size": 1,
+            "--hicache-ratio": 1.2,
+            "--hicache-storage-backend": "hf3fs",
+            "--hicache-io-backend": "kernel_ascend",
+            "--attention-backend": "ascend",
+            "--disable-cuda-graph": True,
+            "--hicache-storage-backend-extra-config": json.dumps(hf3fs_config),
+        }
+
+        env_vars = {}
+
+        return server_args, env_vars
+
+
+class TestNPUHf3fsBackendPageFirstLayout(
+    NPUHiCacheStorage3FSBackendBaseMixin, CustomTestCase
+):
+    """Page first layout tests for HiCache-HF3FS backend on NPU.
+
+    [Test Category] HiCache
+    [Test Target] HF3FS distributed storage with page_first_direct layout
+    """
+
+    @classmethod
+    def _get_additional_server_args_and_env(cls):
+        server_args, env_vars = super()._get_additional_server_args_and_env()
+        server_args["--hicache-mem-layout"] = "page_first_direct"
+        return server_args, env_vars
+
+    def test_basic_storage_and_retrieval(self):
+        """Test storage and retrieval through HF3FS backend."""
+        import requests
+
+        print("\n=== Testing HF3FS Cache Storage & Retrieval ===")
+
+        prompt = "What is the capital of France? " * 50
+
+        print("Step 1: Populating cache...")
+        response1 = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 50,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=60,
+        )
+        self.assertEqual(response1.status_code, 200)
+
+        print("Step 2: Flushing cache...")
+        res = requests.post(
+            f"{self.base_url}/flush_cache",
+            params={"timeout": 30},
+            timeout=40,
+        )
+        res.raise_for_status()
+
+        import time
+
+        time.sleep(2)
+
+        print("Step 3: Testing cache hit from HF3FS storage...")
+        response2 = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 50,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=60,
+        )
+        self.assertEqual(response2.status_code, 200)
+
+        cached_tokens = int(response2.json().get("meta_info", {}).get("cached_tokens", 0))
+        print(f"Cached tokens: {cached_tokens}")
+
+        self.assertGreater(
+            cached_tokens, 100, "Expected significant cached tokens for HF3FS hit"
+        )
+
+
+class TestNPUHf3fsBackendAccuracy(
+    NPUHiCacheStorage3FSBackendBaseMixin, CustomTestCase
+):
+    """Accuracy tests for HiCache-HF3FS backend on NPU.
+
+    [Test Category] HiCache
+    [Test Target] GSM8K accuracy consistency after cache flush with HF3FS backend
+    """
+
+    @classmethod
+    def _get_additional_server_args_and_env(cls):
+        server_args, env_vars = super()._get_additional_server_args_and_env()
+        server_args["--hicache-ratio"] = 1.5
+        server_args["--hicache-mem-layout"] = "page_first_direct"
+        return server_args, env_vars
+
+    def test_eval_accuracy(self):
+        """Test eval accuracy with cache persistence across cache flushes."""
+        import requests
+        from types import SimpleNamespace
+
+        print("\n=== Testing Eval Accuracy with HF3FS Cache ===")
+
+        print("Phase 1: Running initial GSM8K evaluation...")
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics_initial = run_eval_few_shot_gsm8k(args)
+        print(f"Initial accuracy: {metrics_initial['accuracy']}")
+
+        print("Phase 2: Flushing device cache...")
+        res = requests.post(
+            f"{self.base_url}/flush_cache",
+            params={"timeout": 30},
+            timeout=40,
+        )
+        res.raise_for_status()
+
+        print("Phase 3: Running second GSM8K evaluation...")
+        metrics_cached = run_eval_few_shot_gsm8k(args)
+        print(f"Cached accuracy: {metrics_cached['accuracy']}")
+
+        accuracy_diff = abs(metrics_initial["accuracy"] - metrics_cached["accuracy"])
+        print(f"Accuracy difference: {accuracy_diff:.4f}")
+
+        self.assertGreater(
+            metrics_initial["accuracy"], 0.6, "Initial accuracy should be reasonable"
+        )
+        self.assertGreater(
+            metrics_cached["accuracy"], 0.6, "Cached accuracy should be reasonable"
+        )
+        self.assertLess(
+            accuracy_diff,
+            0.05,
+            "Accuracy should be consistent between cache states",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_3fs_backend.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_3fs_backend.py
@@ -206,7 +206,9 @@ class TestNPUHf3fsBackendPageFirstLayout(
         )
         self.assertEqual(response2.status_code, 200)
 
-        cached_tokens = int(response2.json().get("meta_info", {}).get("cached_tokens", 0))
+        cached_tokens = int(
+            response2.json().get("meta_info", {}).get("cached_tokens", 0)
+        )
         print(f"Cached tokens: {cached_tokens}")
 
         self.assertGreater(
@@ -214,9 +216,7 @@ class TestNPUHf3fsBackendPageFirstLayout(
         )
 
 
-class TestNPUHf3fsBackendAccuracy(
-    NPUHiCacheStorage3FSBackendBaseMixin, CustomTestCase
-):
+class TestNPUHf3fsBackendAccuracy(NPUHiCacheStorage3FSBackendBaseMixin, CustomTestCase):
     """Accuracy tests for HiCache-HF3FS backend on NPU.
 
     [Test Category] HiCache

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_eagle_variant.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_eagle_variant.py
@@ -18,7 +18,7 @@ Usage:
 
 import unittest
 
-from sglang.srt.utils import is_hip, kill_process_tree
+from sglang.srt.utils import kill_process_tree
 from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import (

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_eagle_variant.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_eagle_variant.py
@@ -1,0 +1,131 @@
+"""
+Test HiCache with EAGLE speculative decoding variant on Ascend NPU.
+
+Tests HiCache combined with EAGLE3 speculative decoding to verify
+cache reuse and speculative accept length meet thresholds.
+
+NPU-specific adaptations:
+- --attention-backend ascend
+- --disable-cuda-graph
+- --hicache-io-backend kernel_ascend
+- --hicache-mem-layout page_first_direct
+
+Note: Skip if EAGLE3 is not supported on current NPU aiter version.
+
+Usage:
+    python3 -m pytest test/registered/ascend/basic_function/HiCache/test_npu_hicache_eagle_variant.py -v
+"""
+
+import unittest
+
+from sglang.srt.utils import is_hip, kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+@unittest.skip("EAGLE3 speculative decoding not yet supported on Ascend NPU")
+class TestNPUHiCacheEagle(CustomTestCase):
+    """Test HiCache with EAGLE speculative decoding on NPU.
+
+    [Test Category] HiCache
+    [Test Target] HiCache + EAGLE3 speculative decoding integration
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_8B_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        cls.hicache_args = [
+            "--enable-hierarchical-cache",
+            "--hicache-ratio",
+            "1.2",
+            "--mem-fraction-static",
+            "0.7",
+            "--hicache-io-backend",
+            "kernel_ascend",
+            "--hicache-mem-layout",
+            "page_first_direct",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--speculative-algorithm",
+            "EAGLE3",
+            "--speculative-draft-model-path",
+            cls.model,
+            "--speculative-num-steps",
+            "5",
+            "--speculative-eagle-topk",
+            "1",
+            "--speculative-num-draft-tokens",
+            "4",
+        ]
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls.hicache_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_hicache_eagle_cache_reuse(self):
+        """Test that HiCache works correctly with EAGLE speculative decoding."""
+        import requests
+
+        prompt = "Explain the concept of machine learning in detail. " * 20
+
+        for i in range(2):
+            response = requests.post(
+                f"{self.base_url}/generate",
+                json={
+                    "text": prompt,
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 50,
+                        "ignore_eos": True,
+                    },
+                },
+                timeout=120,
+            )
+            self.assertEqual(response.status_code, 200)
+
+            meta_info = response.json().get("meta_info", {})
+            cached_tokens = int(meta_info.get("cached_tokens", 0))
+            spec_accept_length = float(meta_info.get("spec_accept_length", 0))
+
+            print(f"Request {i+1}: cached_tokens={cached_tokens}, spec_accept_length={spec_accept_length:.2f}")
+
+            if i == 0:
+                self.assertEqual(cached_tokens, 0, "First request should have no cache")
+                self.assertGreater(
+                    spec_accept_length,
+                    1.5,
+                    "First request spec_accept_length should be reasonable",
+                )
+            else:
+                self.assertGreater(
+                    cached_tokens,
+                    0,
+                    "Second request should have cache hit",
+                )
+                self.assertGreater(
+                    spec_accept_length,
+                    1.5,
+                    "Second request spec_accept_length should be maintained",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_eagle_variant.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_eagle_variant.py
@@ -105,7 +105,9 @@ class TestNPUHiCacheEagle(CustomTestCase):
             cached_tokens = int(meta_info.get("cached_tokens", 0))
             spec_accept_length = float(meta_info.get("spec_accept_length", 0))
 
-            print(f"Request {i+1}: cached_tokens={cached_tokens}, spec_accept_length={spec_accept_length:.2f}")
+            print(
+                f"Request {i+1}: cached_tokens={cached_tokens}, spec_accept_length={spec_accept_length:.2f}"
+            )
 
             if i == 0:
                 self.assertEqual(cached_tokens, 0, "First request should have no cache")

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_kv_events.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_kv_events.py
@@ -1,0 +1,135 @@
+"""
+Test KV Events with HiCache on Ascend NPU.
+
+Tests that KV cache events (BlockStored) are correctly emitted when
+HiCache stores KV blocks to file storage.
+
+NPU-specific adaptations:
+- --attention-backend ascend
+- --disable-cuda-graph
+- --hicache-io-backend kernel_ascend
+- --hicache-mem-layout page_first_direct
+
+Usage:
+    python3 -m pytest test/registered/ascend/basic_function/HiCache/test_npu_hicache_kv_events.py -v
+"""
+
+import shutil
+import tempfile
+import time
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPUHiCacheKVEvents(CustomTestCase):
+    """Test KV Events with HiCache on NPU.
+
+    [Test Category] HiCache
+    [Test Target] KV events emission with HiCache file storage
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_8B_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.storage_dir = tempfile.mkdtemp(prefix="npu-hicache-kv-events-")
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--enable-hierarchical-cache",
+                "--hicache-ratio",
+                "1.2",
+                "--hicache-size",
+                "0",
+                "--hicache-write-policy",
+                "write_through",
+                "--hicache-storage-backend",
+                "file",
+                "--hicache-storage-prefetch-policy",
+                "wait_complete",
+                "--hicache-mem-layout",
+                "page_first_direct",
+                "--hicache-io-backend",
+                "kernel_ascend",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--kv-events-config",
+                '{"publisher": "zmq", "topic": "kv-events"}',
+            ],
+            env={
+                "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.storage_dir,
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+        shutil.rmtree(cls.storage_dir, ignore_errors=True)
+
+    def test_kv_events_smoke(self):
+        """Test that KV events are emitted when HiCache stores blocks."""
+        try:
+            import zmq
+            from msgspec.msgpack import Decoder
+
+            from sglang.srt.disaggregation.kv_events import BlockStored, KVEventBatch
+        except ImportError:
+            self.skipTest("zmq or msgspec not available for KV events test")
+
+        decoder = Decoder(type=KVEventBatch)
+        context = zmq.Context()
+        sub = context.socket(zmq.SUB)
+        sub.connect("tcp://localhost:5557")
+        sub.setsockopt_string(zmq.SUBSCRIBE, "kv-events")
+
+        try:
+            time.sleep(1.0)
+
+            prompt = "HiCache KV event compatibility check on NPU. " * 64
+            res = requests.post(
+                f"{self.base_url}/generate",
+                json={
+                    "text": prompt,
+                    "sampling_params": {"temperature": 0, "max_new_tokens": 10},
+                },
+                timeout=120,
+            )
+            res.raise_for_status()
+
+            events = []
+            deadline = time.time() + 10
+            while time.time() < deadline and not any(
+                isinstance(event, BlockStored) for event in events
+            ):
+                if sub.poll(timeout=100):
+                    _, _, payload = sub.recv_multipart()
+                    events.extend(decoder.decode(payload).events)
+
+            self.assertTrue(
+                any(isinstance(event, BlockStored) for event in events),
+                "Expected at least one BlockStored event from NPU HiCache server",
+            )
+        finally:
+            sub.close()
+            context.term()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_large_model.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_large_model.py
@@ -1,0 +1,143 @@
+"""
+Test Large Model with HiCache on 4-NPU Ascend cluster.
+
+Tests HiCache with large model (Qwen3-32B) on 4 NPUs to verify
+cache functionality and accuracy consistency at scale.
+
+NPU-specific adaptations:
+- --attention-backend ascend
+- --disable-cuda-graph
+- --hicache-io-backend kernel_ascend
+- --hicache-mem-layout page_first_direct
+
+Usage:
+    python3 -m pytest test/registered/ascend/basic_function/HiCache/test_npu_hicache_large_model.py -v
+"""
+
+import shutil
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_32B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-4-npu-a3", nightly=True)
+
+ACC_THRESHOLDS = {"gsm8k": 0.8}
+
+
+class TestNPUHiCacheLargeModel(CustomTestCase):
+    """Test Large Model with HiCache on 4-NPU Ascend cluster.
+
+    [Test Category] HiCache
+    [Test Target] Large model + HiCache accuracy at scale
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_32B_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.storage_dir = tempfile.mkdtemp(prefix="npu-hicache-large-")
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp-size",
+                "4",
+                "--max-total-tokens",
+                "120000",
+                "--chunked-prefill-size",
+                "2048",
+                "--max-running-requests",
+                "128",
+                "--hicache-mem-layout",
+                "page_first_direct",
+                "--enable-hierarchical-cache",
+                "--hicache-ratio",
+                "2",
+                "--hicache-size",
+                "0",
+                "--hicache-write-policy",
+                "write_through",
+                "--hicache-storage-backend",
+                "file",
+                "--hicache-storage-prefetch-policy",
+                "wait_complete",
+                "--hicache-io-backend",
+                "kernel_ascend",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ],
+            env={
+                "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.storage_dir,
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+        shutil.rmtree(cls.storage_dir, ignore_errors=True)
+
+    def _run_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        return run_eval_few_shot_gsm8k(args)
+
+    def test_gsm8k(self):
+        """Test GSM8K accuracy consistency with HiCache on large model."""
+        print("\n=== Testing Large Model HiCache Accuracy ===")
+
+        first_metrics = self._run_gsm8k()
+        print(f"first_metrics={first_metrics}")
+        self.assertGreaterEqual(
+            first_metrics["accuracy"],
+            ACC_THRESHOLDS["gsm8k"],
+            "Initial accuracy should meet threshold",
+        )
+
+        print("Flushing cache...")
+        res = requests.post(
+            f"{self.base_url}/flush_cache",
+            params={"timeout": 30},
+            timeout=40,
+        )
+        res.raise_for_status()
+
+        second_metrics = self._run_gsm8k()
+        print(f"second_metrics={second_metrics}")
+        self.assertGreaterEqual(
+            second_metrics["accuracy"],
+            ACC_THRESHOLDS["gsm8k"],
+            "Cached accuracy should meet threshold",
+        )
+        self.assertLessEqual(
+            abs(second_metrics["accuracy"] - first_metrics["accuracy"]),
+            0.05,
+            f"HiCache prefetch accuracy drift too large: "
+            f"first={first_metrics['accuracy']}, second={second_metrics['accuracy']}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_mooncake_backend.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_mooncake_backend.py
@@ -1,0 +1,377 @@
+"""
+Benchmark tests for HiCache Storage with Mooncake backend on Ascend NPU.
+
+Tests Mooncake distributed storage backend with different memory layouts
+and accuracy validation after cache flush.
+
+NPU-specific adaptations:
+- --attention-backend ascend
+- --disable-cuda-graph
+- --hicache-io-backend kernel_ascend
+- --hicache-mem-layout page_first_direct
+- MOONCAKE_DEVICE may need NPU-specific device name
+
+Usage:
+    python3 -m pytest test/registered/ascend/basic_function/HiCache/test_npu_hicache_mooncake_backend.py -v
+"""
+
+import os
+import subprocess
+import time
+import unittest
+
+import requests
+
+from sglang.benchmark.utils import get_tokenizer
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    find_available_port,
+    popen_launch_server,
+)
+from sglang.utils import wait_for_http_ready
+
+register_npu_ci(est_time=400, suite="nightly-4-npu-a3", nightly=True)
+
+
+class NPUHiCacheStorageMooncakeBackendBaseMixin:
+    """Base mixin class with common setup and utilities for NPU Mooncake backend tests."""
+
+    mooncake_master_port_base = 50051
+    mooncake_metadata_port_base = 8080
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mooncake_master_port = find_available_port(
+            NPUHiCacheStorageMooncakeBackendBaseMixin.mooncake_master_port_base
+        )
+        cls.mooncake_metadata_port = find_available_port(
+            NPUHiCacheStorageMooncakeBackendBaseMixin.mooncake_metadata_port_base
+        )
+
+        cls._start_mooncake_services()
+
+        cls.temp_dir = None
+        cls.model = cls._get_model_name()
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        cls.tokenizer = get_tokenizer(cls.model)
+
+        cls.process = cls._launch_server_with_hicache()
+        cls._wait_for_server_ready(process=cls.process)
+
+        print(f"Test server launched successfully at {cls.base_url}")
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+        cls._stop_mooncake_services()
+
+    @classmethod
+    def _get_model_name(cls):
+        return QWEN3_8B_WEIGHTS_PATH
+
+    @classmethod
+    def _start_mooncake_services(cls):
+        print("Starting Mooncake services...")
+        print(
+            f"Using master port: {cls.mooncake_master_port}, metadata port: {cls.mooncake_metadata_port}"
+        )
+
+        try:
+            cls.metadata_service_process = subprocess.Popen(
+                [
+                    "python3",
+                    "-m",
+                    "mooncake.http_metadata_server",
+                    "--port",
+                    str(cls.mooncake_metadata_port),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                preexec_fn=os.setsid,
+            )
+            print(
+                f"Mooncake metadata service started on port {cls.mooncake_metadata_port}"
+            )
+        except (FileNotFoundError, subprocess.SubprocessError) as e:
+            print(f"Warning: Could not start Mooncake metadata service: {e}")
+            cls.metadata_service_process = None
+
+        try:
+            cls.master_service_process = subprocess.Popen(
+                ["mooncake_master", "--port", str(cls.mooncake_master_port)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                preexec_fn=os.setsid,
+            )
+            print(f"Mooncake master service started on port {cls.mooncake_master_port}")
+        except (FileNotFoundError, subprocess.SubprocessError) as e:
+            print(f"Warning: Could not start Mooncake master service: {e}")
+            cls.master_service_process = None
+
+        cls._wait_for_mooncake_services_ready()
+
+    @classmethod
+    def _wait_for_mooncake_services_ready(cls, timeout: int = 30) -> bool:
+        print("Waiting for Mooncake services to be ready...")
+
+        start_time = time.time()
+        services_ready = False
+
+        while time.time() - start_time < timeout:
+            try:
+                metadata_ready = False
+                if (
+                    cls.metadata_service_process
+                    and cls.metadata_service_process.poll() is None
+                ):
+                    try:
+                        metadata_url = (
+                            f"http://127.0.0.1:{cls.mooncake_metadata_port}/metadata"
+                        )
+                        response = requests.get(metadata_url, timeout=2)
+                        if response.status_code == 200:
+                            metadata_ready = True
+                            print("Mooncake metadata service is ready")
+                    except (requests.RequestException, ConnectionError):
+                        pass
+
+                master_ready = False
+                if (
+                    cls.master_service_process
+                    and cls.master_service_process.poll() is None
+                ):
+                    if time.time() - start_time > 5:
+                        master_ready = True
+                        print("Mooncake master service is ready")
+
+                if metadata_ready and master_ready:
+                    services_ready = True
+                    print("All Mooncake services are ready")
+                    break
+
+            except Exception as e:
+                print(f"Error checking service readiness: {e}")
+
+            time.sleep(2)
+
+        if not services_ready:
+            print("Warning: Mooncake services may not be fully ready, continuing anyway...")
+
+        return services_ready
+
+    @classmethod
+    def _stop_mooncake_services(cls):
+        print("Stopping Mooncake services...")
+
+        if hasattr(cls, "metadata_service_process") and cls.metadata_service_process:
+            try:
+                os.killpg(os.getpgid(cls.metadata_service_process.pid), 9)
+                cls.metadata_service_process.wait(timeout=5)
+                print("Mooncake metadata service stopped")
+            except (ProcessLookupError, subprocess.TimeoutExpired, OSError) as e:
+                print(f"Warning: Could not stop Mooncake metadata service: {e}")
+
+        if hasattr(cls, "master_service_process") and cls.master_service_process:
+            try:
+                os.killpg(os.getpgid(cls.master_service_process.pid), 9)
+                cls.master_service_process.wait(timeout=5)
+                print("Mooncake master service stopped")
+            except (ProcessLookupError, subprocess.TimeoutExpired, OSError) as e:
+                print(f"Warning: Could not stop Mooncake master service: {e}")
+
+    @classmethod
+    def _launch_server_with_hicache(cls):
+        server_args, env_vars = cls._get_additional_server_args_and_env()
+
+        final_server_args = []
+        for k, v in server_args.items():
+            if isinstance(v, bool):
+                final_server_args.append(str(k))
+            else:
+                final_server_args.append(str(k))
+                final_server_args.append(str(v))
+
+        print(f"final_server_args: {final_server_args}")
+
+        env_vars = {
+            **os.environ,
+            **env_vars,
+            "SGLANG_ENABLE_DETERMINISTIC_INFERENCE": "1",
+        }
+
+        return popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=final_server_args,
+            env=env_vars,
+        )
+
+    @classmethod
+    def _wait_for_server_ready(cls, timeout: int = 60, process=None) -> bool:
+        wait_for_http_ready(
+            url=f"{cls.base_url}/health",
+            timeout=timeout,
+            process=process,
+        )
+        return True
+
+    @classmethod
+    def _get_additional_server_args_and_env(cls):
+        server_args = {
+            "--tp-size": 2,
+            "--hicache-ratio": 2,
+            "--hicache-storage-backend": "mooncake",
+            "--hicache-io-backend": "kernel_ascend",
+            "--attention-backend": "ascend",
+            "--disable-cuda-graph": True,
+        }
+
+        env_vars = {
+            "MOONCAKE_MASTER": f"127.0.0.1:{cls.mooncake_master_port}",
+            "MOONCAKE_PROTOCOL": "tcp",
+            "MC_MS_AUTO_DISC": "0",
+            "MOONCAKE_DEVICE": "",
+            "MOONCAKE_TE_META_DATA_SERVER": f"http://127.0.0.1:{cls.mooncake_metadata_port}/metadata",
+            "MOONCAKE_GLOBAL_SEGMENT_SIZE": "4294967296",
+        }
+
+        return server_args, env_vars
+
+    def send_request(self, prompt: str, max_tokens: int = 100, temperature: float = 0.0):
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {
+                    "temperature": temperature,
+                    "max_new_tokens": max_tokens,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=60,
+        )
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Request failed: {response.status_code} - {response.text}",
+        )
+        return response.json()
+
+    def flush_cache(self):
+        res = requests.post(
+            f"{self.base_url}/flush_cache",
+            params={"timeout": 30},
+            timeout=40,
+        )
+        res.raise_for_status()
+
+
+class TestNPUMooncakeBackendPageFirstLayout(
+    NPUHiCacheStorageMooncakeBackendBaseMixin, CustomTestCase
+):
+    """Page first layout tests for HiCache-Mooncake backend on NPU.
+
+    [Test Category] HiCache
+    [Test Target] Mooncake distributed storage with page_first_direct layout
+    """
+
+    @classmethod
+    def _get_additional_server_args_and_env(cls):
+        server_args, env_vars = super()._get_additional_server_args_and_env()
+        server_args["--hicache-mem-layout"] = "page_first_direct"
+        return server_args, env_vars
+
+    def test_basic_backup_and_prefetch(self):
+        """Test storage and retrieval through Mooncake backend."""
+        print("\n=== Testing Mooncake Cache Storage & Retrieval ===")
+
+        prompt = "What is the capital of France? " * 50
+
+        print("Step 1: Populating cache...")
+        response1 = self.send_request(prompt, max_tokens=50)
+        self.assertIsNotNone(response1)
+
+        print("Step 2: Flushing cache...")
+        self.flush_cache()
+        time.sleep(2)
+
+        print("Step 3: Testing cache hit from Mooncake storage...")
+        response2 = self.send_request(prompt, max_tokens=50)
+        cached_tokens = int(response2.get("meta_info", {}).get("cached_tokens", 0))
+        print(f"Cached tokens: {cached_tokens}")
+
+        self.assertGreater(
+            cached_tokens, 100, "Expected significant cached tokens for Mooncake hit"
+        )
+
+
+class TestNPUMooncakeBackendAccuracy(
+    NPUHiCacheStorageMooncakeBackendBaseMixin, CustomTestCase
+):
+    """Accuracy tests for HiCache-Mooncake backend on NPU.
+
+    [Test Category] HiCache
+    [Test Target] GSM8K accuracy consistency after cache flush with Mooncake backend
+    """
+
+    @classmethod
+    def _get_additional_server_args_and_env(cls):
+        server_args, env_vars = super()._get_additional_server_args_and_env()
+        server_args["--hicache-ratio"] = 1.5
+        server_args["--hicache-mem-layout"] = "page_first_direct"
+        return server_args, env_vars
+
+    def test_eval_accuracy(self):
+        """Test eval accuracy with cache persistence across cache flushes."""
+        print("\n=== Testing Eval Accuracy with Mooncake Cache ===")
+
+        from types import SimpleNamespace
+
+        print("Phase 1: Running initial GSM8K evaluation...")
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics_initial = run_eval_few_shot_gsm8k(args)
+        print(f"Initial accuracy: {metrics_initial['accuracy']}")
+
+        print("Phase 2: Flushing device cache...")
+        self.flush_cache()
+
+        print("Phase 3: Running second GSM8K evaluation...")
+        metrics_cached = run_eval_few_shot_gsm8k(args)
+        print(f"Cached accuracy: {metrics_cached['accuracy']}")
+
+        accuracy_diff = abs(metrics_initial["accuracy"] - metrics_cached["accuracy"])
+        print(f"Accuracy difference: {accuracy_diff:.4f}")
+
+        self.assertGreater(
+            metrics_initial["accuracy"], 0.6, "Initial accuracy should be reasonable"
+        )
+        self.assertGreater(
+            metrics_cached["accuracy"], 0.6, "Cached accuracy should be reasonable"
+        )
+        self.assertLess(
+            accuracy_diff,
+            0.05,
+            "Accuracy should be consistent between cache states",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_mooncake_backend.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_mooncake_backend.py
@@ -164,7 +164,9 @@ class NPUHiCacheStorageMooncakeBackendBaseMixin:
             time.sleep(2)
 
         if not services_ready:
-            print("Warning: Mooncake services may not be fully ready, continuing anyway...")
+            print(
+                "Warning: Mooncake services may not be fully ready, continuing anyway..."
+            )
 
         return services_ready
 
@@ -247,7 +249,9 @@ class NPUHiCacheStorageMooncakeBackendBaseMixin:
 
         return server_args, env_vars
 
-    def send_request(self, prompt: str, max_tokens: int = 100, temperature: float = 0.0):
+    def send_request(
+        self, prompt: str, max_tokens: int = 100, temperature: float = 0.0
+    ):
         response = requests.post(
             f"{self.base_url}/generate",
             json={

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_runtime_attach_detach.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_runtime_attach_detach.py
@@ -1,0 +1,321 @@
+"""
+E2E test for HiCache storage runtime attach/detach on Ascend NPU.
+
+This test launches an SGLang server with hierarchical cache enabled but WITHOUT
+any storage backend at startup, then attaches/detaches a storage backend via the
+HTTP endpoints.
+
+NPU-specific adaptations:
+- --attention-backend ascend
+- --disable-cuda-graph
+- --hicache-io-backend kernel_ascend
+- --hicache-mem-layout page_first_direct
+
+Usage:
+    python3 -m pytest test/registered/ascend/basic_function/HiCache/test_npu_hicache_runtime_attach_detach.py -v
+"""
+
+import json
+import os
+import tempfile
+import time
+import unittest
+from urllib import error, request
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    find_available_port,
+    popen_launch_server,
+)
+from sglang.utils import wait_for_http_ready
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPUHiCacheStorageRuntimeAttachDetach(CustomTestCase):
+    """Test runtime attach/detach of HiCache storage backend on NPU.
+
+    [Test Category] HiCache
+    [Test Target] Runtime storage backend management via HTTP API
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = tempfile.mkdtemp()
+        cls.model = QWEN3_8B_WEIGHTS_PATH
+        default_port = int(DEFAULT_URL_FOR_TEST.rsplit(":", 1)[1])
+        cls.base_url = f"http://127.0.0.1:{find_available_port(default_port)}"
+
+        cls.other_args = [
+            "--enable-hierarchical-cache",
+            "--mem-fraction-static",
+            "0.6",
+            "--hicache-ratio",
+            "1.2",
+            "--page-size",
+            "64",
+            "--enable-cache-report",
+            "--hicache-io-backend",
+            "kernel_ascend",
+            "--hicache-mem-layout",
+            "page_first_direct",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            # NOTE: do NOT pass --hicache-storage-backend* here
+        ]
+
+        cls.env = {
+            **os.environ,
+            "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.temp_dir,
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        import shutil
+
+        shutil.rmtree(cls.temp_dir, ignore_errors=True)
+
+    @classmethod
+    def _wait_for_server_ready(cls, base_url: str, timeout: int = 60, process=None) -> bool:
+        wait_for_http_ready(
+            url=f"{base_url}/health",
+            timeout=timeout,
+            process=process,
+        )
+        return True
+
+    @staticmethod
+    def _http_get(url: str, timeout: int = 10, headers: dict | None = None):
+        try:
+            req = request.Request(url, headers=headers or {}, method="GET")
+            with request.urlopen(req, timeout=timeout) as resp:
+                return resp.getcode(), resp.read().decode("utf-8", errors="replace")
+        except error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace")
+            return e.code, body
+
+    @staticmethod
+    def _http_put_json_with_headers(
+        url: str,
+        payload: dict | None = None,
+        timeout: int = 30,
+        headers: dict | None = None,
+    ):
+        data = None
+        all_headers = dict(headers or {})
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            all_headers["Content-Type"] = "application/json"
+        req = request.Request(url, data=data, headers=all_headers, method="PUT")
+        try:
+            with request.urlopen(req, timeout=timeout) as resp:
+                return resp.getcode(), resp.read().decode("utf-8", errors="replace")
+        except error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace")
+            return e.code, body
+
+    @staticmethod
+    def _http_delete_with_headers(
+        url: str, timeout: int = 30, headers: dict | None = None
+    ):
+        all_headers = dict(headers or {})
+        req = request.Request(url, headers=all_headers, method="DELETE")
+        try:
+            with request.urlopen(req, timeout=timeout) as resp:
+                return resp.getcode(), resp.read().decode("utf-8", errors="replace")
+        except error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace")
+            return e.code, body
+
+    def _get_backend_status(self, base_url: str, headers: dict | None = None):
+        code, body = self._http_get(
+            f"{base_url}/hicache/storage-backend", timeout=10, headers=headers
+        )
+        self.assertEqual(code, 200, body)
+        return json.loads(body)
+
+    def _attach_backend(
+        self,
+        base_url: str,
+        backend: str,
+        extra_cfg: dict,
+        prefetch_policy: str = "timeout",
+        write_policy: str = "write_through",
+        headers: dict | None = None,
+    ):
+        payload = {
+            "hicache_storage_backend": backend,
+            "hicache_storage_backend_extra_config_json": json.dumps(extra_cfg),
+            "hicache_storage_prefetch_policy": prefetch_policy,
+            "hicache_write_policy": write_policy,
+        }
+        return self._http_put_json_with_headers(
+            f"{base_url}/hicache/storage-backend",
+            payload,
+            timeout=30,
+            headers=headers,
+        )
+
+    def _detach_backend(self, base_url: str, headers: dict | None = None):
+        return self._http_delete_with_headers(
+            f"{base_url}/hicache/storage-backend",
+            timeout=30,
+            headers=headers,
+        )
+
+    def test_runtime_attach_detach(self):
+        """Test runtime attach/detach lifecycle with admin authentication."""
+        # Phase A: WITHOUT --admin-api-key, endpoints must return 400
+        process1 = popen_launch_server(
+            self.model,
+            self.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=self.other_args,
+            env=self.env,
+        )
+        try:
+            self._wait_for_server_ready(self.base_url, process=process1)
+
+            code_info, _body_info = self._http_get(
+                f"{self.base_url}/hicache/storage-backend", timeout=10
+            )
+            self.assertEqual(code_info, 400)
+
+            code_attach_no_admin, _ = self._attach_backend(
+                base_url=self.base_url, backend="file", extra_cfg={}
+            )
+            self.assertEqual(code_attach_no_admin, 400)
+
+            code_detach_no_admin, _ = self._detach_backend(self.base_url)
+            self.assertEqual(code_detach_no_admin, 400)
+        finally:
+            kill_process_tree(process1.pid)
+            time.sleep(2)
+
+        # Phase B: WITH --admin-api-key, must provide Authorization: Bearer <admin_key>
+        admin_key = "sglang-test-admin-key"
+        base_url2 = f"http://127.0.0.1:{find_available_port(int(self.base_url.rsplit(':', 1)[1]) + 1)}"
+        other_args2 = list(self.other_args) + ["--admin-api-key", admin_key]
+        process2 = popen_launch_server(
+            self.model,
+            base_url2,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args2,
+            env=self.env,
+        )
+        try:
+            self._wait_for_server_ready(base_url2, process=process2)
+
+            # 1) Initially unauthorized
+            code_info2_unauth, _ = self._http_get(
+                f"{base_url2}/hicache/storage-backend", timeout=10
+            )
+            self.assertEqual(code_info2_unauth, 401)
+
+            admin_headers = {"Authorization": f"Bearer {admin_key}"}
+            status0 = self._get_backend_status(base_url2, headers=admin_headers)
+            self.assertIsNone(status0.get("hicache_storage_backend"))
+
+            # 2) Attach should succeed when idle
+            extra_cfg = {
+                "hicache_storage_pass_prefix_keys": True,
+                "prefetch_threshold": 256,
+                "prefetch_timeout_base": 3,
+                "prefetch_timeout_per_ki_token": 0.01,
+            }
+
+            code_attach_unauth, _ = self._attach_backend(
+                base_url=base_url2, backend="file", extra_cfg=extra_cfg
+            )
+            self.assertEqual(code_attach_unauth, 401)
+
+            code_attach, body_attach = self._attach_backend(
+                base_url=base_url2,
+                backend="file",
+                extra_cfg=extra_cfg,
+                prefetch_policy="timeout",
+                write_policy="write_back",
+                headers=admin_headers,
+            )
+            self.assertEqual(code_attach, 200, f"{code_attach} - {body_attach}")
+
+            status1 = self._get_backend_status(base_url2, headers=admin_headers)
+            self.assertEqual(status1.get("hicache_storage_backend"), "file")
+            self.assertEqual(
+                status1.get("hicache_storage_backend_extra_config"),
+                json.dumps(extra_cfg),
+            )
+            self.assertEqual(status1.get("hicache_storage_prefetch_policy"), "timeout")
+            self.assertEqual(status1.get("hicache_write_policy"), "write_back")
+
+            # 3) Attach again with updated policies
+            code_attach_again, body_attach_again = self._attach_backend(
+                base_url=base_url2,
+                backend="file",
+                extra_cfg=extra_cfg,
+                prefetch_policy="wait_complete",
+                write_policy="write_through_selective",
+                headers=admin_headers,
+            )
+            self.assertEqual(
+                code_attach_again, 200, f"{code_attach_again} - {body_attach_again}"
+            )
+
+            status2 = self._get_backend_status(base_url2, headers=admin_headers)
+            self.assertEqual(
+                status2.get("hicache_storage_prefetch_policy"), "wait_complete"
+            )
+            self.assertEqual(
+                status2.get("hicache_write_policy"), "write_through_selective"
+            )
+
+            # 4) Attach different backend should be rejected
+            code_attach_diff, body_attach_diff = self._attach_backend(
+                base_url=base_url2,
+                backend="mooncake",
+                extra_cfg=extra_cfg,
+                headers=admin_headers,
+            )
+            self.assertNotEqual(code_attach_diff, 200, body_attach_diff)
+
+            # 5) Detach should succeed and be idempotent
+            code_detach, body_detach = self._detach_backend(
+                base_url2, headers=admin_headers
+            )
+            self.assertEqual(code_detach, 200, f"{code_detach} - {body_detach}")
+
+            status3 = self._get_backend_status(base_url2, headers=admin_headers)
+            self.assertIsNone(status3.get("hicache_storage_backend"))
+
+            code_detach_again, _ = self._detach_backend(
+                base_url2, headers=admin_headers
+            )
+            self.assertEqual(code_detach_again, 200)
+
+            # 6) Re-attach after detach should succeed
+            code_attach2, body_attach2 = self._attach_backend(
+                base_url=base_url2,
+                backend="file",
+                extra_cfg=extra_cfg,
+                headers=admin_headers,
+            )
+            self.assertEqual(code_attach2, 200, f"{code_attach2} - {body_attach2}")
+
+            status4 = self._get_backend_status(base_url2, headers=admin_headers)
+            self.assertEqual(status4.get("hicache_storage_backend"), "file")
+
+            # Cleanup
+            self._detach_backend(base_url2, headers=admin_headers)
+        finally:
+            kill_process_tree(process2.pid)
+            time.sleep(2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_runtime_attach_detach.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_runtime_attach_detach.py
@@ -82,7 +82,9 @@ class TestNPUHiCacheStorageRuntimeAttachDetach(CustomTestCase):
         shutil.rmtree(cls.temp_dir, ignore_errors=True)
 
     @classmethod
-    def _wait_for_server_ready(cls, base_url: str, timeout: int = 60, process=None) -> bool:
+    def _wait_for_server_ready(
+        cls, base_url: str, timeout: int = 60, process=None
+    ) -> bool:
         wait_for_http_ready(
             url=f"{base_url}/health",
             timeout=timeout,

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_spec_file_storage.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_spec_file_storage.py
@@ -1,0 +1,322 @@
+"""
+E2E test for HiCache file storage with speculative decoding on Ascend NPU.
+
+Tests that after server restart, the file storage can load back KV cache
+and maintain speculative decoding accept length.
+
+NPU-specific adaptations:
+- --attention-backend ascend
+- --disable-cuda-graph
+- --hicache-io-backend kernel_ascend
+- --hicache-mem-layout page_first_direct
+
+Note: Skip if EAGLE3 speculative decoding is not supported on current NPU aiter version.
+
+Usage:
+    python3 -m pytest test/registered/ascend/basic_function/HiCache/test_npu_hicache_spec_file_storage.py -v
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from typing import Dict, List
+
+import psutil
+import requests
+
+from sglang.benchmark.utils import get_tokenizer
+from sglang.srt.utils import is_hip, kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    CustomTestCase,
+    find_available_port,
+    popen_launch_server,
+)
+from sglang.utils import wait_for_http_ready
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+@unittest.skip("EAGLE3 speculative decoding not yet supported on Ascend NPU")
+class TestNPUHiCacheSpecFileStorage(CustomTestCase):
+    """Test HiCache file storage with speculative decoding on NPU.
+
+    [Test Category] HiCache
+    [Test Target] File storage loadback with EAGLE3 speculative decoding
+    """
+
+    model = QWEN3_8B_WEIGHTS_PATH
+    draft_model = QWEN3_8B_WEIGHTS_PATH
+
+    input_token_len = 1024
+    max_new_tokens = 200
+    page_size = 64
+    min_expected_accept_length = 2.0
+    min_second_to_first_accept_ratio = 0.8
+    storage_wait_timeout = 30
+    first_measure_new_tokens = 128
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = tempfile.mkdtemp()
+        default_port = int(DEFAULT_URL_FOR_TEST.rsplit(":", 1)[1])
+        cls.base_url = f"http://127.0.0.1:{find_available_port(default_port)}"
+
+        cls.tokenizer = get_tokenizer(cls.model)
+        cls.prompt_input_ids = cls._build_long_repetitive_prompt_ids(
+            cls.tokenizer, cls.input_token_len
+        )
+
+        extra_config = {
+            "hicache_storage_pass_prefix_keys": True,
+        }
+        cls.other_args = [
+            "--enable-hierarchical-cache",
+            "--enable-cache-report",
+            "--mem-fraction-static",
+            "0.3",
+            "--hicache-ratio",
+            "1.5",
+            "--disable-cuda-graph",
+            "--page-size",
+            str(cls.page_size),
+            "--hicache-storage-backend",
+            "file",
+            "--hicache-storage-prefetch-policy",
+            "wait_complete",
+            "--hicache-storage-backend-extra-config",
+            json.dumps(extra_config),
+            "--hicache-io-backend",
+            "kernel_ascend",
+            "--hicache-mem-layout",
+            "page_first_direct",
+            "--attention-backend",
+            "ascend",
+            "--speculative-algorithm",
+            "EAGLE3",
+            "--speculative-draft-model-path",
+            cls.draft_model,
+            "--speculative-num-steps",
+            "5",
+            "--speculative-eagle-topk",
+            "1",
+            "--speculative-num-draft-tokens",
+            "4",
+        ]
+        cls.env = {
+            **os.environ,
+            "SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN": "1",
+            "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.temp_dir,
+        }
+        cls.process = None
+        cls._launch_server()
+
+    @classmethod
+    def _launch_server(cls):
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls.other_args,
+            env=cls.env,
+        )
+        wait_for_http_ready(
+            url=f"{cls.base_url}/health",
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            process=cls.process,
+        )
+
+    @classmethod
+    def _stop_server(cls):
+        if getattr(cls, "process", None) is None:
+            return
+
+        process = cls.process
+        try:
+            root = psutil.Process(process.pid)
+            watched_procs = [root] + root.children(recursive=True)
+        except psutil.NoSuchProcess:
+            watched_procs = []
+
+        try:
+            kill_process_tree(process.pid, wait_timeout=60)
+        except RuntimeError:
+            non_zombie_procs = []
+            for proc in watched_procs:
+                try:
+                    if proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE:
+                        non_zombie_procs.append(proc)
+                except psutil.NoSuchProcess:
+                    pass
+            if non_zombie_procs:
+                raise
+        finally:
+            cls.process = None
+
+    @classmethod
+    def _restart_server(cls):
+        cls._stop_server()
+        cls._launch_server()
+
+    @classmethod
+    def _count_file_storage_pages(cls):
+        try:
+            filenames = os.listdir(cls.temp_dir)
+        except FileNotFoundError:
+            return 0, 0
+
+        target_pages = 0
+        draft_pages = 0
+        for filename in filenames:
+            if not filename.endswith(".bin"):
+                continue
+            if filename.startswith("d:"):
+                draft_pages += 1
+            else:
+                target_pages += 1
+        return target_pages, draft_pages
+
+    @classmethod
+    def _wait_for_file_storage_pages(cls):
+        min_pages = (cls.input_token_len - 2 * cls.page_size) // cls.page_size
+        deadline = time.monotonic() + cls.storage_wait_timeout
+        target_pages = draft_pages = 0
+
+        while time.monotonic() < deadline:
+            target_pages, draft_pages = cls._count_file_storage_pages()
+            if target_pages >= min_pages and draft_pages >= min_pages:
+                return target_pages, draft_pages
+            time.sleep(0.2)
+
+        raise AssertionError(
+            "Timed out waiting for HiCache file storage pages before restart: "
+            f"{target_pages=}, {draft_pages=}, {min_pages=}"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._stop_server()
+        if hasattr(cls, "temp_dir"):
+            shutil.rmtree(cls.temp_dir, ignore_errors=True)
+
+    @classmethod
+    def _encode_without_special_tokens(cls, tokenizer, text: str) -> List[int]:
+        return tokenizer.encode(text, add_special_tokens=False)
+
+    @classmethod
+    def _build_long_repetitive_prompt_ids(cls, tokenizer, target_len: int) -> List[int]:
+        bos_ids = (
+            [tokenizer.bos_token_id]
+            if getattr(tokenizer, "bos_token_id", None) is not None
+            else []
+        )
+        suffix_ids = cls._encode_without_special_tokens(
+            tokenizer,
+            "\n\nContinue the sequence with only the word apple separated by spaces.\n"
+            "Answer: apple apple apple apple",
+        )
+        repeat_ids = cls._encode_without_special_tokens(tokenizer, " apple")
+        if not repeat_ids:
+            raise ValueError(
+                "Tokenizer produced no ids for the repetitive prompt seed."
+            )
+        if len(bos_ids) + len(suffix_ids) >= target_len:
+            raise ValueError(
+                "Prompt suffix is too long: "
+                f"{len(bos_ids)=}, {len(suffix_ids)=}, {target_len=}."
+            )
+
+        prefix_len = target_len - len(bos_ids) - len(suffix_ids)
+        repeats = (prefix_len + len(repeat_ids) - 1) // len(repeat_ids)
+        prefix_ids = (repeat_ids * repeats)[:prefix_len]
+        prompt_ids = bos_ids + prefix_ids + suffix_ids
+        assert len(prompt_ids) == target_len
+        return prompt_ids
+
+    def _send_long_prompt(self, max_new_tokens: int = None) -> Dict:
+        if max_new_tokens is None:
+            max_new_tokens = self.max_new_tokens
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "input_ids": self.prompt_input_ids,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": max_new_tokens,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=900,
+        )
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Request failed: {response.status_code} - {response.text}",
+        )
+        return response.json()
+
+    def _get_spec_accept_length(self, response_json: Dict) -> float:
+        meta_info = response_json.get("meta_info", {})
+        self.assertIn(
+            "spec_accept_length",
+            meta_info,
+            f"Missing spec_accept_length in meta_info: {meta_info}",
+        )
+        return float(meta_info["spec_accept_length"])
+
+    def test_file_storage_loadback_keeps_spec_accept_length(self):
+        first = self._send_long_prompt(max_new_tokens=self.first_measure_new_tokens)
+        first_accept_length = self._get_spec_accept_length(first)
+        self.assertGreaterEqual(
+            first_accept_length,
+            self.min_expected_accept_length,
+            f"First prompt accept length is too low: {first_accept_length=}",
+        )
+
+        target_pages, draft_pages = self._wait_for_file_storage_pages()
+        print(f"file_storage_before_restart: {target_pages=}, {draft_pages=}")
+
+        self._restart_server()
+
+        second = self._send_long_prompt()
+        second_accept_length = self._get_spec_accept_length(second)
+        second_meta = second.get("meta_info", {})
+        cached_details = second_meta.get("cached_tokens_details") or {}
+        storage_cached_tokens = int(cached_details.get("storage", 0))
+
+        print(
+            f"{first_accept_length=:.3f}, {second_accept_length=:.3f}, "
+            f"{storage_cached_tokens=}, {cached_details=}"
+        )
+
+        self.assertGreaterEqual(
+            storage_cached_tokens,
+            self.input_token_len - 2 * self.page_size,
+            "Expected the second request to load the long prompt KV cache from "
+            f"file storage, got {cached_details=}",
+        )
+        self.assertEqual(
+            cached_details.get("storage_backend"),
+            "HiCacheFile",
+            f"Expected file storage backend in cache report, got {cached_details=}",
+        )
+        self.assertGreaterEqual(
+            second_accept_length,
+            self.min_expected_accept_length,
+            f"Second prompt accept length is too low: {second_accept_length=}",
+        )
+        self.assertGreaterEqual(
+            second_accept_length,
+            first_accept_length * self.min_second_to_first_accept_ratio,
+            "Spec accept length dropped after file-storage loadback: "
+            f"{first_accept_length=:.3f}, {second_accept_length=:.3f}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_spec_file_storage.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_spec_file_storage.py
@@ -28,7 +28,7 @@ import psutil
 import requests
 
 from sglang.benchmark.utils import get_tokenizer
-from sglang.srt.utils import is_hip, kill_process_tree
+from sglang.srt.utils import kill_process_tree
 from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import (

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_spec_file_storage.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_spec_file_storage.py
@@ -33,6 +33,7 @@ from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     find_available_port,
     popen_launch_server,

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_storage_file_backend.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_hicache_storage_file_backend.py
@@ -1,0 +1,304 @@
+"""
+E2E tests for HiCache Storage functionality on Ascend NPU.
+
+Tests file backend storage with different memory layouts, IO backends,
+and accuracy validation after cache flush.
+
+NPU-specific adaptations:
+- --attention-backend ascend
+- --disable-cuda-graph
+- --hicache-io-backend kernel_ascend
+- --hicache-mem-layout page_first_direct / page_first_kv_split
+
+Usage:
+    python3 -m pytest test/registered/ascend/basic_function/HiCache/test_npu_hicache_storage_file_backend.py -v
+"""
+
+import json
+import os
+import random
+import tempfile
+import time
+import unittest
+from types import SimpleNamespace
+from typing import Dict
+from urllib.parse import urlparse
+
+import requests
+
+from sglang.benchmark.utils import get_tokenizer
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+from sglang.utils import wait_for_http_ready
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class NPUHiCacheStorageBaseMixin:
+    """Base mixin class with common setup and utilities for NPU HiCache storage tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = tempfile.mkdtemp()
+        cls.model = cls._get_model_name()
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        parsed_url = urlparse(cls.base_url)
+        cls.base_host = parsed_url.hostname
+        cls.base_port = str(parsed_url.port)
+
+        cls.tokenizer = get_tokenizer(cls.model)
+
+        cls.process = cls._launch_server_with_hicache()
+        cls._wait_for_server_ready(process=cls.process)
+
+        print(f"Test server launched successfully at {cls.base_url}")
+        print(f"Cache directory: {cls.temp_dir}")
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+        import shutil
+
+        if hasattr(cls, "temp_dir"):
+            shutil.rmtree(cls.temp_dir, ignore_errors=True)
+
+    @classmethod
+    def _get_model_name(cls):
+        return QWEN3_8B_WEIGHTS_PATH
+
+    @classmethod
+    def _get_base_server_args(cls):
+        extra_config = {
+            "hicache_storage_pass_prefix_keys": True,
+        }
+        return {
+            "--enable-hierarchical-cache": True,
+            "--mem-fraction-static": 0.6,
+            "--hicache-ratio": 1.2,
+            "--page-size": 64,
+            "--enable-cache-report": True,
+            "--hicache-storage-prefetch-policy": "wait_complete",
+            "--hicache-storage-backend": "file",
+            "--hicache-storage-backend-extra-config": json.dumps(extra_config),
+            "--hicache-io-backend": "kernel_ascend",
+            "--attention-backend": "ascend",
+            "--disable-cuda-graph": True,
+        }
+
+    @classmethod
+    def _get_additional_server_args_and_env(cls):
+        return {}, {"SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.temp_dir}
+
+    @classmethod
+    def _launch_server_with_hicache(cls):
+        additional_server_args, env_vars = cls._get_additional_server_args_and_env()
+        env_vars["SGLANG_ENABLE_DETERMINISTIC_INFERENCE"] = "1"
+        server_args = cls._get_base_server_args()
+        if additional_server_args:
+            server_args.update(additional_server_args)
+
+        final_server_args = []
+        for k, v in server_args.items():
+            if isinstance(v, bool):
+                final_server_args.append(str(k))
+            else:
+                final_server_args.append(str(k))
+                final_server_args.append(str(v))
+
+        print(f"final_server_args: {final_server_args}")
+
+        env_vars = {
+            **os.environ,
+            **env_vars,
+        }
+
+        return popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=final_server_args,
+            env=env_vars,
+        )
+
+    @classmethod
+    def _wait_for_server_ready(cls, timeout: int = 60, process=None) -> bool:
+        wait_for_http_ready(
+            url=f"{cls.base_url}/health",
+            timeout=timeout,
+            process=process,
+        )
+        return True
+
+    def send_request(
+        self, prompt: str, max_tokens: int = 100, temperature: float = 0.0
+    ) -> Dict:
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {
+                    "temperature": temperature,
+                    "max_new_tokens": max_tokens,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=60,
+        )
+
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Request failed: {response.status_code} - {response.text}",
+        )
+        return response.json()
+
+    def get_cached_tokens(self, response_json: Dict) -> int:
+        meta = response_json.get("meta_info", {})
+        return int(meta.get("cached_tokens", 0))
+
+    def flush_cache(self):
+        res = requests.post(
+            f"{self.base_url}/flush_cache",
+            params={"timeout": 30},
+            timeout=40,
+        )
+        res.raise_for_status()
+
+    def gen_prompt(self, token_num: int) -> str:
+        all_available_tokens = list(self.tokenizer.get_vocab().values())
+        selected_tokens = random.choices(all_available_tokens, k=token_num)
+        return self.tokenizer.decode(selected_tokens)
+
+    def trigger_offloading_and_flush(self):
+        self.send_request(self.gen_prompt(1), max_tokens=150)
+        self.flush_cache()
+
+    def test_basic_backup_and_prefetch(self):
+        """Test storage and retrieval of large context through remote cache."""
+        print("\n=== Testing Large Context Cache Storage & Retrieval ===")
+
+        base_prompt = self.gen_prompt(768)
+
+        print("Step 1: Populating cache with large context...")
+        response1 = self.send_request(base_prompt, max_tokens=150)
+        self.assertIsNotNone(response1)
+
+        self.trigger_offloading_and_flush()
+
+        print("Step 2: Testing cache hit from remote storage...")
+        start_time = time.time()
+        response2 = self.send_request(base_prompt, max_tokens=150)
+        retrieval_time = time.time() - start_time
+
+        cached_tokens = self.get_cached_tokens(response2)
+        print(
+            f"Remote cache retrieval time: {retrieval_time:.3f}s, cached_tokens={cached_tokens}"
+        )
+
+        self.assertGreater(
+            cached_tokens, 700, "Expected significant cached tokens for remote hit"
+        )
+
+
+class TestNPUHiCacheStoragePageFirstLayout(NPUHiCacheStorageBaseMixin, CustomTestCase):
+    """Page first layout tests for HiCache Storage on NPU.
+
+    [Test Category] HiCache
+    [Test Target] --hicache-mem-layout page_first_direct
+    """
+
+    @classmethod
+    def _get_additional_server_args_and_env(cls):
+        server_args = {"--hicache-mem-layout": "page_first_direct"}
+        return server_args, {"SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.temp_dir}
+
+
+class TestNPUHiCacheStoragePageFirstKVSplit(NPUHiCacheStorageBaseMixin, CustomTestCase):
+    """Page first KV split layout tests for HiCache Storage on NPU.
+
+    [Test Category] HiCache
+    [Test Target] --hicache-mem-layout page_first_kv_split
+    """
+
+    @classmethod
+    def _get_additional_server_args_and_env(cls):
+        server_args = {"--hicache-mem-layout": "page_first_kv_split"}
+        return server_args, {"SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.temp_dir}
+
+
+class TestNPUHiCacheStorageAccuracy(NPUHiCacheStorageBaseMixin, CustomTestCase):
+    """Accuracy tests for HiCache Storage on NPU.
+
+    [Test Category] HiCache
+    [Test Target] GSM8K accuracy consistency after cache flush
+    """
+
+    @classmethod
+    def _get_additional_server_args_and_env(cls):
+        server_args = {
+            "--tp-size": 1,
+            "--hicache-ratio": 1.5,
+        }
+        return server_args, {"SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.temp_dir}
+
+    def test_eval_accuracy(self):
+        """Test eval accuracy with cache persistence across cache flushes."""
+        run_eval_accuracy_test(self)
+
+
+def run_eval_accuracy_test(test_instance, accuracy_threshold: float = 0.05):
+    """Generic eval accuracy test with configurable accuracy threshold.
+
+    Args:
+        test_instance: The test class instance that provides base_host, base_port, flush_cache, and assert methods
+        accuracy_threshold: Maximum allowed accuracy difference between runs
+    """
+    print("\n=== Testing Eval Accuracy with Cache Persistence ===")
+
+    print("Phase 1: Running initial GSM8K evaluation to populate cache...")
+    args_initial = SimpleNamespace(
+        num_shots=5,
+        data_path=None,
+        num_questions=200,
+        max_new_tokens=512,
+        parallel=128,
+        host="http://127.0.0.1",
+        port=int(test_instance.base_port),
+    )
+    metrics_initial = run_eval_few_shot_gsm8k(args_initial)
+
+    print("Phase 2: Flushing device cache...")
+    test_instance.flush_cache()
+
+    print("Phase 3: Running second GSM8K evaluation using remote cache...")
+    metrics_cached = run_eval_few_shot_gsm8k(args_initial)
+
+    accuracy_diff = abs(metrics_initial["accuracy"] - metrics_cached["accuracy"])
+    print(f"Accuracy difference: {accuracy_diff:.4f}")
+
+    test_instance.assertGreater(
+        metrics_initial["accuracy"], 0.6, "Initial accuracy should be reasonable"
+    )
+    test_instance.assertGreater(
+        metrics_cached["accuracy"], 0.6, "Cached accuracy should be reasonable"
+    )
+    test_instance.assertLess(
+        accuracy_diff,
+        accuracy_threshold,
+        "Accuracy should be consistent between cache states",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_pp_with_hicache.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_pp_with_hicache.py
@@ -1,0 +1,132 @@
+"""
+Test Pipeline Parallelism with HiCache on Ascend NPU.
+
+Tests HiCache with pipeline parallel (PP) configuration to verify
+cache functionality works correctly across pipeline stages.
+
+NPU-specific adaptations:
+- --attention-backend ascend
+- --disable-cuda-graph
+- --hicache-io-backend kernel_ascend
+- --hicache-mem-layout page_first_direct
+
+Usage:
+    python3 -m pytest test/registered/ascend/basic_function/HiCache/test_npu_pp_with_hicache.py -v
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-4-npu-a3", nightly=True)
+
+
+class TestNPUPPWithHiCache(CustomTestCase):
+    """Test Pipeline Parallelism with HiCache on NPU.
+
+    [Test Category] HiCache
+    [Test Target] PP + HiCache integration
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_8B_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--enable-hierarchical-cache",
+                "--mem-fraction-static",
+                "0.6",
+                "--hicache-ratio",
+                "1.2",
+                "--page-size",
+                "64",
+                "--enable-cache-report",
+                "--hicache-storage-prefetch-policy",
+                "wait_complete",
+                "--hicache-storage-backend",
+                "file",
+                "--tp-size",
+                "2",
+                "--pp-size",
+                "2",
+                "--hicache-mem-layout",
+                "page_first_direct",
+                "--hicache-io-backend",
+                "kernel_ascend",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def flush_cache(self):
+        res = requests.post(
+            f"{self.base_url}/flush_cache",
+            params={"timeout": 30},
+            timeout=40,
+        )
+        res.raise_for_status()
+
+    def test_eval_accuracy(self):
+        """Test eval accuracy with cache persistence across cache flushes with PP."""
+        print("\n=== Testing PP + HiCache Accuracy ===")
+
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+
+        print("Phase 1: Running initial GSM8K evaluation...")
+        metrics_initial = run_eval_few_shot_gsm8k(args)
+        print(f"Initial accuracy: {metrics_initial['accuracy']}")
+
+        self.assertGreater(metrics_initial["accuracy"], 0.6, "Initial accuracy should be reasonable")
+
+        print("Phase 2: Flushing device cache...")
+        self.flush_cache()
+
+        print("Phase 3: Running second GSM8K evaluation...")
+        metrics_cached = run_eval_few_shot_gsm8k(args)
+        print(f"Cached accuracy: {metrics_cached['accuracy']}")
+
+        accuracy_diff = abs(metrics_initial["accuracy"] - metrics_cached["accuracy"])
+        print(f"Accuracy difference: {accuracy_diff:.4f}")
+
+        self.assertGreater(
+            metrics_cached["accuracy"], 0.6, "Cached accuracy should be reasonable"
+        )
+        self.assertLess(
+            accuracy_diff,
+            0.05,
+            "Accuracy should be consistent between cache states",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_pp_with_hicache.py
+++ b/test/registered/ascend/basic_function/HiCache_npu_new/test_npu_pp_with_hicache.py
@@ -106,7 +106,9 @@ class TestNPUPPWithHiCache(CustomTestCase):
         metrics_initial = run_eval_few_shot_gsm8k(args)
         print(f"Initial accuracy: {metrics_initial['accuracy']}")
 
-        self.assertGreater(metrics_initial["accuracy"], 0.6, "Initial accuracy should be reasonable")
+        self.assertGreater(
+            metrics_initial["accuracy"], 0.6, "Initial accuracy should be reasonable"
+        )
 
         print("Phase 2: Flushing device cache...")
         self.flush_cache()


### PR DESCRIPTION
This PR adds new HiCache NPU test cases:

## Test Cases Added

### 1 NPU Tests
- 	est_npu_hicache_kv_events.py - KV events emission test
- 	est_npu_hicache_3fs_backend.py - 3FS storage backend test
- 	est_npu_hicache_storage_file_backend.py - File storage backend test
- 	est_npu_hicache_runtime_attach_detach.py - Runtime attach/detach test

### 4 NPU Tests
- 	est_npu_hicache_large_model.py - Large model (Qwen3-32B) test
- 	est_npu_pp_with_hicache.py - Pipeline Parallelism with HiCache test
- 	est_npu_hicache_mooncake_backend.py - Mooncake storage backend test

### Skipped Tests (EAGLE not supported yet)
- 	est_npu_hicache_eagle_variant.py
- 	est_npu_hicache_spec_file_storage.py

## CI Workflow
Added .github/workflows/single-test-npu.yml to run these tests on PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->