### PR TITLE
test: add LoRA eviction and update NPU test cases

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,100 @@
+name: Single Test (NPU)
+# test round 4: LoRA eviction and update test cases (new PR)
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases
+          test_cases=(
+            "test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_eviction.py"
+            "test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_update.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_eviction.py
+++ b/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_eviction.py
@@ -1,0 +1,253 @@
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_2_1B_INSTRUCT_TOOL_CALLING_LORA_WEIGHTS_PATH,
+    LLAMA_3_2_1B_INSTRUCT_TOOL_FAST_LORA_WEIGHTS_PATH,
+    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=450, suite="nightly-2-npu-a3", nightly=True)
+
+PROMPTS = [
+    "AI is a field of computer science focused on",
+    "The capital of France is",
+]
+
+ADAPTERS = [
+    "lora_a",
+    "lora_b",
+]
+
+BASE_MODEL = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+
+
+class TestNPULoRAEviction(CustomTestCase):
+    """Testcase: Verify LoRA eviction with different adapters on NPU.
+
+    [Test Category] Feature
+    [Test Target] LoRA eviction, adapter switching, output consistency
+    """
+
+    lora_a = LLAMA_3_2_1B_INSTRUCT_TOOL_CALLING_LORA_WEIGHTS_PATH
+    lora_b = LLAMA_3_2_1B_INSTRUCT_TOOL_FAST_LORA_WEIGHTS_PATH
+
+    @classmethod
+    def setUpClass(cls):
+        other_args = [
+            "--tp-size",
+            "2",
+            "--enable-lora",
+            "--lora-path",
+            f"lora_a={cls.lora_a}",
+            f"lora_b={cls.lora_b}",
+            "--max-loaded-loras",
+            "2",
+            "--max-loras-per-batch",
+            "1",
+            "--lora-target-modules",
+            "all",
+            "--lora-eviction-policy",
+            "lru",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.3",
+        ]
+        cls.process = popen_launch_server(
+            BASE_MODEL,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_lora_eviction_with_different_adapters(self):
+        """Test LoRA eviction with different adapters in sequence."""
+        output_history = {}
+
+        for prompt in PROMPTS:
+            for adapter in ADAPTERS:
+                response = requests.post(
+                    DEFAULT_URL_FOR_TEST + "/generate",
+                    json={
+                        "text": prompt,
+                        "lora_path": adapter,
+                        "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+                    },
+                )
+                self.assertEqual(response.status_code, 200)
+                output = response.json()["text"].strip()
+
+                key = (adapter, prompt)
+                prev_output = output_history.get(key)
+                if prev_output is not None:
+                    self.assertEqual(
+                        prev_output,
+                        output,
+                        f"Output mismatch for adapter {adapter} and prompt '{prompt}'",
+                    )
+                else:
+                    output_history[key] = output
+
+    def test_lora_eviction_reversed_order(self):
+        """Test LoRA eviction with reversed adapter order."""
+        output_history = {}
+
+        reversed_adapters = ADAPTERS[::-1]
+        for prompt in PROMPTS:
+            for adapter in reversed_adapters:
+                response = requests.post(
+                    DEFAULT_URL_FOR_TEST + "/generate",
+                    json={
+                        "text": prompt,
+                        "lora_path": adapter,
+                        "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+                    },
+                )
+                self.assertEqual(response.status_code, 200)
+                output = response.json()["text"].strip()
+
+                key = (adapter, prompt)
+                prev_output = output_history.get(key)
+                if prev_output is not None:
+                    self.assertEqual(
+                        prev_output,
+                        output,
+                        f"Output mismatch for adapter {adapter} and prompt '{prompt}' in reversed order",
+                    )
+                else:
+                    output_history[key] = output
+
+    def test_adapter_outputs_are_different(self):
+        """Test that different adapters produce different outputs."""
+        base_params = {
+            "text": PROMPTS[0],
+            "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+        }
+
+        outputs = []
+        for adapter in ADAPTERS:
+            response = requests.post(
+                DEFAULT_URL_FOR_TEST + "/generate",
+                json={**base_params, "lora_path": adapter},
+            )
+            self.assertEqual(response.status_code, 200)
+            outputs.append(response.json()["text"])
+
+        self.assertNotEqual(
+            outputs[0],
+            outputs[1],
+            "Different adapters should produce different outputs",
+        )
+
+
+class TestNPULoRAEvictionWithReusedName(CustomTestCase):
+    """Testcase: Verify LoRA eviction with reused adapter names on NPU.
+
+    [Test Category] Feature
+    [Test Target] LoRA eviction, reused lora_name
+    """
+
+    lora_a = LLAMA_3_2_1B_INSTRUCT_TOOL_CALLING_LORA_WEIGHTS_PATH
+    lora_b = LLAMA_3_2_1B_INSTRUCT_TOOL_FAST_LORA_WEIGHTS_PATH
+
+    @classmethod
+    def setUpClass(cls):
+        other_args = [
+            "--tp-size",
+            "2",
+            "--enable-lora",
+            "--max-loaded-loras",
+            "1",
+            "--max-loras-per-batch",
+            "1",
+            "--max-lora-rank",
+            "64",
+            "--lora-target-modules",
+            "all",
+            "--lora-eviction-policy",
+            "lru",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.3",
+        ]
+        cls.process = popen_launch_server(
+            BASE_MODEL,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_reused_lora_name_eviction(self):
+        """Test LoRA eviction with reused adapter name."""
+        reused_name = "shared_lora"
+
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/load_lora_adapter",
+            json={"lora_name": reused_name, "lora_path": self.lora_a},
+        )
+        self.assertTrue(response.ok)
+
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={
+                "text": PROMPTS[0],
+                "lora_path": reused_name,
+                "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        output_a = response.json()["text"]
+
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/unload_lora_adapter",
+            json={"lora_name": reused_name},
+        )
+        self.assertTrue(response.ok)
+
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/load_lora_adapter",
+            json={"lora_name": reused_name, "lora_path": self.lora_b},
+        )
+        self.assertTrue(response.ok)
+
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={
+                "text": PROMPTS[0],
+                "lora_path": reused_name,
+                "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        output_b = response.json()["text"]
+
+        self.assertNotEqual(
+            output_a,
+            output_b,
+            "Different LoRA paths with same name should produce different outputs",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_update.py
+++ b/test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_update.py
@@ -1,0 +1,219 @@
+import json
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_2_1B_INSTRUCT_TOOL_CALLING_LORA_WEIGHTS_PATH,
+    LLAMA_3_2_1B_INSTRUCT_TOOL_FAST_LORA_WEIGHTS_PATH,
+    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=500, suite="nightly-2-npu-a3", nightly=True)
+
+PROMPTS = [
+    "SGL is a",
+    "AI is a field of computer science focused on",
+]
+
+
+class TestNPULoRAUpdate(CustomTestCase):
+    """Testcase: Verify dynamic LoRA adapter load/unload operations on NPU.
+
+    [Test Category] Feature
+    [Test Target] LoRA dynamic update, load_lora_adapter, unload_lora_adapter
+    """
+
+    base_model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+    lora_a = LLAMA_3_2_1B_INSTRUCT_TOOL_CALLING_LORA_WEIGHTS_PATH
+    lora_b = LLAMA_3_2_1B_INSTRUCT_TOOL_FAST_LORA_WEIGHTS_PATH
+
+    @classmethod
+    def setUpClass(cls):
+        other_args = [
+            "--tp-size",
+            "2",
+            "--enable-lora",
+            "--lora-path",
+            f"lora_a={cls.lora_a}",
+            "--max-loaded-loras",
+            "2",
+            "--max-loras-per-batch",
+            "2",
+            "--lora-target-modules",
+            "all",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.3",
+        ]
+        cls.process = popen_launch_server(
+            cls.base_model,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_load_lora_adapter(self):
+        """Test loading a new LoRA adapter dynamically."""
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/load_lora_adapter",
+            json={"lora_name": "lora_b", "lora_path": self.lora_b},
+        )
+        self.assertTrue(response.ok, f"Failed to load LoRA adapter: {response.text}")
+        loaded_adapters = set(response.json()["loaded_adapters"])
+        self.assertIn("lora_a", loaded_adapters)
+        self.assertIn("lora_b", loaded_adapters)
+
+    def test_load_already_loaded_adapter(self):
+        """Test loading an already loaded LoRA adapter should fail."""
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/load_lora_adapter",
+            json={"lora_name": "lora_a", "lora_path": self.lora_a},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("already loaded", response.text)
+
+    def test_unload_lora_adapter(self):
+        """Test unloading a LoRA adapter."""
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/unload_lora_adapter",
+            json={"lora_name": "lora_a"},
+        )
+        self.assertTrue(response.ok, f"Failed to unload LoRA adapter: {response.text}")
+        loaded_adapters = set(response.json()["loaded_adapters"])
+        self.assertNotIn("lora_a", loaded_adapters)
+
+    def test_forward_with_never_loaded_adapter(self):
+        """Test forward pass with never-loaded adapter should fail."""
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={
+                "text": PROMPTS[0],
+                "lora_path": "never_loaded_lora",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("never been loaded", response.text)
+
+    def test_dynamic_load_unload_sequence(self):
+        """Test a sequence of load/unload operations."""
+        base_params = {
+            "text": PROMPTS[0],
+            "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+        }
+
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={**base_params, "lora_path": "lora_a"},
+        )
+        self.assertEqual(response.status_code, 200)
+        text_lora_a = response.json()["text"]
+
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/load_lora_adapter",
+            json={"lora_name": "lora_b", "lora_path": self.lora_b},
+        )
+        self.assertTrue(response.ok)
+
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={**base_params, "lora_path": "lora_b"},
+        )
+        self.assertEqual(response.status_code, 200)
+        text_lora_b = response.json()["text"]
+
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/unload_lora_adapter",
+            json={"lora_name": "lora_b"},
+        )
+        self.assertTrue(response.ok)
+
+        self.assertNotEqual(text_lora_a, text_lora_b)
+
+
+class TestNPULoRAUpdateWithPinned(CustomTestCase):
+    """Testcase: Verify pinned LoRA adapter behavior on NPU.
+
+    [Test Category] Feature
+    [Test Target] pinned LoRA adapters, eviction behavior
+    """
+
+    base_model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+    lora_a = LLAMA_3_2_1B_INSTRUCT_TOOL_CALLING_LORA_WEIGHTS_PATH
+    lora_b = LLAMA_3_2_1B_INSTRUCT_TOOL_FAST_LORA_WEIGHTS_PATH
+
+    @classmethod
+    def setUpClass(cls):
+        other_args = [
+            "--tp-size",
+            "2",
+            "--enable-lora",
+            "--lora-path",
+            json.dumps(
+                {
+                    "lora_name": "lora_a",
+                    "lora_path": cls.lora_a,
+                    "pinned": True,
+                },
+            ),
+            "--max-loaded-loras",
+            "2",
+            "--max-loras-per-batch",
+            "2",
+            "--lora-target-modules",
+            "all",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.3",
+        ]
+        cls.process = popen_launch_server(
+            cls.base_model,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_pinned_adapter_not_evicted(self):
+        """Test pinned adapter is not evicted when loading new adapter."""
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/load_lora_adapter",
+            json={"lora_name": "lora_b", "lora_path": self.lora_b},
+        )
+        self.assertTrue(response.ok)
+        loaded_adapters = set(response.json()["loaded_adapters"])
+        self.assertIn("lora_a", loaded_adapters)
+        self.assertIn("lora_b", loaded_adapters)
+
+    def test_load_pinned_when_capacity_full(self):
+        """Test loading pinned adapter when capacity is full should cause starvation."""
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/load_lora_adapter",
+            json={"lora_name": "lora_c", "lora_path": self.lora_a, "pinned": True},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("starvation", response.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add NPU LoRA test cases:
- `test_npu_lora_eviction.py`: LoRA eviction with different adapters, reversed order, output consistency, reused adapter name
- `test_npu_lora_update.py`: Dynamic LoRA adapter load/unload, pinned adapter behavior



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->