### PR TITLE
test: add LoRA overlap loading test case

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,92 @@
+name: Single Test (NPU)
+# test round 2: LoRA overlap loading test case
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test case
+          test_case="test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_overlap_loading.py"
+          if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+            echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+            exit 1
+          fi
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          tc_name=test_npu_lora_overlap_loading
+          log_path="/root/.cache/tests/logs/log/${current_date}/${tc_name}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          echo "Running test case ${test_case}"
+          python -u ${sglang_source_path}/${test_case}
+          echo "Finished test case ${test_case}"
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${tc_name}/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,4 +1,4 @@
-name: Single Test (NPU)
+﻿name: Single Test (NPU)
 # test round 2: LoRA overlap loading test case
 
 on:

--- a/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_overlap_loading.py
+++ b/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_overlap_loading.py
@@ -1,0 +1,252 @@
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_2_1B_INSTRUCT_TOOL_CALLING_LORA_WEIGHTS_PATH,
+    LLAMA_3_2_1B_INSTRUCT_TOOL_FAST_LORA_WEIGHTS_PATH,
+    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=450, suite="nightly-2-npu-a3", nightly=True)
+
+PROMPTS = [
+    "The capital of France is",
+    "Machine learning is a subset of",
+    "What is artificial intelligence",
+]
+
+
+class TestNPULoRAOverlapLoadingEnabled(CustomTestCase):
+    """Testcase: Verify LoRA with overlap loading enabled on NPU.
+
+    [Test Category] Feature
+    [Test Target] --enable-lora-overlap-loading, async LoRA loading during inference
+    """
+
+    base_model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+    lora_a = LLAMA_3_2_1B_INSTRUCT_TOOL_CALLING_LORA_WEIGHTS_PATH
+    lora_b = LLAMA_3_2_1B_INSTRUCT_TOOL_FAST_LORA_WEIGHTS_PATH
+
+    @classmethod
+    def setUpClass(cls):
+        other_args = [
+            "--tp-size",
+            "2",
+            "--enable-lora",
+            "--enable-lora-overlap-loading",
+            "--lora-path",
+            f"lora_a={cls.lora_a}",
+            f"lora_b={cls.lora_b}",
+            "--max-loaded-loras",
+            "2",
+            "--max-loras-per-batch",
+            "2",
+            "--lora-target-modules",
+            "all",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.3",
+        ]
+        cls.process = popen_launch_server(
+            cls.base_model,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_lora_with_overlap_loading_single_adapter(self):
+        """Test LoRA inference with overlap loading enabled - single adapter."""
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={
+                "text": PROMPTS[0],
+                "lora_path": "lora_a",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text", response.json())
+        self.assertGreater(len(response.json()["text"]), 0)
+
+    def test_lora_with_overlap_loading_multiple_adapters(self):
+        """Test LoRA inference with overlap loading enabled - multiple adapters."""
+        outputs = []
+        for adapter in ["lora_a", "lora_b"]:
+            response = requests.post(
+                DEFAULT_URL_FOR_TEST + "/generate",
+                json={
+                    "text": PROMPTS[0],
+                    "lora_path": adapter,
+                    "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+            outputs.append(response.json()["text"])
+
+        self.assertNotEqual(outputs[0], outputs[1], "Different adapters should produce different outputs")
+
+    def test_lora_overlap_loading_batch_inference(self):
+        """Test batch inference with overlap loading enabled."""
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={
+                "text": PROMPTS,
+                "lora_path": "lora_a",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        results = response.json()
+        self.assertEqual(len(results), len(PROMPTS))
+        for result in results:
+            self.assertGreater(len(result["text"]), 0)
+
+    def test_lora_overlap_loading_consistency(self):
+        """Test output consistency with overlap loading enabled."""
+        outputs = []
+        for _ in range(3):
+            response = requests.post(
+                DEFAULT_URL_FOR_TEST + "/generate",
+                json={
+                    "text": PROMPTS[0],
+                    "lora_path": "lora_a",
+                    "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+            outputs.append(response.json()["text"])
+
+        self.assertTrue(all(o == outputs[0] for o in outputs), "Outputs should be consistent with overlap loading")
+
+
+class TestNPULoRABatchSplittingEquivalence(CustomTestCase):
+    """Testcase: Verify batch splitting equivalence with overlap loading on NPU.
+
+    [Test Category] Feature
+    [Test Target] Batch splitting, multi-adapter batch processing consistency
+    """
+
+    base_model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+    lora_a = LLAMA_3_2_1B_INSTRUCT_TOOL_CALLING_LORA_WEIGHTS_PATH
+    lora_b = LLAMA_3_2_1B_INSTRUCT_TOOL_FAST_LORA_WEIGHTS_PATH
+
+    @classmethod
+    def setUpClass(cls):
+        other_args = [
+            "--tp-size",
+            "2",
+            "--enable-lora",
+            "--enable-lora-overlap-loading",
+            "--lora-path",
+            f"lora_a={cls.lora_a}",
+            f"lora_b={cls.lora_b}",
+            "--max-loaded-loras",
+            "2",
+            "--max-loras-per-batch",
+            "2",
+            "--lora-target-modules",
+            "all",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.3",
+        ]
+        cls.process = popen_launch_server(
+            cls.base_model,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_batch_splitting_single_adapter(self):
+        """Test batch splitting with single adapter - results should match individual requests."""
+        prompt = PROMPTS[0]
+
+        response_batch = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={
+                "text": [prompt, prompt, prompt],
+                "lora_path": "lora_a",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+            },
+        )
+        self.assertEqual(response_batch.status_code, 200)
+        batch_results = response_batch.json()
+
+        response_single = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={
+                "text": prompt,
+                "lora_path": "lora_a",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+            },
+        )
+        self.assertEqual(response_single.status_code, 200)
+        single_result = response_single.json()["text"]
+
+        for batch_result in batch_results:
+            self.assertEqual(batch_result["text"], single_result, "Batch and single outputs should match")
+
+    def test_batch_splitting_mixed_adapters(self):
+        """Test batch splitting with mixed adapters."""
+        prompts = PROMPTS[:3]
+        adapters = ["lora_a", "lora_b", "lora_a"]
+
+        batch_results = []
+        for prompt, adapter in zip(prompts, adapters):
+            response = requests.post(
+                DEFAULT_URL_FOR_TEST + "/generate",
+                json={
+                    "text": prompt,
+                    "lora_path": adapter,
+                    "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+            batch_results.append(response.json()["text"])
+
+        self.assertEqual(len(batch_results), 3)
+        self.assertNotEqual(batch_results[0], batch_results[1], "Different adapters should produce different outputs")
+        self.assertEqual(batch_results[0], batch_results[2], "Same adapter should produce same output")
+
+    def test_batch_splitting_large_batch(self):
+        """Test batch splitting with large batch size."""
+        large_prompts = PROMPTS * 4
+
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={
+                "text": large_prompts,
+                "lora_path": "lora_a",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        results = response.json()
+        self.assertEqual(len(results), len(large_prompts))
+        for result in results:
+            self.assertGreater(len(result["text"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_overlap_loading.py
+++ b/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_overlap_loading.py
@@ -220,11 +220,11 @@ class TestNPULoRABatchSplittingEquivalence(CustomTestCase):
 
     def test_batch_splitting_mixed_adapters(self):
         """Test batch splitting with mixed adapters."""
-        prompts = PROMPTS[:3]
+        prompt = PROMPTS[0]
         adapters = ["lora_a", "lora_b", "lora_a"]
 
         batch_results = []
-        for prompt, adapter in zip(prompts, adapters):
+        for adapter in adapters:
             response = requests.post(
                 DEFAULT_URL_FOR_TEST + "/generate",
                 json={

--- a/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_overlap_loading.py
+++ b/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_overlap_loading.py
@@ -1,4 +1,4 @@
-import unittest
+﻿import unittest
 
 import requests
 
@@ -98,7 +98,9 @@ class TestNPULoRAOverlapLoadingEnabled(CustomTestCase):
             self.assertEqual(response.status_code, 200)
             outputs.append(response.json()["text"])
 
-        self.assertNotEqual(outputs[0], outputs[1], "Different adapters should produce different outputs")
+        self.assertNotEqual(
+            outputs[0], outputs[1], "Different adapters should produce different outputs"
+        )
 
     def test_lora_overlap_loading_batch_inference(self):
         """Test batch inference with overlap loading enabled."""
@@ -131,7 +133,9 @@ class TestNPULoRAOverlapLoadingEnabled(CustomTestCase):
             self.assertEqual(response.status_code, 200)
             outputs.append(response.json()["text"])
 
-        self.assertTrue(all(o == outputs[0] for o in outputs), "Outputs should be consistent with overlap loading")
+        self.assertTrue(
+            all(o == outputs[0] for o in outputs), "Outputs should be consistent with overlap loading"
+        )
 
 
 class TestNPULoRABatchSplittingEquivalence(CustomTestCase):
@@ -205,7 +209,9 @@ class TestNPULoRABatchSplittingEquivalence(CustomTestCase):
         single_result = response_single.json()["text"]
 
         for batch_result in batch_results:
-            self.assertEqual(batch_result["text"], single_result, "Batch and single outputs should match")
+            self.assertEqual(
+                batch_result["text"], single_result, "Batch and single outputs should match"
+            )
 
     def test_batch_splitting_mixed_adapters(self):
         """Test batch splitting with mixed adapters."""
@@ -226,8 +232,12 @@ class TestNPULoRABatchSplittingEquivalence(CustomTestCase):
             batch_results.append(response.json()["text"])
 
         self.assertEqual(len(batch_results), 3)
-        self.assertNotEqual(batch_results[0], batch_results[1], "Different adapters should produce different outputs")
-        self.assertEqual(batch_results[0], batch_results[2], "Same adapter should produce same output")
+        self.assertNotEqual(
+            batch_results[0], batch_results[1], "Different adapters should produce different outputs"
+        )
+        self.assertEqual(
+            batch_results[0], batch_results[2], "Same adapter should produce same output"
+        )
 
     def test_batch_splitting_large_batch(self):
         """Test batch splitting with large batch size."""

--- a/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_overlap_loading.py
+++ b/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_overlap_loading.py
@@ -99,7 +99,9 @@ class TestNPULoRAOverlapLoadingEnabled(CustomTestCase):
             outputs.append(response.json()["text"])
 
         self.assertNotEqual(
-            outputs[0], outputs[1], "Different adapters should produce different outputs"
+            outputs[0],
+            outputs[1],
+            "Different adapters should produce different outputs",
         )
 
     def test_lora_overlap_loading_batch_inference(self):
@@ -134,7 +136,8 @@ class TestNPULoRAOverlapLoadingEnabled(CustomTestCase):
             outputs.append(response.json()["text"])
 
         self.assertTrue(
-            all(o == outputs[0] for o in outputs), "Outputs should be consistent with overlap loading"
+            all(o == outputs[0] for o in outputs),
+            "Outputs should be consistent with overlap loading",
         )
 
 
@@ -210,7 +213,9 @@ class TestNPULoRABatchSplittingEquivalence(CustomTestCase):
 
         for batch_result in batch_results:
             self.assertEqual(
-                batch_result["text"], single_result, "Batch and single outputs should match"
+                batch_result["text"],
+                single_result,
+                "Batch and single outputs should match",
             )
 
     def test_batch_splitting_mixed_adapters(self):
@@ -233,10 +238,14 @@ class TestNPULoRABatchSplittingEquivalence(CustomTestCase):
 
         self.assertEqual(len(batch_results), 3)
         self.assertNotEqual(
-            batch_results[0], batch_results[1], "Different adapters should produce different outputs"
+            batch_results[0],
+            batch_results[1],
+            "Different adapters should produce different outputs",
         )
         self.assertEqual(
-            batch_results[0], batch_results[2], "Same adapter should produce same output"
+            batch_results[0],
+            batch_results[2],
+            "Same adapter should produce same output",
         )
 
     def test_batch_splitting_large_batch(self):


### PR DESCRIPTION
## Summary

Add LoRA overlap loading test case for NPU.

## Test Case

- 	est/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_overlap_loading.py

## Test Content

1. **TestNPULoRAOverlapLoadingEnabled** - Verify LoRA with overlap loading enabled
   - Single adapter inference
   - Multiple adapters inference
   - Batch inference
   - Output consistency

2. **TestNPULoRABatchSplittingEquivalence** - Verify batch splitting equivalence
   - Single adapter batch splitting
   - Mixed adapters batch splitting
   - Large batch processing











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->