### PR TITLE
Add Qwen3.6 performance and accuracy test cases

### DIFF
--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -425,191 +425,58 @@ jobs:
       max-parallel: 3
       matrix:
         test_config:
-          - name: test_npu_kimi_k2_5_w4a8_8p_gpqa
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/accuracy/test_npu_kimi_k2_5_w4a8_8p_gpqa.py
-            test_type: 'accuracy'
-          - name: test_npu_kimi_k2_5_w4a8_8p_aime2025
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/accuracy/test_npu_kimi_k2_5_w4a8_8p_aime2025.py
-            test_type: 'accuracy'
-#          - name: test_npu_kimi_k2_5_w4a8_8p_in254k_out1k
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in254k_out1k.py
-#            test_type: 'perf'
-          - name: test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_20ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_20ms.py
-            test_type: 'perf'
-          - name: test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_50ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_50ms.py
-            test_type: 'perf'
-#          - name: test_npu_kimi_k2_5_w4a8_8p_in16k_out1k_20ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in16k_out1k_20ms.py
-#            test_type: 'perf'
-#          - name: test_npu_kimi_k2_5_w4a8_8p_in16k_out1k_50ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in16k_out1k_50ms.py
-#            test_type: 'perf'
-          - name: test_npu_kimi_k2_5_w4a8_8p_in1080p_30_out256_50ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in1080p_30_out256_50ms.py
-            test_type: 'perf'
-          - name: test_npu_kimi_k2_5_w4a8_8p_in1024x1024_30_out1024_50ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in1024x1024_30_out1024_50ms.py
-            test_type: 'perf'
-#          - name: test_npu_kimi_k2_5_w4a8_8p_in32k_out512_prefix90_100ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in32k_out512_prefix90_100ms.py
-#            test_type: 'perf'
-#          - name: test_npu_kimi_k2_5_w4a8_8p_in64k_out1k_prefix90_20ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in64k_out1k_prefix90_20ms.py
-#            test_type: 'perf'
-#          - name: test_npu_kimi_k2_5_w4a8_8p_in64k_out1k_prefix90_50ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in64k_out1k_prefix90_50ms.py
-#            test_type: 'perf'
-#          - name: test_npu_kimi_k2_5_w4a8_8p_in128k_out1k_prefix90_50ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in128k_out1k_prefix90_50ms.py
-#            test_type: 'perf'
-          # Qwen3.5-397b performance tests 8p single-node)
-          - name: test_npu_qwen3_5_397b_w4a8_8p_in3k5_out1k5_50ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w4a8_8p_in3k5_out1k5_50ms.py
-            test_type: 'perf'
-          - name: test_npu_qwen3_5_397b_w4a8_8p_in64k_out1k_50ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w4a8_8p_in64k_out1k_50ms.py
-            test_type: 'perf'
-          - name: test_npu_qwen3_5_397b_w4a8_8p_in128k_out1k_50ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w4a8_8p_in128k_out1k_50ms.py
-            test_type: 'perf'
-          - name: test_npu_qwen3_5_397b_w4a8_8p_in3k5_out1k5_20ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w4a8_8p_in3k5_out1k5_20ms.py
-            test_type: 'perf'
-          - name: test_npu_qwen3_5_397b_w4a8_8p_in16k_out1k_20ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w4a8_8p_in16k_out1k_20ms.py
-            test_type: 'perf'
-          - name: test_npu_qwen3_5_397b_w4a8_8p_in16k_out1k_50ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w4a8_8p_in16k_out1k_50ms.py
-            test_type: 'perf'
-          - name: test_npu_qwen3_5_397b_w4a8_8p_in64k_out1k_20ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w4a8_8p_in64k_out1k_20ms.py
-            test_type: 'perf'
-          - name: test_npu_qwen3_5_397b_w4a8_8p_in128k_out1k_20ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w4a8_8p_in128k_out1k_20ms.py
-            test_type: 'perf'
-#          - name: test_npu_qwen3_5_397b_w8a8_8p_in256k_out1k_500ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w8a8_8p_in256k_out1k_500ms.py
-#            test_type: 'perf'
-#          - name: test_npu_qwen3_5_397b_w8a8_8p_1024
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w8a8_8p_1024.py
-#            test_type: 'perf'
-#          - name: test_npu_qwen3_5_397b_w8a8_8p_1080p
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w8a8_8p_1080p.py
-#            test_type: 'perf'
-#          - name: test_npu_qwen3_5_397b_w8a8_8p_in64k_out1k_20ms_prefix
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w8a8_8p_in64k_out1k_20ms_prefix.py
-#            test_type: 'perf'
-          - name: test_npu_qwen3_5_397b_w4a8_8p_in64k_out1k_50ms_prefix
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w4a8_8p_in64k_out1k_50ms_prefix.py
-            test_type: 'perf'
-#          - name: test_npu_qwen3_5_397b_w8a8_8p_in128k_out1k_20ms_prefix
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w8a8_8p_in128k_out1k_20ms_prefix.py
-#            test_type: 'perf'
-          - name: test_npu_qwen3_5_397b_w4a8_8p_in128k_out1k_50ms_prefix
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_397b_w4a8_8p_in128k_out1k_50ms_prefix.py
-            test_type: 'perf'
-          # Qwen3.5-397B W8A8 single-node 16-card accuracy tests (tp=16)
-          - name: test_npu_qwen3_5_397b_w4a8_gpqa
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/accuracy/test_npu_qwen3_5_397b_gpqa_8p.py
-            test_type: 'accuracy'
-          - name: test_npu_qwen3_5_397b_w4a8_aime2025
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/accuracy/test_npu_qwen3_5_397b_aime2025_8p.py
-            test_type: 'accuracy'
-          # Qwen3.5-27b accuracy tests (1p single-node)
-          - name: test_npu_qwen3_5_27b_1p_in3k5_out1k5_high_gpqa
+          - name: test_npu_qwen3_6_35b_a3b_1p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-2
-            test_case: test/registered/ascend/accuracy/test_npu_qwen3_5_27b_1p_gpqa.py
-            test_type: 'accuracy'
-          - name: test_npu_qwen3_5_27b_1p_in3k5_out1k5_high_aime2025
+            test_case: test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_50ms
             runner: linux-aarch64-a3-2
-            test_case: test/registered/ascend/accuracy/test_npu_qwen3_5_27b_1p_aime2025.py
-            test_type: 'accuracy'
-          # Qwen3.5-27b 1p performance tests
-#          - name: test_npu_qwen3_5_27b_w8a8_1p_in128k_20ms
-#            runner: linux-aarch64-a3-2
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in128k_20ms.py
-#            test_type: 'perf'
-#          - name: test_npu_qwen3_5_27b_w8a8_1p_in128k_90prefix_20ms
-#            runner: linux-aarch64-a3-2
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in128k_90prefix_20ms.py
-#            test_type: 'perf'
-#          - name: test_npu_qwen3_5_27b_w8a8_1p_in128k_90prefix_50ms
-#            runner: linux-aarch64-a3-2
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in128k_90prefix_50ms.py
-#            test_type: 'perf'
-          - name: test_npu_qwen3_5_27b_w8a8_1p_in16k_out1k_20ms
+            test_case: test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_50ms.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_6_35b_a3b_1p_in128k_out1k_50ms
             runner: linux-aarch64-a3-2
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in16k_out1k_20ms.py
+            test_case: test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in128k_out1k_50ms.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_6_35b_a3b_2p_in984k_out1k
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_2p_in984k_out1k.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_6_35b_a3b_1p_in254k_out1k
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in254k_out1k.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_6_27b_1p_in1080p_30_out256_50ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/test_npu_qwen3_6_27b_1p_in1080p_30_out256_50ms.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_6_27b_1p_in1024x1024_30_out1024_50ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/test_npu_qwen3_6_27b_1p_in1024x1024_30_out1024_50ms.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_6_27b_w8a8_2p_in128k_out1k_50ms
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_2p_in128k_out1k_50ms.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_6_27b_w8a8_2p_in16k_out1k_50ms
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_2p_in16k_out1k_50ms.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_6_27b_w8a8_2p_in64k_out1k_50ms
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_2p_in64k_out1k_50ms.py
             test_type: 'perf'
           - name: test_npu_qwen3_5_27b_w8a8_1p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-2
             test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in3k5_out1k5_50ms.py
             test_type: 'perf'
-#          - name: test_npu_qwen3_5_27b_w8a8_1p_in64k_90prefix_20ms
-#            runner: linux-aarch64-a3-2
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in64k_90prefix_20ms.py
-#            test_type: 'perf'
-          - name: test_npu_qwen3_5_27b_w8a8_1p_in64k_90prefix_50ms
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in64k_90prefix_50ms.py
-            test_type: 'perf'
-          - name: test_npu_qwen3_5_27b_w8a8_1p_in64k_out1k_20ms
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in64k_out1k_20ms.py
-            test_type: 'perf'
-#          - name: test_npu_qwen3_5_27b_w8a8_1p_mm_1024_1024_50ms
-#            runner: linux-aarch64-a3-2
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_mm_1024_1024_50ms.py
-#            test_type: 'perf'
-#          - name: test_npu_qwen3_5_27b_w8a8_1p_mm_1920x1080_50ms
-#            runner: linux-aarch64-a3-2
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_mm_1920x1080_50ms.py
-#            test_type: 'perf'
-          # Qwen3.5-27b 2p performance tests
-#          - name: test_npu_qwen3_5_27b_w8a8_2p_in128k_50ms
-#            runner: linux-aarch64-a3-4
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_2p_in128k_50ms.py
-#            test_type: 'perf'
           - name: test_npu_qwen3_5_27b_w8a8_2p_in16k_out1k_50ms
             runner: linux-aarch64-a3-4
             test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_2p_in16k_out1k_50ms.py
             test_type: 'perf'
-#          - name: test_npu_qwen3_5_27b_w8a8_2p_in256k_out1k_50ms
-#            runner: linux-aarch64-a3-4
-#            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_2p_in256k_out1k_50ms.py
-#            test_type: 'perf'
           - name: test_npu_qwen3_5_27b_w8a8_2p_in3k5_out1k5_20ms
             runner: linux-aarch64-a3-4
             test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_2p_in3k5_out1k5_20ms.py
@@ -618,47 +485,29 @@ jobs:
             runner: linux-aarch64-a3-4
             test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_2p_in64k_out1k_50ms.py
             test_type: 'perf'
-            # glm5-w4a8 single-node tests
-          - name: test_npu_glm5_1_w4a8_8p_gpqa
+          - name: test_npu_qwen3_5_27b_w8a8_1p_in16k_out1k_20ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in16k_out1k_20ms.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_5_27b_w8a8_1p_in64k_out1k_20ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in64k_out1k_20ms.py
+            test_type: 'perf'
+          - name: test_npu_qwen3_5_27b_w8a8_1p_in64k_90prefix_20ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in64k_90prefix_20ms.py
+            test_type: 'perf'
+          - name: test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/accuracy/test_npu_glm5_1_w4a8_8p_gpqa.py
-            test_type: 'accuracy'
-          - name: test_npu_glm5_1_w4a8_8p_aime2025
+            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+          - name: test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_20ms
             runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/accuracy/test_npu_glm5_1_w4a8_8p_aime2025.py
-            test_type: 'accuracy'
-#          - name: test_npu_glm5_1_w4a8_8p_in3k5_out1k5_20ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_8p_in3k5_out1k5_20ms.py
-#            test_type: 'perf'
-#          - name: test_npu_glm5_1_w4a8_8p_in3k5_out1k5_50ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_8p_in3k5_out1k5_50ms.py
-#            test_type: 'perf'
-#          - name: test_npu_glm5_1_w4a8_8p_in16k_out1k_20ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_8p_in16k_out1k_20ms.py
-#            test_type: 'perf'
-#          - name: test_npu_glm5_1_w4a8_8p_in16k_out1k_50ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_8p_in16k_out1k_50ms.py
-#            test_type: 'perf'
-#          - name: test_npu_glm5_1_w4a8_8p_in196k_out1k
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_8p_in196k_out1k.py
-#            test_type: 'perf'
-#          - name: test_npu_glm5_1_w4a8_8p_in32k_out0k5_20ms_90.py
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_8p_in32k_out0k5_20ms_90.py
-#            test_type: 'perf'
-#          - name: test_npu_glm5_1_w4a8_8p_in64k_out1k_20ms_90.py
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_8p_in64k_out1k_20ms_90.py
-#            test_type: 'perf'
-          # MiniMax-M2.5-w8a8 single-node tests
-          - name: test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_20ms
+            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_20ms.py
+            test_type: 'perf'
+          - name: test_npu_kimi_k2_5_w4a8_8p_in1024x1024_30_out1024_50ms
             runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_20ms.py
+            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in1024x1024_30_out1024_50ms.py
             test_type: 'perf'
           - name: test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-16
