### PR TITLE
Add DeepEP Low Latency Qwen3 30B A3B W8A8 NPU test case

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,111 @@
+# test round 1: DeepEP Low Latency Qwen3 30B A3B W8A8 NPU test case - test_npu_deepep_low_latency_qwen3_30b_a3b_w8a8.py
+name: Single Test (NPU)
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (branch, tag, or SHA) to test. If not provided, uses the default branch.'
+        required: false
+        type: string
+        default: ''
+      job_filter:
+        description: 'Select which job to run (leave empty or "all" to run all jobs)'
+        required: false
+        type: string
+        default: 'all'
+      image_a3:
+        description: 'The a3 running docker image of the test task.'
+        required: false
+        type: string
+        default: ''
+      skip_install_flag:
+        description: 'Indicates whether to skip the installation of sglang, defaulting to false.'
+        required: false
+        type: string
+        default: ''
+      test_scope:
+        description: 'Test scope: all / single / multi'
+        required: true
+        type: choice
+        options:
+          - all
+          - single
+          - multi
+        default: 'single'
+
+concurrency:
+  group: single-test-npu-${{ inputs.ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
+
+jobs:
+  set-image-config:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.set-vars.outputs.ref }}
+      job_filter: ${{ steps.set-vars.outputs.job_filter }}
+      image_a3: ${{ steps.set-vars.outputs.image_a3 }}
+      skip_install_flag: ${{ steps.set-vars.outputs.skip_install_flag }}
+      test_scope: ${{ steps.set-vars.outputs.test_scope }}
+    steps:
+      - name: Set image config
+        id: set-vars
+        run: |
+          if [ -z "${{ inputs.ref }}" ]; then
+            echo "ref=" >> $GITHUB_OUTPUT
+          else
+            echo "ref=${{ inputs.ref }}" >> $GITHUB_OUTPUT
+          fi
+
+          if [ -z "${{ inputs.job_filter }}" ]; then
+            echo "job_filter=all" >> $GITHUB_OUTPUT
+          else
+            echo "job_filter=${{ inputs.job_filter }}" >> $GITHUB_OUTPUT
+          fi
+
+          if [ -z "${{ inputs.image_a3 }}" ]; then
+            echo "image_a3=swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11" >> $GITHUB_OUTPUT
+          else
+            echo "image_a3=${{ inputs.image_a3 }}" >> $GITHUB_OUTPUT
+          fi
+
+          if [ -z "${{ inputs.skip_install_flag }}" ]; then
+            echo "skip_install_flag=false" >> $GITHUB_OUTPUT
+          else
+            echo "skip_install_flag=${{ inputs.skip_install_flag }}" >> $GITHUB_OUTPUT
+          fi
+
+          if [ -z "${{ inputs.test_scope }}" ]; then
+            echo "test_scope=all" >> $GITHUB_OUTPUT
+          else
+            echo "test_scope=${{ inputs.test_scope }}" >> $GITHUB_OUTPUT
+          fi
+
+  single-node-tests:
+    name: single-node-poc
+    needs: [ set-image-config ]
+    if: ${{ !cancelled() && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'single') }}
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        test_config:
+          # DeepEP Low Latency Qwen3 30B A3B W8A8 NPU test case
+          - name: test_npu_deepep_low_latency_qwen3_30b_a3b_w8a8
+            runner: linux-aarch64-a3-8
+            test_case: test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_low_latency_qwen3_30b_a3b_w8a8.py
+            test_type: 'func'
+    uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
+    with:
+      runner: ${{ matrix.test_config.runner }}
+      test_type: ${{ matrix.test_config.test_type }}
+      test_config_name: ${{ matrix.test_config.name }}
+      test_case: ${{ matrix.test_config.test_case }}
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3-20260515'
+      install_sglang_from_source: false
+      transformers_version: ''


### PR DESCRIPTION
This PR adds the DeepEP Low Latency Qwen3 30B A3B W8A8 NPU test case.

## Changes
- Added CI configuration in .github/workflows/single-test-npu.yml
- Test case: 	est_npu_deepep_low_latency_qwen3_30b_a3b_w8a8.py
- Docker image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3-20260515

## Test Details
- **Test Target**: --moe-a2a-backend; --deepep-mode
- **Model**: Qwen3-30B-A3B-W8A8
- **Backend**: DeepEP low latency mode
- **Runner**: linux-aarch64-a3-8



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->