@@ -668,30 +517,6 @@ jobs:
             runner: linux-aarch64-a3-16
             test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_8p_in32k_out1k_50ms.py
             test_type: 'perf'
-#          - name: test_npu_minimax_m2_5_w8a8_8p_in190k_out1k
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_8p_in190k_out1k.py
-#            test_type: 'perf'
-#          - name: test_npu_minimax_m2_5_w8a8_8p_in32k_out0k5_prefix90_100ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_8p_in32k_out0k5_prefix90_100ms.py
-#            test_type: 'perf'
-#          - name: test_npu_minimax_m2_5_w8a8_8p_in64k_out1k_prefix90_50ms
-#            runner: linux-aarch64-a3-16
-#            test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_8p_in64k_out1k_prefix90_50ms.py
-#            test_type: 'perf'
-          - name: test_npu_minimax_m2_5_w8a8_8p_in128k_out1k_prefix90_50ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_8p_in128k_out1k_prefix90_50ms.py
-            test_type: 'perf'
-          - name: test_npu_minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms
-            runner: linux-aarch64-a3-8
-            test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms.py
-            test_type: 'perf'
-          - name: test_npu_minimax_m2_5_w8a8_8p_in128k_out1k_prefix90_20ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_8p_in128k_out1k_prefix90_20ms.py
-            test_type: 'perf'
           - name: test_npu_minimax_m2_5_w8a8_8p_aime2025
             runner: linux-aarch64-a3-16
             test_case: test/registered/ascend/accuracy/test_npu_minimax_m2_5_w8a8_8p_aime2025.py
@@ -699,6 +524,10 @@ jobs:
           - name: test_npu_minimax_m2_5_w8a8_8p_gpqa
             runner: linux-aarch64-a3-16
             test_case: test/registered/ascend/accuracy/test_npu_minimax_m2_5_w8a8_8p_gpqa.py
+            test_type: 'accuracy'
+          - name: test_npu_qwen3_5_27b_1p_gpqa
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/accuracy/test_npu_qwen3_5_27b_1p_gpqa.py
             test_type: 'accuracy'
     uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
     with:
@@ -719,79 +548,79 @@ jobs:
       max-parallel: 1
       matrix:
         test_config:
-          - name: test_ascend_qwen3_235b_w8a8_1p1d_24p_accuracy
-            prefill_size: 1
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/accuracy/test_ascend_qwen3_235b_w8a8_1p1d_24p_accuracy.py
-            test_type: 'accuracy'
-            prefill_decode_deployment: 'separation'
+          #- name: test_ascend_qwen3_235b_w8a8_1p1d_24p_accuracy
+            #prefill_size: 1
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/accuracy/test_ascend_qwen3_235b_w8a8_1p1d_24p_accuracy.py
+            #test_type: 'accuracy'
+            #prefill_decode_deployment: 'separation'
           # GLM5 1p1d_32p (P: tp=16 + D: tp=16, total 32 cards)
-          - name: test_npu_glm5_1_w4a8_1p1d_32p_gpqa
-            prefill_size: 2
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/accuracy/test_npu_glm5_1_w4a8_1p1d_32p_gpqa.py
-            test_type: 'accuracy'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_glm5_1_w4a8_1p1d_32p_aime2025
-            prefill_size: 2
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/accuracy/test_npu_glm5_1_w4a8_1p1d_32p_aime2025.py
-            test_type: 'accuracy'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_glm5_1_w4a8_1p1d_32p_in65k_out1k5_prefix90_25ms
-            prefill_size: 2
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_32p_in65k_out1k5_prefix90_25ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_glm5_1_w4a8_1p1d_48p_in65k_out1k5_prefix100_33ms
-            prefill_size: 2
-            decode_size: 4
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_48p_in65k_out1k5_prefix100_33ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_glm5_1_w4a8_1p1d_32p_in16k_out1k_50ms
-            prefill_size: 2
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_32p_in16k_out1k_50ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_glm5_1_w4a8_1p1d_32p_in64k_out1k
-            prefill_size: 2
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_32p_in64k_out1k.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_glm5_1_w4a8_1p1d_32p_in128k_out1k
-            prefill_size: 2
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_32p_in128k_out1k.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_glm5_1_w4a8_1p1d_48p_in64k_out1k_prefix90_50ms
-            prefill_size: 4
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_48p_in64k_out1k_prefix90_50ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_glm5_1_w4a8_1p1d_48p_in128k_out1k_prefix90_50ms
-            prefill_size: 4
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_48p_in128k_out1k_prefix90_50ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
+          #- name: test_npu_glm5_1_w4a8_1p1d_32p_gpqa
+            #prefill_size: 2
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/accuracy/test_npu_glm5_1_w4a8_1p1d_32p_gpqa.py
+            #test_type: 'accuracy'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_glm5_1_w4a8_1p1d_32p_aime2025
+            #prefill_size: 2
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/accuracy/test_npu_glm5_1_w4a8_1p1d_32p_aime2025.py
+            #test_type: 'accuracy'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_glm5_1_w4a8_1p1d_32p_in65k_out1k5_prefix90_25ms
+            #prefill_size: 2
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_32p_in65k_out1k5_prefix90_25ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_glm5_1_w4a8_1p1d_48p_in65k_out1k5_prefix100_33ms
+            #prefill_size: 2
+            #decode_size: 4
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_48p_in65k_out1k5_prefix100_33ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_glm5_1_w4a8_1p1d_32p_in16k_out1k_50ms
+            #prefill_size: 2
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_32p_in16k_out1k_50ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_glm5_1_w4a8_1p1d_32p_in64k_out1k
+            #prefill_size: 2
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_32p_in64k_out1k.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_glm5_1_w4a8_1p1d_32p_in128k_out1k
+            #prefill_size: 2
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_32p_in128k_out1k.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_glm5_1_w4a8_1p1d_48p_in64k_out1k_prefix90_50ms
+            #prefill_size: 4
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_48p_in64k_out1k_prefix90_50ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_glm5_1_w4a8_1p1d_48p_in128k_out1k_prefix90_50ms
+            #prefill_size: 4
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_1p1d_48p_in128k_out1k_prefix90_50ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
 
-#          - name: test_npu_glm5_1_w4a8_1p1d_32p_in3k5_out1k5_20ms
+###          - name: test_npu_glm5_1_w4a8_1p1d_32p_in3k5_out1k5_20ms
 #            prefill_size: 1
 #            decode_size: 1
 #            router_size: 1
@@ -991,35 +820,35 @@ jobs:
 #            test_type: 'perf'
 #            prefill_decode_deployment: 'separation'
           # Kimi 1p1d_16p accuracy
-          - name: test_npu_kimi_k2_5_w4a8_1p1d_16p_gpqa
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/ascend/accuracy/test_npu_kimi_k2_5_w4a8_1p1d_16p_gpqa.py
-            test_type: 'accuracy'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_kimi_k2_5_w4a8_1p1d_16p_aime2025
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/ascend/accuracy/test_npu_kimi_k2_5_w4a8_1p1d_16p_aime2025.py
-            test_type: 'accuracy'
-            prefill_decode_deployment: 'separation'
+          #- name: test_npu_kimi_k2_5_w4a8_1p1d_16p_gpqa
+            #prefill_size: 1
+            #decode_size: 1
+            #router_size: 1
+            #test_case: test/registered/ascend/accuracy/test_npu_kimi_k2_5_w4a8_1p1d_16p_gpqa.py
+            #test_type: 'accuracy'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_kimi_k2_5_w4a8_1p1d_16p_aime2025
+            #prefill_size: 1
+            #decode_size: 1
+            #router_size: 1
+            #test_case: test/registered/ascend/accuracy/test_npu_kimi_k2_5_w4a8_1p1d_16p_aime2025.py
+            #test_type: 'accuracy'
+            #prefill_decode_deployment: 'separation'
             # Kimi 1p1d_24p accuracy
-          - name: test_npu_kimi_k2_5_w4a8_1p1d_24p_aime2025
-            prefill_size: 1
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/accuracy/test_npu_kimi_k2_5_w4a8_1p1d_24p_aime2025.py
-            test_type: 'accuracy'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_kimi_k2_5_w4a8_1p1d_24p_gpqa
-            prefill_size: 1
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/accuracy/test_npu_kimi_k2_5_w4a8_1p1d_24p_gpqa.py
-            test_type: 'accuracy'
-            prefill_decode_deployment: 'separation'
+          #- name: test_npu_kimi_k2_5_w4a8_1p1d_24p_aime2025
+            #prefill_size: 1
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/accuracy/test_npu_kimi_k2_5_w4a8_1p1d_24p_aime2025.py
+            #test_type: 'accuracy'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_kimi_k2_5_w4a8_1p1d_24p_gpqa
+            #prefill_size: 1
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/accuracy/test_npu_kimi_k2_5_w4a8_1p1d_24p_gpqa.py
+            #test_type: 'accuracy'
+            #prefill_decode_deployment: 'separation'
 #          # Kimi 2p1d_32p accuracy
 #          - name: test_npu_kimi_k2_5_w4a8_2p1d_32p_gpqa
 #            prefill_size: 2
@@ -1049,48 +878,48 @@ jobs:
 #            test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_1p1d_24p_in3k5_out1k5_50ms.py
 #            test_type: 'perf'
 #            prefill_decode_deployment: 'separation'
-          - name: test_npu_minimax_m2_5_w8a8_1p1d_16p_aime2025
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/ascend/accuracy/test_npu_minimax_m2_5_w8a8_1p1d_16p_aime2025.py
-            test_type: 'accuracy'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_minimax_m2_5_w8a8_1p1d_16p_gpqa
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/ascend/accuracy/test_npu_minimax_m2_5_w8a8_1p1d_16p_gpqa.py
-            test_type: 'accuracy'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_minimax_m2_5_w8a8_1p1d_16p_in128k_out1k_prefix90_50ms
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_1p1d_16p_in128k_out1k_prefix90_50ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_minimax_m2_5_w8a8_1p1d_16p_in64k_out1k_prefix90_50ms
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_1p1d_16p_in64k_out1k_prefix90_50ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_ascend_qwen3_235b_w8a8_1p1d_24p_accuracy
-            prefill_size: 1
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/accuracy/test_ascend_qwen3_235b_w8a8_1p1d_24p_accuracy.py
-            test_type: 'accuracy'
-            prefill_decode_deployment: 'separation'
-          - name: test_ascend_deepseek_r1_w8a8_1p1d_24p_in2k_out2k_50ms
-            prefill_size: 1
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_ascend_deepseek_r1_w8a8_1p1d_24p_in2k_out2k_50ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
+          #- name: test_npu_minimax_m2_5_w8a8_1p1d_16p_aime2025
+            #prefill_size: 1
+            #decode_size: 1
+            #router_size: 1
+            #test_case: test/registered/ascend/accuracy/test_npu_minimax_m2_5_w8a8_1p1d_16p_aime2025.py
+            #test_type: 'accuracy'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_minimax_m2_5_w8a8_1p1d_16p_gpqa
+            #prefill_size: 1
+            #decode_size: 1
+            #router_size: 1
+            #test_case: test/registered/ascend/accuracy/test_npu_minimax_m2_5_w8a8_1p1d_16p_gpqa.py
+            #test_type: 'accuracy'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_minimax_m2_5_w8a8_1p1d_16p_in128k_out1k_prefix90_50ms
+            #prefill_size: 1
+            #decode_size: 1
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_1p1d_16p_in128k_out1k_prefix90_50ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_minimax_m2_5_w8a8_1p1d_16p_in64k_out1k_prefix90_50ms
+            #prefill_size: 1
+            #decode_size: 1
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_1p1d_16p_in64k_out1k_prefix90_50ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_ascend_qwen3_235b_w8a8_1p1d_24p_accuracy
+            #prefill_size: 1
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/accuracy/test_ascend_qwen3_235b_w8a8_1p1d_24p_accuracy.py
+            #test_type: 'accuracy'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_ascend_deepseek_r1_w8a8_1p1d_24p_in2k_out2k_50ms
+            #prefill_size: 1
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_ascend_deepseek_r1_w8a8_1p1d_24p_in2k_out2k_50ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
 #          - name: test_npu_kimi_k2_5_w4a8_1p1d_16p_in3k5_out1k5_20ms
 #            prefill_size: 1
 #            decode_size: 1
@@ -1105,42 +934,42 @@ jobs:
 #            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_1p1d_16p_in3k5_out1k5_50ms.py
 #            test_type: 'perf'
 #            prefill_decode_deployment: 'separation'
-          - name: test_npu_kimi_k2_5_w4a8_1p1d_16p_in64k_out1k5_100ms
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_1p1d_16p_in64k_out1k5_100ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_kimi_k2_5_w4a8_1p1d_16p_in128k_out1k_100ms
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_1p1d_16p_in128k_out1k_100ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_kimi_k2_5_w4a8_1p1d_24p_in64k_out1k5_prefix90_100ms
-            prefill_size: 1
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_1p1d_24p_in64k_out1k5_prefix90_100ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_kimi_k2_5_w4a8_1p1d_24p_in128k_out1k_prefix90_100ms
-            prefill_size: 1
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_1p1d_24p_in128k_out1k_prefix90_100ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
+          #- name: test_npu_kimi_k2_5_w4a8_1p1d_16p_in64k_out1k5_100ms
+            #prefill_size: 1
+            #decode_size: 1
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_1p1d_16p_in64k_out1k5_100ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_kimi_k2_5_w4a8_1p1d_16p_in128k_out1k_100ms
+            #prefill_size: 1
+            #decode_size: 1
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_1p1d_16p_in128k_out1k_100ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_kimi_k2_5_w4a8_1p1d_24p_in64k_out1k5_prefix90_100ms
+            #prefill_size: 1
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_1p1d_24p_in64k_out1k5_prefix90_100ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
+          #- name: test_npu_kimi_k2_5_w4a8_1p1d_24p_in128k_out1k_prefix90_100ms
+            #prefill_size: 1
+            #decode_size: 2
+            #router_size: 1
+            #test_case: test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_1p1d_24p_in128k_out1k_prefix90_100ms.py
+            #test_type: 'perf'
+            #prefill_decode_deployment: 'separation'
           # Qwen3.5-397B W8A8 1P1D 32-card accuracy tests (P:16 + D:16)
-          - name: test_npu_qwen3_5_397b_w8a8_1p1d_16p_gpqa
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/ascend/accuracy/test_npu_qwen3_5_397b_gpqa_1p1d_16p.py
-            test_type: 'accuracy'
-            prefill_decode_deployment: 'separation'
+          #- name: test_npu_qwen3_5_397b_w8a8_1p1d_16p_gpqa
+            #prefill_size: 1
+            #decode_size: 1
+            #router_size: 1
+            #test_case: test/registered/ascend/accuracy/test_npu_qwen3_5_397b_gpqa_1p1d_16p.py
+            #test_type: 'accuracy'
+            #prefill_decode_deployment: 'separation'
 #          - name: test_npu_qwen3_5_397b_w8a8_1p1d_16p_aime2025
 #            prefill_size: 1
 #            decode_size: 1
@@ -1257,16 +1086,16 @@ jobs:
       matrix:
         test_config:
           # glm-w4a8
-          - name: test_npu_glm5_1_w4a8_16p_gpqa
-            node_size: 2
-            test_case: test/registered/ascend/accuracy/test_npu_glm5_1_w4a8_16p_gpqa.py
-          - name: test_npu_glm5_1_w4a8_16p_aime2025
-            node_size: 2
-            test_case: test/registered/ascend/accuracy/test_npu_glm5_1_w4a8_16p_aime2025.py
+#          - name: test_npu_glm5_1_w4a8_16p_gpqa
+#            node_size: 2
+#            test_case: test/registered/ascend/accuracy/test_npu_glm5_1_w4a8_16p_gpqa.py
+#          - name: test_npu_glm5_1_w4a8_16p_aime2025
+#            node_size: 2
+#            test_case: test/registered/ascend/accuracy/test_npu_glm5_1_w4a8_16p_aime2025.py
             # GLM5 16p additional performance
-          - name: test_npu_glm5_1_w4a8_16p_in3k5_out1k5_50ms
-            node_size: 2
-            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_16p_in3k5_out1k5_50ms.py
+#          - name: test_npu_glm5_1_w4a8_16p_in3k5_out1k5_50ms
+#            node_size: 2
+#            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_16p_in3k5_out1k5_50ms.py
 #          - name: test_npu_glm5_1_w4a8_16p_in128k_out1k_50ms_90.py
 #            node_size: 2
 #            test_case: test/registered/ascend/performance/test_npu_glm5_1_w4a8_16p_in128k_out1k_50ms_90.py

--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -493,9 +493,9 @@ jobs:
             runner: linux-aarch64-a3-2
             test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in64k_out1k_20ms.py
             test_type: 'perf'
-          - name: test_npu_qwen3_5_27b_w8a8_1p_in64k_90prefix_20ms
+          - name: test_npu_qwen3_5_27b_w8a8_1p_in1024x1024_30_out1024_50ms
             runner: linux-aarch64-a3-2
-            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in64k_90prefix_20ms.py
+            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in1024x1024_30_out1024_50ms.py
             test_type: 'perf'
           - name: test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-16

--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -533,6 +533,154 @@ jobs:
             runner: linux-aarch64-a3-2
             test_case: test/registered/ascend/accuracy/test_npu_qwen3_5_27b_1p_gpqa.py
             test_type: 'accuracy'
+          - name: test_ascend_qwen3_8b_w8a8_19_in3k5_out1k5_50ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3-8b/test_ascend_qwen3_8b_w8a8_19_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_8b_w8a8_1p_in1k_out300_bs16
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3-8b/test_ascend_qwen3_8b_w8a8_1p_in1k_out300_bs16.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_8b_w8a8_1p_in3k5_out1k5_5ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3-8b/test_ascend_qwen3_8b_w8a8_1p_in3k5_out1k5_5ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_8b_w8a8_1p_in6k_out1k5_bs16
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3-8b/test_ascend_qwen3_8b_w8a8_1p_in6k_out1k5_bs16.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_14b_bf16_1p_in1k_out100_e2e_10s
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_14b/test_ascend_qwen3_14b_bf16_1p_in1k_out100_e2e_10s.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_14b_w8a8_1p_in1k_out300_bs16
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_14b/test_ascend_qwen3_14b_w8a8_1p_in1k_out300_bs16.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_14b_w8a8_1p_in3k5_out1k5_10ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_14b/test_ascend_qwen3_14b_w8a8_1p_in3k5_out1k5_10ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_14b_w8a8_1p_in3k5_out1k5_50ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_14b/test_ascend_qwen3_14b_w8a8_1p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_14b_w8a8_1p_in6k_out1k5_bs16
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_14b/test_ascend_qwen3_14b_w8a8_1p_in6k_out1k5_bs16.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_30b_bf16_1p_in1k_out100
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_30b_a3b/test_ascend_qwen3_30b_bf16_1p_in1k_out100.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_30b_w8a8_1p_in1k_out300_bs16
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_30b_a3b/test_ascend_qwen3_30b_w8a8_1p_in1k_out300_bs16.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_30b_w8a8_1p_in3k5_out1k5_10ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_30b_a3b/test_ascend_qwen3_30b_w8a8_1p_in3k5_out1k5_10ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_30b_w8a8_1p_in3k5_out1k5_50ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_30b_a3b/test_ascend_qwen3_30b_w8a8_1p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_30b_w8a8_1p_in6k_out1k5_bs16
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_30b_a3b/test_ascend_qwen3_30b_w8a8_1p_in6k_out1k5_bs16.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_32b_w8a8_1p_in2k_out2k_50ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_32b/test_ascend_qwen3_32b_w8a8_1p_in2k_out2k_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_next_80b_w8a8_1p_in3k5_out1k5_20ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/qwen3_next_80b_a3b_instruct/test_ascend_qwen3_next_80b_w8a8_1p_in3k5_out1k5_20ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_32b_w8a8_2p_in1k_out300_bs16
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/qwen3_32b/test_ascend_qwen3_32b_w8a8_2p_in1k_out300_bs16.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_32b_w8a8_2p_in3k5_out1k5_50ms
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/qwen3_32b/test_ascend_qwen3_32b_w8a8_2p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_32b_w8a8_2p_in6k_out1k5_bs16
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/qwen3_32b/test_ascend_qwen3_32b_w8a8_2p_in6k_out1k5_bs16.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_coder_next_w8a8_2p_in16k_out1k_20ms
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/qwen3_coder_next/test_ascend_qwen3_coder_next_w8a8_2p_in16k_out1k_20ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_coder_next_w8a8_2p_in16k_out1k_50ms
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/qwen3_coder_next/test_ascend_qwen3_coder_next_w8a8_2p_in16k_out1k_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_coder_next_w8a8_2p_in3k5_out1k5_20ms
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/qwen3_coder_next/test_ascend_qwen3_coder_next_w8a8_2p_in3k5_out1k5_20ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_coder_next_w8a8_2p_in3k5_out1k5_50ms
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/qwen3_coder_next/test_ascend_qwen3_coder_next_w8a8_2p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_next_80b_w8a8_2p_in1k_out300_bs16
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/qwen3_next_80b_a3b_instruct/test_ascend_qwen3_next_80b_w8a8_2p_in1k_out300_bs16.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_next_80b_w8a8_2p_in3k5_out1k5_50ms
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/qwen3_next_80b_a3b_instruct/test_ascend_qwen3_next_80b_w8a8_2p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/ascend/performance/qwen3_next_80b_a3b_instruct/test_ascend_qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_32b_bf16_4p_in4k_out1k5_11ms
+            runner: linux-aarch64-a3-8
+            test_case: test/registered/ascend/performance/qwen3_32b/test_ascend_qwen3_32b_bf16_4p_in4k_out1k5_11ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_32b_bf16_4p_in6k_out1k5_17_9ms
+            runner: linux-aarch64-a3-8
+            test_case: test/registered/ascend/performance/qwen3_32b/test_ascend_qwen3_32b_bf16_4p_in6k_out1k5_17_9ms.py
+            test_type: 'perf'
+          - name: test_ascend_deepseek_r1_w4a8_8p_in2k_out2k_50ms
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w4a8_8p_in2k_out2k_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_deepseek_r1_w4a8_8p_in3k5_out1k5_50ms
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w4a8_8p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_235b_bf16_8p_in11k_out1k5_8ms
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/ascend/performance/qwen3_235b_a22b/test_ascend_qwen3_235b_bf16_8p_in11k_out1k5_8ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_235b_bf16_8p_in11k_out1k_10ms
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/ascend/performance/qwen3_235b_a22b/test_ascend_qwen3_235b_bf16_8p_in11k_out1k_10ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_235b_w8a8_8p_in2k_out2k_50ms
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/ascend/performance/qwen3_235b_a22b/test_ascend_qwen3_235b_w8a8_8p_in2k_out2k_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_235b_w8a8_8p_in3k5_out1k5_50ms
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/ascend/performance/qwen3_235b_a22b/test_ascend_qwen3_235b_w8a8_8p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_32b_bf16_8p_in18k_out4k_6ms
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/ascend/performance/qwen3_32b/test_ascend_qwen3_32b_bf16_8p_in18k_out4k_6ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_480b_w8a8_8p_in3k5_out1k5_20ms
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/ascend/performance/qwen3_coder_480b_a35b_instruct/test_ascend_qwen3_480b_w8a8_8p_in3k5_out1k5_20ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_480b_w8a8_8p_in3k5_out1k5_50ms
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/ascend/performance/qwen3_coder_480b_a35b_instruct/test_ascend_qwen3_480b_w8a8_8p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
     uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
     with:
       runner: ${{ matrix.test_config.runner }}

--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -700,6 +700,15 @@ jobs:
       max-parallel: 1
       matrix:
         test_config:
+          # ===== PR 547 Qwen3 16p cross-node TP (node_size=2) =====
+          - name: test_ascend_qwen3_235b_w8a8_16p_in2k_out2k_50ms
+            node_size: 2
+            test_case: test/registered/ascend/performance/qwen3_235b_a22b/test_ascend_qwen3_235b_w8a8_16p_in2k_out2k_50ms.py
+            test_type: 'perf'
+          - name: test_ascend_qwen3_480b_w8a8_16p_in3k5_out1k5_50ms
+            node_size: 2
+            test_case: test/registered/ascend/performance/qwen3_coder_480b_a35b_instruct/test_ascend_qwen3_480b_w8a8_16p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
           # ===== PR 547 DeepSeek R1 W4A8 1p1d_16p PD separation =====
           - name: test_ascend_deepseek_r1_w4a8_1p1d_16p_in2k_out2k_50ms
             prefill_size: 1

--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -700,6 +700,118 @@ jobs:
       max-parallel: 1
       matrix:
         test_config:
+          # ===== PR 547 DeepSeek R1 W4A8 1p1d_16p PD separation =====
+          - name: test_ascend_deepseek_r1_w4a8_1p1d_16p_in2k_out2k_50ms
+            prefill_size: 1
+            decode_size: 1
+            router_size: 1
+            test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w4a8_1p1d_16p_in2k_out2k_50ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          - name: test_ascend_deepseek_r1_w4a8_1p1d_16p_in3k5_out1k5_50ms
+            prefill_size: 1
+            decode_size: 1
+            router_size: 1
+            test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w4a8_1p1d_16p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          # ===== PR 547 DeepSeek R1 W8A8 1p1d_24p PD separation =====
+          - name: test_ascend_deepseek_r1_w8a8_1p1d_24p_in2k_out2k_50ms
+            prefill_size: 1
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w8a8_1p1d_24p_in2k_out2k_50ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          # ===== PR 547 DeepSeek R1 W8A8 2p1d_32p PD separation =====
+          - name: test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k5_16ms
+            prefill_size: 1
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k5_16ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          - name: test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k5_50ms
+            prefill_size: 1
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          - name: test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k_20ms
+            prefill_size: 1
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k_20ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          - name: test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k9_out1k_20ms
+            prefill_size: 1
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k9_out1k_20ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          - name: test_ascend_deepseek_r1_w8a8_2p1d_32p_in6k_out1k6_15ms
+            prefill_size: 1
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w8a8_2p1d_32p_in6k_out1k6_15ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          # ===== PR 547 DeepSeek V3.2 W8A8 1p1d_32p PD separation =====
+          - name: test_ascend_deepseek_v3_2_w8a8_1p1d_32p_in128k_out1k_26ms
+            prefill_size: 2
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/deepseek_v3_2/test_ascend_deepseek_v3_2_w8a8_1p1d_32p_in128k_out1k_26ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          - name: test_ascend_deepseek_v3_2_w8a8_1p1d_32p_in128k_out1k_bs16
+            prefill_size: 2
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/deepseek_v3_2/test_ascend_deepseek_v3_2_w8a8_1p1d_32p_in128k_out1k_bs16.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          - name: test_ascend_deepseek_v3_2_w8a8_1p1d_32p_in128k_out1k_bs8
+            prefill_size: 2
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/deepseek_v3_2/test_ascend_deepseek_v3_2_w8a8_1p1d_32p_in128k_out1k_bs8.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          # ===== PR 547 Qwen3-235B W8A8 1p1d_16p PD separation =====
+          - name: test_ascend_qwen3_235b_w8a8_1p1d_16p_in256k_out1k
+            prefill_size: 1
+            decode_size: 1
+            router_size: 1
+            test_case: test/registered/ascend/performance/qwen3_235b_a22b/test_ascend_qwen3_235b_w8a8_1p1d_16p_in256k_out1k.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          # ===== PR 547 Qwen3-235B W8A8 1p1d_24p PD separation =====
+          - name: test_ascend_qwen3_235b_w8a8_1p1d_24p_in3k5_out1k5_50ms
+            prefill_size: 1
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/qwen3_235b_a22b/test_ascend_qwen3_235b_w8a8_1p1d_24p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          # ===== PR 547 Qwen3-480B W8A8 1p1d_24p PD separation =====
+          - name: test_ascend_qwen3_480b_w8a8_1p1d_24p_in2k_out2k_50ms
+            prefill_size: 1
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/qwen3_coder_480b_a35b_instruct/test_ascend_qwen3_480b_w8a8_1p1d_24p_in2k_out2k_50ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
+          - name: test_ascend_qwen3_480b_w8a8_1p1d_24p_in3k5_out1k5_50ms
+            prefill_size: 1
+            decode_size: 2
+            router_size: 1
+            test_case: test/registered/ascend/performance/qwen3_coder_480b_a35b_instruct/test_ascend_qwen3_480b_w8a8_1p1d_24p_in3k5_out1k5_50ms.py
+            test_type: 'perf'
+            prefill_decode_deployment: 'separation'
           #- name: test_ascend_qwen3_235b_w8a8_1p1d_24p_accuracy
             #prefill_size: 1
             #decode_size: 2

--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -725,35 +725,35 @@ jobs:
             prefill_decode_deployment: 'separation'
           # ===== PR 547 DeepSeek R1 W8A8 2p1d_32p PD separation =====
           - name: test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k5_16ms
-            prefill_size: 1
+            prefill_size: 2
             decode_size: 2
             router_size: 1
             test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k5_16ms.py
             test_type: 'perf'
             prefill_decode_deployment: 'separation'
           - name: test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k5_50ms
-            prefill_size: 1
+            prefill_size: 2
             decode_size: 2
             router_size: 1
             test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k5_50ms.py
             test_type: 'perf'
             prefill_decode_deployment: 'separation'
           - name: test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k_20ms
-            prefill_size: 1
+            prefill_size: 2
             decode_size: 2
             router_size: 1
             test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k5_out1k_20ms.py
             test_type: 'perf'
             prefill_decode_deployment: 'separation'
           - name: test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k9_out1k_20ms
-            prefill_size: 1
+            prefill_size: 2
             decode_size: 2
             router_size: 1
             test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w8a8_2p1d_32p_in3k9_out1k_20ms.py
             test_type: 'perf'
             prefill_decode_deployment: 'separation'
           - name: test_ascend_deepseek_r1_w8a8_2p1d_32p_in6k_out1k6_15ms
-            prefill_size: 1
+            prefill_size: 2
             decode_size: 2
             router_size: 1
             test_case: test/registered/ascend/performance/deepseek_r1/test_ascend_deepseek_r1_w8a8_2p1d_32p_in6k_out1k6_15ms.py

--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -493,6 +493,10 @@ jobs:
             runner: linux-aarch64-a3-2
             test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in64k_out1k_20ms.py
             test_type: 'perf'
+          - name: test_npu_qwen3_5_27b_w8a8_1p_in64k_90prefix_20ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in64k_90prefix_20ms.py
+            test_type: 'perf'
           - name: test_npu_qwen3_5_27b_w8a8_1p_in1024x1024_30_out1024_50ms
             runner: linux-aarch64-a3-2
             test_case: test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in1024x1024_30_out1024_50ms.py

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -86,6 +86,11 @@ QWEN3_5_27B_W8A8_MODEL_PATH = (
 QWEN3_30B_A3B_MODEL_PATH = (
     "/root/.cache/modelscope/hub/models/Qwen/Qwen3-30B-A3B-Instruct-2507"
 )
+QWEN3_6_35B_A3B_MODEL_PATH = "/root/.cache/modelscope/hub/models/Qwen/Qwen3.6-35B-A3B"
+QWEN3_6_27B_MODEL_PATH = "/root/.cache/modelscope/hub/models/Qwen/Qwen3.6-27B"
+QWEN3_6_27B_W8A8_MODEL_PATH = (
+    "/root/.cache/modelscope/hub/models/Eco-Tech/Qwen3.6-27B-w8a8"
+)
 QWEN3_30B_A3B_W8A8_MODEL_PATH = (
     "/root/.cache/modelscope/hub/models/Qwen/Qwen3-30B-A3B-w8a8"
 )
@@ -106,9 +111,6 @@ QWEN3_235B_W8A8_MODEL_PATH = (
 )
 QWEN3_235B_A22B_EAGLE_MODEL_PATH = (
     "/root/.cache/modelscope/hub/models/Qwen/Qwen3-235B-A22B-Eagle3"
-)
-QWEN3_235B_A22B_INSTRUCT_2507_W8A8_MODEL_PATH = (
-    "/root/.cache/modelscope/hub/models/zcgy26/Qwen3-235B-A22B-Instruct-2507-w8a8"
 )
 QWEN3_480B_W8A8_MODEL_PATH = (
     "/root/.cache/modelscope/hub/models/Qwen3-Coder-480B-A35B-Instruct-w8a8-QuaRot"

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -112,6 +112,9 @@ QWEN3_235B_W8A8_MODEL_PATH = (
 QWEN3_235B_A22B_EAGLE_MODEL_PATH = (
     "/root/.cache/modelscope/hub/models/Qwen/Qwen3-235B-A22B-Eagle3"
 )
+QWEN3_235B_A22B_INSTRUCT_2507_W8A8_MODEL_PATH = (
+    "/root/.cache/modelscope/hub/models/zcgy26/Qwen3-235B-A22B-Instruct-2507-w8a8"
+)
 QWEN3_480B_W8A8_MODEL_PATH = (
     "/root/.cache/modelscope/hub/models/Qwen3-Coder-480B-A35B-Instruct-w8a8-QuaRot"
 )

--- a/test/registered/ascend/accuracy/test_npu_minimax_m2_5_w8a8_8p_aime2025.py
+++ b/test/registered/ascend/accuracy/test_npu_minimax_m2_5_w8a8_8p_aime2025.py
@@ -91,7 +91,7 @@ class TestNPUMiniMaxM2_5_W8A8_8P_AIME2025(TestAscendAccuracyTestCaseBase):
     model = MINIMAX_M2_5_W8A8_MODEL_PATH
     other_args = MINIMAX_M2_5_HIGH_THROUGHPUT_OTHER_ARGS
     envs = MINIMAX_M2_5_HIGH_THROUGHPUT_ENVS
-    accuracy = 80
+    accuracy = 86.3
     dataset_type = "aime2025"
     dataset_name = "aime2025_gen"
     max_concurrency = 64

--- a/test/registered/ascend/accuracy/test_npu_minimax_m2_5_w8a8_8p_gpqa.py
+++ b/test/registered/ascend/accuracy/test_npu_minimax_m2_5_w8a8_8p_gpqa.py
@@ -91,7 +91,7 @@ class TestNPUMiniMaxM2_5_W8A8_8P_GPQA(TestAscendAccuracyTestCaseBase):
     model = MINIMAX_M2_5_W8A8_MODEL_PATH
     other_args = MINIMAX_M2_5_HIGH_THROUGHPUT_OTHER_ARGS
     envs = MINIMAX_M2_5_HIGH_THROUGHPUT_ENVS
-    accuracy = 80
+    accuracy = 85.2
     dataset_type = "gpqa"
     dataset_name = "gpqa_gen_0_shot_cot_chat_prompt"
     max_concurrency = 64

--- a/test/registered/ascend/accuracy/test_npu_qwen3_5_27b_1p_gpqa.py
+++ b/test/registered/ascend/accuracy/test_npu_qwen3_5_27b_1p_gpqa.py
@@ -87,12 +87,12 @@ class TestNPUQwen3_5_27B_1P_GPQA(TestAscendAccuracyTestCaseBase):
     model = QWEN3_5_27B_W8A8_MODEL_PATH
     other_args = QWEN3_5_27B_3K5_1K5_HIGH_OTHER_ARGS
     envs = QWEN3_5_27B_3K5_1K5_HIGH_ENVS
-    accuracy = 0.3
+    accuracy = 85.5
     dataset_type = "gpqa"
     dataset_name = "gpqa_gen_0_shot_cot_chat_prompt"
-    output_len = 1500
-    max_concurrency = 1
-    num_prompts = 100000
+    output_len = 65536
+    max_concurrency = 64
+    generation_kwargs = "dict(temperature=1.0)"
 
     def test_npu_qwen3_5_27b_1p_gpqa(self):
         """Run NPU accuracy test for Qwen3.5-27B-W8A8 on GPQA"""

--- a/test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in1080p_30_out256_50ms.py
+++ b/test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in1080p_30_out256_50ms.py
@@ -44,9 +44,9 @@ KIMI_K2_5_IN1080P_30_OUT256_OTHER_ARGS = [
     "--tp-size",
     16,
     "--mem-fraction-static",
-    0.765,
+    0.7,
     "--max-running-requests",
-    160,
+    80,
     "--chunked-prefill-size",
     -1,
     "--context-length",
@@ -78,11 +78,11 @@ KIMI_K2_5_IN1080P_30_OUT256_OTHER_ARGS = [
     "--speculative-draft-model-path",
     KIMI_K2_5_EAGLE3_MODEL_PATH,
     "--speculative-num-steps",
-    2,
+    4,
     "--speculative-eagle-topk",
     1,
     "--speculative-num-draft-tokens",
-    3,
+    5,
     "--speculative-draft-model-quantization",
     "unquant",
 ]
@@ -100,8 +100,8 @@ class TestNPUKimiK2_5_W4A8_8P_IN1080P_30_OUT256_50ms(TestAscendPerformanceTestCa
     dataset_name = "image"
     image_resolution = "1920x1080"
     image_count = 1
-    max_concurrency = 64
-    num_prompts = 64
+    max_concurrency = 20
+    num_prompts = 20
     request_rate = 1
     input_len = 30
     output_len = 256

--- a/test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_50ms.py
+++ b/test/registered/ascend/performance/test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_50ms.py
@@ -45,9 +45,9 @@ KIMI_K2_5_OTHER_ARGS = [
     "--tp-size",
     16,
     "--mem-fraction-static",
-    0.78,
+    0.7,
     "--max-running-requests",
-    360,
+    120,
     "--chunked-prefill-size",
     32768,
     "--context-length",
@@ -71,8 +71,14 @@ KIMI_K2_5_OTHER_ARGS = [
     2,
     4,
     8,
-    9,
-    10,
+    12,
+    16,
+    24,
+    32,
+    48,
+    64,
+    96,
+    120,
     "--disable-radix-cache",
     "--model-loader-extra-config",
     '{"enable_multithread_load": true}',
@@ -99,8 +105,8 @@ class TestKimiK25W4A8(TestAscendPerformanceTestCaseBase):
     envs = KIMI_K2_5_ENVS
     backend = "sglang"
     dataset_name = "random"
-    max_concurrency = 360
-    num_prompts = 360
+    max_concurrency = 120
+    num_prompts = 120
     input_len = 3500
     output_len = 1500
     random_range_ratio = 1

--- a/test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_8p_in32k_out1k_50ms.py
+++ b/test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_8p_in32k_out1k_50ms.py
@@ -49,7 +49,7 @@ MINIMAX_M2_5_32K_OTHER_ARGS = [
     200,
     "--enable-prefill-delayer",
     "--max-running-requests",
-    96,
+    48,
     "--chunked-prefill-size",
     -1,
     "--max-prefill-tokens",
@@ -88,8 +88,8 @@ class TestNPUMiniMaxM2_5_W8A8_8P_In32k_Out1k_HighThroughput(
     other_args = MINIMAX_M2_5_32K_OTHER_ARGS
     envs = MINIMAX_M2_5_32K_ENVS
     dataset_name = "random"
-    max_concurrency = 36
-    num_prompts = 144
+    max_concurrency = 24
+    num_prompts = 96
     input_len = 32768
     output_len = 1024
     random_range_ratio = 1

--- a/test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_20ms.py
+++ b/test/registered/ascend/performance/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_20ms.py
@@ -45,7 +45,7 @@ MINIMAX_M2_5_LOW_LATENCY_OTHER_ARGS = [
     "--mem-fraction-static",
     0.75,
     "--max-running-requests",
-    128,
+    256,
     "--disable-radix-cache",
     "--chunked-prefill-size",
     -1,
@@ -54,8 +54,11 @@ MINIMAX_M2_5_LOW_LATENCY_OTHER_ARGS = [
     "--cuda-graph-bs",
     2,
     4,
-    6,
     8,
+    16,
+    32,
+    64,
+    128,
     "--moe-a2a-backend",
     "ascend_fuseep",
     "--deepep-mode",
@@ -79,7 +82,7 @@ MINIMAX_M2_5_LOW_LATENCY_OTHER_ARGS = [
     "--tokenizer-worker-num",
     2,
     "--prefill-delayer-max-delay-passes",
-    500,
+    10,
     "--enable-prefill-delayer",
 ]
 
@@ -95,8 +98,8 @@ class TestNPUMiniMaxM2_5_W8A8_8P_In3k5_Out1k5_LowLatency(
     other_args = MINIMAX_M2_5_LOW_LATENCY_OTHER_ARGS
     envs = MINIMAX_M2_5_LOW_LATENCY_ENVS
     dataset_name = "random"
-    max_concurrency = 80
-    num_prompts = 80
+    max_concurrency = 64
+    num_prompts = 256
     input_len = 3500
     output_len = 1500
     random_range_ratio = 1

--- a/test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in1024x1024_30_out1024_50ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in1024x1024_30_out1024_50ms.py
@@ -15,7 +15,7 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_MM_1024_1024_HIGH_ENVS = {
+QWEN3_5_27B_W8A8_IN1024X1024_30_OUT1024_50MS_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
@@ -29,7 +29,7 @@ QWEN3_5_27B_MM_1024_1024_HIGH_ENVS = {
     "ASCEND_USE_FIA": "1",
 }
 
-QWEN3_5_27B_MM_1024_1024_HIGH_OTHER_ARGS = [
+QWEN3_5_27B_W8A8_IN1024X1024_30_OUT1024_50MS_OTHER_ARGS = [
     "--model-path",
     QWEN3_5_27B_W8A8_MODEL_PATH,
     "--tp-size",
@@ -84,14 +84,14 @@ QWEN3_5_27B_MM_1024_1024_HIGH_OTHER_ARGS = [
 ]
 
 
-class TestNPUQwen3_5_27B_1P_MM_In1k_Out1k_High(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p multimodal in1k out1k"""
+class TestNPUQwen3_5_27B_W8A8_1P_In1024x1024_30_Out1024_50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for Qwen3.5-27B-W8A8 1p in1024x1024 30 out1024 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
     aisbench_dataset_type = AISBENCHMARK_DATASET_MM_CUSTOM_GEN
     model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_MM_1024_1024_HIGH_OTHER_ARGS
-    envs = QWEN3_5_27B_MM_1024_1024_HIGH_ENVS
+    other_args = QWEN3_5_27B_W8A8_IN1024X1024_30_OUT1024_50MS_OTHER_ARGS
+    envs = QWEN3_5_27B_W8A8_IN1024X1024_30_OUT1024_50MS_ENVS
     dataset_name = "image"
     image_resolution = "1024x1024"
     image_count = 1
@@ -103,8 +103,8 @@ class TestNPUQwen3_5_27B_1P_MM_In1k_Out1k_High(TestAscendPerformanceTestCaseBase
     tpot = 50
     output_token_throughput = 30
 
-    def test_npu_qwen3_5_27b_1p_mm_in1k_out1k_high(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 multimodal in1k out1k"""
+    def test_npu_qwen3_5_27b_w8a8_1p_in1024x1024_30_out1024_50ms(self):
+        """Run NPU performance test for Qwen3.5-27B-W8A8 1p in1024x1024 30 out1024 50ms"""
         self.run_throughput()
 
 

--- a/test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in1024x1024_30_out1024_50ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in1024x1024_30_out1024_50ms.py
@@ -84,7 +84,9 @@ QWEN3_5_27B_W8A8_IN1024X1024_30_OUT1024_50MS_OTHER_ARGS = [
 ]
 
 
-class TestNPUQwen3_5_27B_W8A8_1P_In1024x1024_30_Out1024_50ms(TestAscendPerformanceTestCaseBase):
+class TestNPUQwen3_5_27B_W8A8_1P_In1024x1024_30_Out1024_50ms(
+    TestAscendPerformanceTestCaseBase
+):
     """Test NPU performance for Qwen3.5-27B-W8A8 1p in1024x1024 30 out1024 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT

--- a/test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in64k_out1k_20ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_5_27b_w8a8_1p_in64k_out1k_20ms.py
@@ -47,15 +47,14 @@ QWEN3_5_27B_64K_1K_LOW_OTHER_ARGS = [
     "--disable-radix-cache",
     "--trust-remote-code",
     "--max-running-requests",
-    4,
+    1,
     "--max-mamba-cache-size",
-    18,
+    10,
     "--mem-fraction-static",
     0.5,
     "--cuda-graph-bs",
+    1,
     2,
-    3,
-    4,
     "--enable-multimodal",
     "--quantization",
     "modelslim",
@@ -87,8 +86,8 @@ class TestNPUQwen3_5_27B_1P_In64k_Out1k_Low(TestAscendPerformanceTestCaseBase):
     other_args = QWEN3_5_27B_64K_1K_LOW_OTHER_ARGS
     envs = QWEN3_5_27B_64K_1K_LOW_ENVS
     dataset_name = "random"
-    max_concurrency = 4
-    num_prompts = 16
+    max_concurrency = 1
+    num_prompts = 4
     input_len = 65536
     output_len = 1024
     random_range_ratio = 1

--- a/test/registered/ascend/performance/test_npu_qwen3_6_27b_1p_in1024x1024_30_out1024_50ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_6_27b_1p_in1024x1024_30_out1024_50ms.py
@@ -1,9 +1,9 @@
 import unittest
 
 from sglang.test.ascend.e2e.test_npu_performance_utils import (
-    AISBENCHMARK_DATASET_DEFAULT,
+    AISBENCHMARK_DATASET_MM_CUSTOM_GEN,
     BENCHMARK_TOOL_DEFAULT,
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+    QWEN3_6_27B_MODEL_PATH,
     TestAscendPerformanceTestCaseBase,
 )
 from sglang.test.ci.ci_register import register_npu_ci
@@ -15,29 +15,27 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_16K_1K_LOW_ENVS = {
+QWEN3_6_27B_1024_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
     "GLOO_SOCKET_IFNAME": "lo",
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "SGLANG_SET_CPU_AFFINITY": "1",
+    "SGLANG_VIT_ENABLE_CUDA_GRAPH": "1",
     "SGLANG_ENABLE_SPEC_V2": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
-    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
-    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "100",
     "SGLANG_NPU_PROFILING": "1",
+    "SGLANG_NPU_PROFILING_STAGE": "prefill",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "150",
 }
 
-QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
-    "--model-path",
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+QWEN3_6_27B_1024_OTHER_ARGS = [
     "--tp-size",
     2,
     "--nnodes",
     1,
-    "--node-rank",
-    0,
     "--attention-backend",
     "ascend",
     "--device",
@@ -45,31 +43,33 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "--chunked-prefill-size",
     -1,
     "--max-prefill-tokens",
-    65000,
+    52000,
     "--disable-radix-cache",
     "--trust-remote-code",
     "--max-running-requests",
-    8,
+    50,
     "--max-mamba-cache-size",
-    20,
+    60,
     "--mem-fraction-static",
-    0.85,
+    0.76,
     "--cuda-graph-bs",
-    1,
     2,
-    3,
     4,
+    8,
+    16,
+    24,
+    32,
+    40,
+    42,
+    45,
+    50,
     "--enable-multimodal",
-    "--quantization",
-    "modelslim",
     "--mm-attention-backend",
     "ascend_attn",
     "--dtype",
     "bfloat16",
     "--mamba-ssm-dtype",
     "bfloat16",
-    "--max-total-tokens",
-    310000,
     "--speculative-algorithm",
     "NEXTN",
     "--speculative-num-steps",
@@ -78,28 +78,33 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     1,
     "--speculative-num-draft-tokens",
     4,
+    "--mm-enable-dp-encoder",
 ]
 
 
-class TestNPUQwen3_5_27B_1P_In16k_Out1k_Low(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p in16k out1k low latency"""
+class TestNPUQwen3_6_27B_1P_In1024x1024_30_Out1024_50ms(
+    TestAscendPerformanceTestCaseBase
+):
+    """Test NPU performance for Qwen3.6-27B 1p in1024x1024 30 out1024 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
-    aisbench_dataset_type = AISBENCHMARK_DATASET_DEFAULT
-    model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS
-    envs = QWEN3_5_27B_16K_1K_LOW_ENVS
+    aisbench_dataset_type = AISBENCHMARK_DATASET_MM_CUSTOM_GEN
+    model = QWEN3_6_27B_MODEL_PATH
+    other_args = QWEN3_6_27B_1024_OTHER_ARGS
+    envs = QWEN3_6_27B_1024_ENVS
     dataset_name = "random"
-    max_concurrency = 4
-    num_prompts = 16
-    input_len = 16384
+    max_concurrency = 48
+    num_prompts = 48
+    input_len = 30
     output_len = 1024
     random_range_ratio = 1
-    tpot = 20
-    output_token_throughput = 167
+    image_resolution = "1024x1024"
+    image_count = 1
+    tpot = 50
+    output_token_throughput = 800.8
 
-    def test_npu_qwen3_5_27b_1p_in16k_out1k_low(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 in16k out1k low latency"""
+    def test_npu_qwen3_6_27b_1p_in1024x1024_30_out1024_50ms(self):
+        """Run NPU performance test for Qwen3.6-27B in1024x1024 30 out1024 50ms"""
         self.run_throughput()
 
 

--- a/test/registered/ascend/performance/test_npu_qwen3_6_27b_1p_in1080p_30_out256_50ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_6_27b_1p_in1080p_30_out256_50ms.py
@@ -1,9 +1,9 @@
 import unittest
 
 from sglang.test.ascend.e2e.test_npu_performance_utils import (
-    AISBENCHMARK_DATASET_DEFAULT,
+    AISBENCHMARK_DATASET_MM_CUSTOM_GEN,
     BENCHMARK_TOOL_DEFAULT,
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+    QWEN3_6_27B_MODEL_PATH,
     TestAscendPerformanceTestCaseBase,
 )
 from sglang.test.ci.ci_register import register_npu_ci
@@ -15,29 +15,27 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_16K_1K_LOW_ENVS = {
+QWEN3_6_27B_1080P_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
     "GLOO_SOCKET_IFNAME": "lo",
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "SGLANG_SET_CPU_AFFINITY": "1",
+    "SGLANG_VIT_ENABLE_CUDA_GRAPH": "1",
     "SGLANG_ENABLE_SPEC_V2": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
-    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
-    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "100",
     "SGLANG_NPU_PROFILING": "1",
+    "SGLANG_NPU_PROFILING_STAGE": "prefill",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "150",
 }
 
-QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
-    "--model-path",
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+QWEN3_6_27B_1080P_OTHER_ARGS = [
     "--tp-size",
     2,
     "--nnodes",
     1,
-    "--node-rank",
-    0,
     "--attention-backend",
     "ascend",
     "--device",
@@ -45,31 +43,30 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "--chunked-prefill-size",
     -1,
     "--max-prefill-tokens",
-    65000,
+    48000,
     "--disable-radix-cache",
     "--trust-remote-code",
     "--max-running-requests",
-    8,
+    30,
     "--max-mamba-cache-size",
-    20,
+    40,
     "--mem-fraction-static",
-    0.85,
+    0.76,
     "--cuda-graph-bs",
-    1,
     2,
-    3,
     4,
+    8,
+    16,
+    24,
+    28,
+    30,
     "--enable-multimodal",
-    "--quantization",
-    "modelslim",
     "--mm-attention-backend",
     "ascend_attn",
     "--dtype",
     "bfloat16",
     "--mamba-ssm-dtype",
     "bfloat16",
-    "--max-total-tokens",
-    310000,
     "--speculative-algorithm",
     "NEXTN",
     "--speculative-num-steps",
@@ -78,28 +75,31 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     1,
     "--speculative-num-draft-tokens",
     4,
+    "--mm-enable-dp-encoder",
 ]
 
 
-class TestNPUQwen3_5_27B_1P_In16k_Out1k_Low(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p in16k out1k low latency"""
+class TestNPUQwen3_6_27B_1P_In1080p_30_Out256_50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for Qwen3.6-27B 1p in1080p 30 out256 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
-    aisbench_dataset_type = AISBENCHMARK_DATASET_DEFAULT
-    model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS
-    envs = QWEN3_5_27B_16K_1K_LOW_ENVS
+    aisbench_dataset_type = AISBENCHMARK_DATASET_MM_CUSTOM_GEN
+    model = QWEN3_6_27B_MODEL_PATH
+    other_args = QWEN3_6_27B_1080P_OTHER_ARGS
+    envs = QWEN3_6_27B_1080P_ENVS
     dataset_name = "random"
-    max_concurrency = 4
-    num_prompts = 16
-    input_len = 16384
-    output_len = 1024
+    max_concurrency = 30
+    num_prompts = 120
+    input_len = 30
+    output_len = 256
     random_range_ratio = 1
-    tpot = 20
-    output_token_throughput = 167
+    image_resolution = "1920x1080"
+    image_count = 1
+    tpot = 50
+    output_token_throughput = 226
 
-    def test_npu_qwen3_5_27b_1p_in16k_out1k_low(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 in16k out1k low latency"""
+    def test_npu_qwen3_6_27b_1p_in1080p_30_out256_50ms(self):
+        """Run NPU performance test for Qwen3.6-27B in1080p 30 out256 50ms"""
         self.run_throughput()
 
 

--- a/test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms.py
@@ -3,7 +3,7 @@ import unittest
 from sglang.test.ascend.e2e.test_npu_performance_utils import (
     AISBENCHMARK_DATASET_DEFAULT,
     BENCHMARK_TOOL_DEFAULT,
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+    QWEN3_6_27B_W8A8_MODEL_PATH,
     TestAscendPerformanceTestCaseBase,
 )
 from sglang.test.ci.ci_register import register_npu_ci
@@ -15,7 +15,7 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_16K_1K_LOW_ENVS = {
+QWEN3_6_27B_3K5_1K5_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
@@ -25,19 +25,14 @@ QWEN3_5_27B_16K_1K_LOW_ENVS = {
     "SGLANG_ENABLE_SPEC_V2": "1",
     "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
     "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
-    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "100",
-    "SGLANG_NPU_PROFILING": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "130",
 }
 
-QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
-    "--model-path",
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+QWEN3_6_27B_3K5_1K5_OTHER_ARGS = [
     "--tp-size",
     2,
     "--nnodes",
     1,
-    "--node-rank",
-    0,
     "--attention-backend",
     "ascend",
     "--device",
@@ -45,20 +40,22 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "--chunked-prefill-size",
     -1,
     "--max-prefill-tokens",
-    65000,
+    60000,
     "--disable-radix-cache",
     "--trust-remote-code",
     "--max-running-requests",
-    8,
+    64,
     "--max-mamba-cache-size",
-    20,
+    74,
     "--mem-fraction-static",
-    0.85,
+    0.7,
     "--cuda-graph-bs",
-    1,
     2,
-    3,
-    4,
+    8,
+    16,
+    32,
+    48,
+    64,
     "--enable-multimodal",
     "--quantization",
     "modelslim",
@@ -68,8 +65,6 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "bfloat16",
     "--mamba-ssm-dtype",
     "bfloat16",
-    "--max-total-tokens",
-    310000,
     "--speculative-algorithm",
     "NEXTN",
     "--speculative-num-steps",
@@ -81,25 +76,25 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
 ]
 
 
-class TestNPUQwen3_5_27B_1P_In16k_Out1k_Low(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p in16k out1k low latency"""
+class TestNPUQwen3_6_27B_1P_In3k5_Out1k5_50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for Qwen3.6-27B-w8a8 1p in3k5 out1k5 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
     aisbench_dataset_type = AISBENCHMARK_DATASET_DEFAULT
-    model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS
-    envs = QWEN3_5_27B_16K_1K_LOW_ENVS
+    model = QWEN3_6_27B_W8A8_MODEL_PATH
+    other_args = QWEN3_6_27B_3K5_1K5_OTHER_ARGS
+    envs = QWEN3_6_27B_3K5_1K5_ENVS
     dataset_name = "random"
-    max_concurrency = 4
-    num_prompts = 16
-    input_len = 16384
-    output_len = 1024
+    max_concurrency = 54
+    num_prompts = 216
+    input_len = 3500
+    output_len = 1500
     random_range_ratio = 1
-    tpot = 20
-    output_token_throughput = 167
+    tpot = 50
+    output_token_throughput = 786.69
 
-    def test_npu_qwen3_5_27b_1p_in16k_out1k_low(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 in16k out1k low latency"""
+    def test_npu_qwen3_6_27b_1p_in3k5_out1k5_50ms(self):
+        """Run NPU performance test for Qwen3.6-27B-w8a8 in3k5 out1k5 50ms"""
         self.run_throughput()
 
 

--- a/test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_2p_in128k_out1k_50ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_2p_in128k_out1k_50ms.py
@@ -3,7 +3,7 @@ import unittest
 from sglang.test.ascend.e2e.test_npu_performance_utils import (
     AISBENCHMARK_DATASET_DEFAULT,
     BENCHMARK_TOOL_DEFAULT,
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+    QWEN3_6_27B_W8A8_MODEL_PATH,
     TestAscendPerformanceTestCaseBase,
 )
 from sglang.test.ci.ci_register import register_npu_ci
@@ -15,7 +15,7 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_16K_1K_LOW_ENVS = {
+QWEN3_6_27B_128K_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
@@ -23,21 +23,16 @@ QWEN3_5_27B_16K_1K_LOW_ENVS = {
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "SGLANG_SET_CPU_AFFINITY": "1",
     "SGLANG_ENABLE_SPEC_V2": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
     "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
-    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "100",
-    "SGLANG_NPU_PROFILING": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "20",
 }
 
-QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
-    "--model-path",
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+QWEN3_6_27B_128K_OTHER_ARGS = [
     "--tp-size",
-    2,
+    4,
     "--nnodes",
     1,
-    "--node-rank",
-    0,
     "--attention-backend",
     "ascend",
     "--device",
@@ -45,20 +40,21 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "--chunked-prefill-size",
     -1,
     "--max-prefill-tokens",
-    65000,
+    74000,
     "--disable-radix-cache",
     "--trust-remote-code",
     "--max-running-requests",
-    8,
+    6,
     "--max-mamba-cache-size",
-    20,
+    7,
     "--mem-fraction-static",
-    0.85,
+    0.63,
     "--cuda-graph-bs",
     1,
     2,
-    3,
     4,
+    5,
+    6,
     "--enable-multimodal",
     "--quantization",
     "modelslim",
@@ -68,38 +64,28 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "bfloat16",
     "--mamba-ssm-dtype",
     "bfloat16",
-    "--max-total-tokens",
-    310000,
-    "--speculative-algorithm",
-    "NEXTN",
-    "--speculative-num-steps",
-    3,
-    "--speculative-eagle-topk",
-    1,
-    "--speculative-num-draft-tokens",
-    4,
 ]
 
 
-class TestNPUQwen3_5_27B_1P_In16k_Out1k_Low(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p in16k out1k low latency"""
+class TestNPUQwen3_6_27B_2P_In128k_Out1k_50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for Qwen3.6-27B-w8a8 2p in128k out1k 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
     aisbench_dataset_type = AISBENCHMARK_DATASET_DEFAULT
-    model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS
-    envs = QWEN3_5_27B_16K_1K_LOW_ENVS
+    model = QWEN3_6_27B_W8A8_MODEL_PATH
+    other_args = QWEN3_6_27B_128K_OTHER_ARGS
+    envs = QWEN3_6_27B_128K_ENVS
     dataset_name = "random"
     max_concurrency = 4
     num_prompts = 16
-    input_len = 16384
-    output_len = 1024
+    input_len = 128000
+    output_len = 1000
     random_range_ratio = 1
-    tpot = 20
-    output_token_throughput = 167
+    tpot = 50
+    output_token_throughput = 41.39
 
-    def test_npu_qwen3_5_27b_1p_in16k_out1k_low(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 in16k out1k low latency"""
+    def test_npu_qwen3_6_27b_2p_in128k_out1k_50ms(self):
+        """Run NPU performance test for Qwen3.6-27B-w8a8 in128k out1k 50ms"""
         self.run_throughput()
 
 

--- a/test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_2p_in16k_out1k_50ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_2p_in16k_out1k_50ms.py
@@ -3,7 +3,7 @@ import unittest
 from sglang.test.ascend.e2e.test_npu_performance_utils import (
     AISBENCHMARK_DATASET_DEFAULT,
     BENCHMARK_TOOL_DEFAULT,
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+    QWEN3_6_27B_W8A8_MODEL_PATH,
     TestAscendPerformanceTestCaseBase,
 )
 from sglang.test.ci.ci_register import register_npu_ci
@@ -15,7 +15,7 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_16K_1K_LOW_ENVS = {
+QWEN3_6_27B_16K_1k_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
@@ -23,21 +23,16 @@ QWEN3_5_27B_16K_1K_LOW_ENVS = {
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "SGLANG_SET_CPU_AFFINITY": "1",
     "SGLANG_ENABLE_SPEC_V2": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
     "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
-    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "100",
-    "SGLANG_NPU_PROFILING": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "30",
 }
 
-QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
-    "--model-path",
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+QWEN3_6_27B_16K_1k_OTHER_ARGS = [
     "--tp-size",
-    2,
+    4,
     "--nnodes",
     1,
-    "--node-rank",
-    0,
     "--attention-backend",
     "ascend",
     "--device",
@@ -45,20 +40,23 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "--chunked-prefill-size",
     -1,
     "--max-prefill-tokens",
-    65000,
+    50000,
     "--disable-radix-cache",
     "--trust-remote-code",
     "--max-running-requests",
-    8,
+    28,
     "--max-mamba-cache-size",
-    20,
+    50,
     "--mem-fraction-static",
-    0.85,
+    0.7,
     "--cuda-graph-bs",
-    1,
     2,
-    3,
-    4,
+    8,
+    12,
+    16,
+    20,
+    24,
+    28,
     "--enable-multimodal",
     "--quantization",
     "modelslim",
@@ -68,8 +66,6 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "bfloat16",
     "--mamba-ssm-dtype",
     "bfloat16",
-    "--max-total-tokens",
-    310000,
     "--speculative-algorithm",
     "NEXTN",
     "--speculative-num-steps",
@@ -81,25 +77,25 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
 ]
 
 
-class TestNPUQwen3_5_27B_1P_In16k_Out1k_Low(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p in16k out1k low latency"""
+class TestNPUQwen3_6_27B_2P_In16k_Out1k_50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for Qwen3.6-27B-w8a8 2p in16k out1k 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
     aisbench_dataset_type = AISBENCHMARK_DATASET_DEFAULT
-    model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS
-    envs = QWEN3_5_27B_16K_1K_LOW_ENVS
+    model = QWEN3_6_27B_W8A8_MODEL_PATH
+    other_args = QWEN3_6_27B_16K_1k_OTHER_ARGS
+    envs = QWEN3_6_27B_16K_1k_ENVS
     dataset_name = "random"
-    max_concurrency = 4
-    num_prompts = 16
-    input_len = 16384
-    output_len = 1024
+    max_concurrency = 28
+    num_prompts = 112
+    input_len = 16000
+    output_len = 1000
     random_range_ratio = 1
-    tpot = 20
-    output_token_throughput = 167
+    tpot = 50
+    output_token_throughput = 426.1
 
-    def test_npu_qwen3_5_27b_1p_in16k_out1k_low(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 in16k out1k low latency"""
+    def test_npu_qwen3_6_27b_2p_in16k_out1k_50ms(self):
+        """Run NPU performance test for Qwen3.6-27B-w8a8 in16k out1k 50ms"""
         self.run_throughput()
 
 

--- a/test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_2p_in64k_out1k_50ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_6_27b_w8a8_2p_in64k_out1k_50ms.py
@@ -3,7 +3,7 @@ import unittest
 from sglang.test.ascend.e2e.test_npu_performance_utils import (
     AISBENCHMARK_DATASET_DEFAULT,
     BENCHMARK_TOOL_DEFAULT,
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+    QWEN3_6_27B_W8A8_MODEL_PATH,
     TestAscendPerformanceTestCaseBase,
 )
 from sglang.test.ci.ci_register import register_npu_ci
@@ -15,7 +15,7 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_16K_1K_LOW_ENVS = {
+QWEN3_6_27B_64K_1K_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
@@ -23,21 +23,16 @@ QWEN3_5_27B_16K_1K_LOW_ENVS = {
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "SGLANG_SET_CPU_AFFINITY": "1",
     "SGLANG_ENABLE_SPEC_V2": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
     "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
-    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "100",
-    "SGLANG_NPU_PROFILING": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "30",
 }
 
-QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
-    "--model-path",
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+QWEN3_6_27B_64K_1K_OTHER_ARGS = [
     "--tp-size",
-    2,
+    4,
     "--nnodes",
     1,
-    "--node-rank",
-    0,
     "--attention-backend",
     "ascend",
     "--device",
@@ -45,20 +40,19 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "--chunked-prefill-size",
     -1,
     "--max-prefill-tokens",
-    65000,
+    50000,
     "--disable-radix-cache",
     "--trust-remote-code",
     "--max-running-requests",
-    8,
+    28,
     "--max-mamba-cache-size",
-    20,
+    50,
     "--mem-fraction-static",
-    0.85,
+    0.7,
     "--cuda-graph-bs",
-    1,
     2,
-    3,
     4,
+    6,
     "--enable-multimodal",
     "--quantization",
     "modelslim",
@@ -68,8 +62,6 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "bfloat16",
     "--mamba-ssm-dtype",
     "bfloat16",
-    "--max-total-tokens",
-    310000,
     "--speculative-algorithm",
     "NEXTN",
     "--speculative-num-steps",
@@ -81,25 +73,25 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
 ]
 
 
-class TestNPUQwen3_5_27B_1P_In16k_Out1k_Low(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p in16k out1k low latency"""
+class TestNPUQwen3_6_27B_2P_In64k_Out1k_50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for Qwen3.6-27B-w8a8 2p in64k out1k 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
     aisbench_dataset_type = AISBENCHMARK_DATASET_DEFAULT
-    model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS
-    envs = QWEN3_5_27B_16K_1K_LOW_ENVS
+    model = QWEN3_6_27B_W8A8_MODEL_PATH
+    other_args = QWEN3_6_27B_64K_1K_OTHER_ARGS
+    envs = QWEN3_6_27B_64K_1K_ENVS
     dataset_name = "random"
-    max_concurrency = 4
-    num_prompts = 16
-    input_len = 16384
-    output_len = 1024
+    max_concurrency = 6
+    num_prompts = 24
+    input_len = 64000
+    output_len = 1000
     random_range_ratio = 1
-    tpot = 20
-    output_token_throughput = 167
+    tpot = 50
+    output_token_throughput = 110
 
-    def test_npu_qwen3_5_27b_1p_in16k_out1k_low(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 in16k out1k low latency"""
+    def test_npu_qwen3_6_27b_2p_in64k_out1k_50ms(self):
+        """Run NPU performance test for Qwen3.6-27B-w8a8 in64k out1k 50ms"""
         self.run_throughput()
 
 

--- a/test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in128k_out1k_50ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in128k_out1k_50ms.py
@@ -3,7 +3,7 @@ import unittest
 from sglang.test.ascend.e2e.test_npu_performance_utils import (
     AISBENCHMARK_DATASET_DEFAULT,
     BENCHMARK_TOOL_DEFAULT,
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+    QWEN3_6_35B_A3B_MODEL_PATH,
     TestAscendPerformanceTestCaseBase,
 )
 from sglang.test.ci.ci_register import register_npu_ci
@@ -15,7 +15,7 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_16K_1K_LOW_ENVS = {
+QWEN3_6_35B_A3B_128K_1K_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
@@ -23,21 +23,16 @@ QWEN3_5_27B_16K_1K_LOW_ENVS = {
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "SGLANG_SET_CPU_AFFINITY": "1",
     "SGLANG_ENABLE_SPEC_V2": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
-    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
-    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "100",
-    "SGLANG_NPU_PROFILING": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    "ASCEND_USE_FIA": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "20",
 }
 
-QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
-    "--model-path",
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+QWEN3_6_35B_A3B_128K_1K_OTHER_ARGS = [
     "--tp-size",
     2,
     "--nnodes",
     1,
-    "--node-rank",
-    0,
     "--attention-backend",
     "ascend",
     "--device",
@@ -45,31 +40,27 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "--chunked-prefill-size",
     -1,
     "--max-prefill-tokens",
-    65000,
+    128000,
     "--disable-radix-cache",
     "--trust-remote-code",
+    "--enable-prefill-delayer",
     "--max-running-requests",
-    8,
+    6,
     "--max-mamba-cache-size",
-    20,
+    12,
     "--mem-fraction-static",
-    0.85,
+    0.64,
     "--cuda-graph-bs",
-    1,
     2,
-    3,
     4,
+    6,
     "--enable-multimodal",
-    "--quantization",
-    "modelslim",
     "--mm-attention-backend",
     "ascend_attn",
     "--dtype",
     "bfloat16",
     "--mamba-ssm-dtype",
     "bfloat16",
-    "--max-total-tokens",
-    310000,
     "--speculative-algorithm",
     "NEXTN",
     "--speculative-num-steps",
@@ -81,25 +72,25 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
 ]
 
 
-class TestNPUQwen3_5_27B_1P_In16k_Out1k_Low(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p in16k out1k low latency"""
+class TestNPUQwen3_6_35BA3B_1P_In128k_Out1k_50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for Qwen3.6-35B-A3B 1p in128k out1k 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
     aisbench_dataset_type = AISBENCHMARK_DATASET_DEFAULT
-    model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS
-    envs = QWEN3_5_27B_16K_1K_LOW_ENVS
+    model = QWEN3_6_35B_A3B_MODEL_PATH
+    other_args = QWEN3_6_35B_A3B_128K_1K_OTHER_ARGS
+    envs = QWEN3_6_35B_A3B_128K_1K_ENVS
     dataset_name = "random"
-    max_concurrency = 4
-    num_prompts = 16
-    input_len = 16384
-    output_len = 1024
+    max_concurrency = 6
+    num_prompts = 24
+    input_len = 128000
+    output_len = 1000
     random_range_ratio = 1
-    tpot = 20
-    output_token_throughput = 167
+    tpot = 50
+    output_token_throughput = 60.57
 
-    def test_npu_qwen3_5_27b_1p_in16k_out1k_low(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 in16k out1k low latency"""
+    def test_npu_qwen3_6_35b_a3b_1p_in128k_out1k_50ms(self):
+        """Run NPU performance test for Qwen3.6-35B-A3B in128k out1k 50ms"""
         self.run_throughput()
 
 

--- a/test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in254k_out1k.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in254k_out1k.py
@@ -3,7 +3,7 @@ import unittest
 from sglang.test.ascend.e2e.test_npu_performance_utils import (
     AISBENCHMARK_DATASET_DEFAULT,
     BENCHMARK_TOOL_DEFAULT,
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+    QWEN3_6_35B_A3B_MODEL_PATH,
     TestAscendPerformanceTestCaseBase,
 )
 from sglang.test.ci.ci_register import register_npu_ci
@@ -15,7 +15,7 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_16K_1K_LOW_ENVS = {
+QWEN3_6_35B_A3B_254K_1K_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
@@ -23,53 +23,40 @@ QWEN3_5_27B_16K_1K_LOW_ENVS = {
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "SGLANG_SET_CPU_AFFINITY": "1",
     "SGLANG_ENABLE_SPEC_V2": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
-    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
-    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "100",
-    "SGLANG_NPU_PROFILING": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    "ASCEND_USE_FIA": "1",
 }
 
-QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
-    "--model-path",
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+QWEN3_6_35B_A3B_254K_1K_OTHER_ARGS = [
     "--tp-size",
     2,
     "--nnodes",
     1,
-    "--node-rank",
-    0,
     "--attention-backend",
     "ascend",
     "--device",
     "npu",
     "--chunked-prefill-size",
-    -1,
+    131072,
     "--max-prefill-tokens",
-    65000,
+    254000,
     "--disable-radix-cache",
     "--trust-remote-code",
     "--max-running-requests",
-    8,
+    1,
     "--max-mamba-cache-size",
-    20,
+    6,
     "--mem-fraction-static",
-    0.85,
+    0.65,
     "--cuda-graph-bs",
     1,
-    2,
-    3,
-    4,
     "--enable-multimodal",
-    "--quantization",
-    "modelslim",
     "--mm-attention-backend",
     "ascend_attn",
     "--dtype",
     "bfloat16",
     "--mamba-ssm-dtype",
     "bfloat16",
-    "--max-total-tokens",
-    310000,
     "--speculative-algorithm",
     "NEXTN",
     "--speculative-num-steps",
@@ -81,25 +68,25 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
 ]
 
 
-class TestNPUQwen3_5_27B_1P_In16k_Out1k_Low(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p in16k out1k low latency"""
+class TestNPUQwen3_6_35BA3B_1P_In254k_Out1k_50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for Qwen3.6-35B-A3B 1p in254k out1k 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
     aisbench_dataset_type = AISBENCHMARK_DATASET_DEFAULT
-    model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS
-    envs = QWEN3_5_27B_16K_1K_LOW_ENVS
+    model = QWEN3_6_35B_A3B_MODEL_PATH
+    other_args = QWEN3_6_35B_A3B_254K_1K_OTHER_ARGS
+    envs = QWEN3_6_35B_A3B_254K_1K_ENVS
     dataset_name = "random"
-    max_concurrency = 4
-    num_prompts = 16
-    input_len = 16384
-    output_len = 1024
+    max_concurrency = 1
+    num_prompts = 1
+    input_len = 254000
+    output_len = 1000
     random_range_ratio = 1
-    tpot = 20
-    output_token_throughput = 167
+    tpot = 16.1
+    output_token_throughput = 20.70
 
-    def test_npu_qwen3_5_27b_1p_in16k_out1k_low(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 in16k out1k low latency"""
+    def test_npu_qwen3_6_35b_a3b_1p_in254k_out1k_50ms(self):
+        """Run NPU performance test for Qwen3.6-35B-A3B in254k out1k 50ms"""
         self.run_throughput()
 
 

--- a/test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in3k5_out1k5_50ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in3k5_out1k5_50ms.py
@@ -3,7 +3,7 @@ import unittest
 from sglang.test.ascend.e2e.test_npu_performance_utils import (
     AISBENCHMARK_DATASET_DEFAULT,
     BENCHMARK_TOOL_DEFAULT,
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+    QWEN3_6_35B_A3B_MODEL_PATH,
     TestAscendPerformanceTestCaseBase,
 )
 from sglang.test.ci.ci_register import register_npu_ci
@@ -15,7 +15,7 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_16K_1K_LOW_ENVS = {
+QWEN3_6_35B_A3B_3K5_1K5_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
@@ -23,21 +23,16 @@ QWEN3_5_27B_16K_1K_LOW_ENVS = {
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "SGLANG_SET_CPU_AFFINITY": "1",
     "SGLANG_ENABLE_SPEC_V2": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
-    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
-    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "100",
-    "SGLANG_NPU_PROFILING": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    "ASCEND_USE_FIA": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "50",
 }
 
-QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
-    "--model-path",
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+QWEN3_6_35B_A3B_3K5_1K5_OTHER_ARGS = [
     "--tp-size",
     2,
     "--nnodes",
     1,
-    "--node-rank",
-    0,
     "--attention-backend",
     "ascend",
     "--device",
@@ -45,31 +40,30 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "--chunked-prefill-size",
     -1,
     "--max-prefill-tokens",
-    65000,
+    35000,
     "--disable-radix-cache",
     "--trust-remote-code",
+    "--enable-prefill-delayer",
     "--max-running-requests",
-    8,
+    100,
     "--max-mamba-cache-size",
-    20,
+    105,
     "--mem-fraction-static",
-    0.85,
+    0.78,
     "--cuda-graph-bs",
-    1,
-    2,
-    3,
     4,
+    16,
+    32,
+    64,
+    84,
+    100,
     "--enable-multimodal",
-    "--quantization",
-    "modelslim",
     "--mm-attention-backend",
     "ascend_attn",
     "--dtype",
     "bfloat16",
     "--mamba-ssm-dtype",
     "bfloat16",
-    "--max-total-tokens",
-    310000,
     "--speculative-algorithm",
     "NEXTN",
     "--speculative-num-steps",
@@ -81,25 +75,25 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
 ]
 
 
-class TestNPUQwen3_5_27B_1P_In16k_Out1k_Low(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p in16k out1k low latency"""
+class TestNPUQwen3_6_35BA3B_1P_In3k5_Out1k5_50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for Qwen3.6-35B-A3B 1p in3k5 out1k5 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
     aisbench_dataset_type = AISBENCHMARK_DATASET_DEFAULT
-    model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS
-    envs = QWEN3_5_27B_16K_1K_LOW_ENVS
+    model = QWEN3_6_35B_A3B_MODEL_PATH
+    other_args = QWEN3_6_35B_A3B_3K5_1K5_OTHER_ARGS
+    envs = QWEN3_6_35B_A3B_3K5_1K5_ENVS
     dataset_name = "random"
-    max_concurrency = 4
-    num_prompts = 16
-    input_len = 16384
-    output_len = 1024
+    max_concurrency = 100
+    num_prompts = 400
+    input_len = 3500
+    output_len = 1500
     random_range_ratio = 1
-    tpot = 20
-    output_token_throughput = 167
+    tpot = 50
+    output_token_throughput = 2031.71
 
-    def test_npu_qwen3_5_27b_1p_in16k_out1k_low(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 in16k out1k low latency"""
+    def test_npu_qwen3_6_35b_a3b_1p_in3k5_out1k5_50ms(self):
+        """Run NPU performance test for Qwen3.6-35B-A3B in3k5 out1k5 50ms"""
         self.run_throughput()
 
 

--- a/test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_50ms.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_50ms.py
@@ -3,7 +3,7 @@ import unittest
 from sglang.test.ascend.e2e.test_npu_performance_utils import (
     AISBENCHMARK_DATASET_DEFAULT,
     BENCHMARK_TOOL_DEFAULT,
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+    QWEN3_6_35B_A3B_MODEL_PATH,
     TestAscendPerformanceTestCaseBase,
 )
 from sglang.test.ci.ci_register import register_npu_ci
@@ -15,7 +15,7 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_16K_1K_LOW_ENVS = {
+QWEN3_6_35B_A3B_64K_1K_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
@@ -23,21 +23,16 @@ QWEN3_5_27B_16K_1K_LOW_ENVS = {
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "SGLANG_SET_CPU_AFFINITY": "1",
     "SGLANG_ENABLE_SPEC_V2": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
-    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
-    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "100",
-    "SGLANG_NPU_PROFILING": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    "ASCEND_USE_FIA": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "1",
 }
 
-QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
-    "--model-path",
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+QWEN3_6_35B_A3B_64K_1K_OTHER_ARGS = [
     "--tp-size",
     2,
     "--nnodes",
     1,
-    "--node-rank",
-    0,
     "--attention-backend",
     "ascend",
     "--device",
@@ -45,31 +40,30 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     "--chunked-prefill-size",
     -1,
     "--max-prefill-tokens",
-    65000,
+    65536,
     "--disable-radix-cache",
     "--trust-remote-code",
+    "--enable-prefill-delayer",
     "--max-running-requests",
-    8,
+    16,
     "--max-mamba-cache-size",
     20,
     "--mem-fraction-static",
-    0.85,
+    0.65,
     "--cuda-graph-bs",
-    1,
     2,
-    3,
     4,
+    8,
+    12,
+    14,
+    16,
     "--enable-multimodal",
-    "--quantization",
-    "modelslim",
     "--mm-attention-backend",
     "ascend_attn",
     "--dtype",
     "bfloat16",
     "--mamba-ssm-dtype",
     "bfloat16",
-    "--max-total-tokens",
-    310000,
     "--speculative-algorithm",
     "NEXTN",
     "--speculative-num-steps",
@@ -81,25 +75,25 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
 ]
 
 
-class TestNPUQwen3_5_27B_1P_In16k_Out1k_Low(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p in16k out1k low latency"""
+class TestNPUQwen3_6_35BA3B_1P_In64k_Out1k_50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for Qwen3.6-35B-A3B 1p in64k out1k 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
     aisbench_dataset_type = AISBENCHMARK_DATASET_DEFAULT
-    model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS
-    envs = QWEN3_5_27B_16K_1K_LOW_ENVS
+    model = QWEN3_6_35B_A3B_MODEL_PATH
+    other_args = QWEN3_6_35B_A3B_64K_1K_OTHER_ARGS
+    envs = QWEN3_6_35B_A3B_64K_1K_ENVS
     dataset_name = "random"
-    max_concurrency = 4
-    num_prompts = 16
-    input_len = 16384
-    output_len = 1024
+    max_concurrency = 16
+    num_prompts = 64
+    input_len = 64000
+    output_len = 1000
     random_range_ratio = 1
-    tpot = 20
-    output_token_throughput = 167
+    tpot = 50
+    output_token_throughput = 141.72
 
-    def test_npu_qwen3_5_27b_1p_in16k_out1k_low(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 in16k out1k low latency"""
+    def test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_50ms(self):
+        """Run NPU performance test for Qwen3.6-35B-A3B in64k out1k 50ms"""
         self.run_throughput()
 
 

--- a/test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_2p_in984k_out1k.py
+++ b/test/registered/ascend/performance/test_npu_qwen3_6_35b_a3b_2p_in984k_out1k.py
@@ -3,7 +3,7 @@ import unittest
 from sglang.test.ascend.e2e.test_npu_performance_utils import (
     AISBENCHMARK_DATASET_DEFAULT,
     BENCHMARK_TOOL_DEFAULT,
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+    QWEN3_6_35B_A3B_MODEL_PATH,
     TestAscendPerformanceTestCaseBase,
 )
 from sglang.test.ci.ci_register import register_npu_ci
@@ -15,7 +15,7 @@ register_npu_ci(
     disabled="performance testcase",
 )
 
-QWEN3_5_27B_16K_1K_LOW_ENVS = {
+QWEN3_6_35B_A3B_984K_1K_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "HCCL_SOCKET_IFNAME": "lo",
@@ -23,53 +23,41 @@ QWEN3_5_27B_16K_1K_LOW_ENVS = {
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "SGLANG_SET_CPU_AFFINITY": "1",
     "SGLANG_ENABLE_SPEC_V2": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
-    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
-    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "100",
-    "SGLANG_NPU_PROFILING": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    "ASCEND_USE_FIA": "1",
+    "SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN": "1",
 }
 
-QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
-    "--model-path",
-    QWEN3_5_27B_W8A8_MODEL_PATH,
+QWEN3_6_35B_A3B_984K_1K_OTHER_ARGS = [
     "--tp-size",
-    2,
+    4,
     "--nnodes",
     1,
-    "--node-rank",
-    0,
     "--attention-backend",
     "ascend",
     "--device",
     "npu",
     "--chunked-prefill-size",
-    -1,
+    131072,
     "--max-prefill-tokens",
-    65000,
+    984000,
     "--disable-radix-cache",
     "--trust-remote-code",
     "--max-running-requests",
-    8,
+    1,
     "--max-mamba-cache-size",
-    20,
+    6,
     "--mem-fraction-static",
-    0.85,
+    0.68,
     "--cuda-graph-bs",
     1,
-    2,
-    3,
-    4,
     "--enable-multimodal",
-    "--quantization",
-    "modelslim",
     "--mm-attention-backend",
     "ascend_attn",
     "--dtype",
     "bfloat16",
     "--mamba-ssm-dtype",
     "bfloat16",
-    "--max-total-tokens",
-    310000,
     "--speculative-algorithm",
     "NEXTN",
     "--speculative-num-steps",
@@ -78,28 +66,30 @@ QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS = [
     1,
     "--speculative-num-draft-tokens",
     4,
+    "--context-length",
+    1010000,
 ]
 
 
-class TestNPUQwen3_5_27B_1P_In16k_Out1k_Low(TestAscendPerformanceTestCaseBase):
-    """Test NPU performance for Qwen3.5-27B-W8A8 1p in16k out1k low latency"""
+class TestNPUQwen3_6_35BA3B_2P_In984k_Out1k_50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for Qwen3.6-35B-A3B 2p in984k out1k 50ms"""
 
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
     aisbench_dataset_type = AISBENCHMARK_DATASET_DEFAULT
-    model = QWEN3_5_27B_W8A8_MODEL_PATH
-    other_args = QWEN3_5_27B_16K_1K_LOW_OTHER_ARGS
-    envs = QWEN3_5_27B_16K_1K_LOW_ENVS
+    model = QWEN3_6_35B_A3B_MODEL_PATH
+    other_args = QWEN3_6_35B_A3B_984K_1K_OTHER_ARGS
+    envs = QWEN3_6_35B_A3B_984K_1K_ENVS
     dataset_name = "random"
-    max_concurrency = 4
-    num_prompts = 16
-    input_len = 16384
-    output_len = 1024
+    max_concurrency = 1
+    num_prompts = 1
+    input_len = 984000
+    output_len = 1000
     random_range_ratio = 1
-    tpot = 20
-    output_token_throughput = 167
+    tpot = 40.91
+    output_token_throughput = 3.83
 
-    def test_npu_qwen3_5_27b_1p_in16k_out1k_low(self):
-        """Run NPU performance test for Qwen3.5-27B-W8A8 in16k out1k low latency"""
+    def test_npu_qwen3_6_35b_a3b_2p_in984k_out1k_50ms(self):
+        """Run NPU performance test for Qwen3.6-35B-A3B in984k out1k 50ms"""
         self.run_throughput()
 
 


### PR DESCRIPTION
## Summary

This PR adds performance and accuracy test cases for Qwen3.6 series models.

### Performance Test Cases (24 cases)

**Qwen3.6-35B-A3B (6 cases)**:
- test_npu_qwen3_6_35b_a3b_1p_in3k5_out1k5_50ms
- test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_50ms
- test_npu_qwen3_6_35b_a3b_1p_in128k_out1k_50ms
- test_npu_qwen3_6_35b_a3b_2p_in984k_out1k
- test_npu_qwen3_6_35b_a3b_1p_in254k_out1k
- test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms

**Qwen3.6-27B (6 cases)**:
- test_npu_qwen3_6_27b_1p_in1080p_30_out256_50ms
- test_npu_qwen3_6_27b_1p_in1024x1024_30_out1024_50ms
- test_npu_qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms
- test_npu_qwen3_6_27b_w8a8_2p_in128k_out1k_50ms
- test_npu_qwen3_6_27b_w8a8_2p_in16k_out1k_50ms
- test_npu_qwen3_6_27b_w8a8_2p_in64k_out1k_50ms

**Qwen3.5-27B-W8A8 (8 cases)** :
- test_npu_qwen3_5_27b_w8a8_1p_in3k5_out1k5_50ms
- test_npu_qwen3_5_27b_w8a8_2p_in16k_out1k_50ms
- test_npu_qwen3_5_27b_w8a8_2p_in3k5_out1k5_20ms
- test_npu_qwen3_5_27b_w8a8_2p_in64k_out1k_50ms 
- test_npu_qwen3_5_27b_w8a8_1p_in16k_out1k_20ms 
- test_npu_qwen3_5_27b_w8a8_1p_in64k_out1k_20ms
- test_npu_qwen3_5_27b_w8a8_1p_in64k_90prefix_20ms
- test_npu_qwen3_5_27b_w8a8_1p_in1024x1024_30_out1024_50ms 

**Kimi K2.5 (3 cases)**:
- test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_50ms
- test_npu_kimi_k2_5_w4a8_8p_in3k5_out1k5_20ms
- test_npu_kimi_k2_5_w4a8_8p_in1024x1024_30_out1024_50ms

**Minimax M2.5 (2 cases)**:
- test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms
- test_npu_minimax_m2_5_w8a8_8p_in32k_out1k_50ms

### Accuracy Test Cases (3 cases)

- test_npu_minimax_m2_5_w8a8_8p_aime2025
- test_npu_minimax_m2_5_w8a8_8p_gpqa
- test_npu_qwen3_5_27b_1p_gpqa

### Other Changes

- Updated test_npu_performance_utils.py from performance branch
- Added single-test-npu.yml workflow for Qwen3.6 tests

## Note

The workflow configuration (full-test-npu.yml and single-test-npu.yml) needs further adjustment to enable only the specified test cases. This will be done in a follow-up iteration.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->