### PR TITLE
Add NPU utils test cases for model file verifier, request logger, and scheduler status logger

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-2
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260528
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 5: re-trigger CI for utils test cases
+# test round 6: re-trigger CI with updated image
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -40,8 +40,9 @@ jobs:
 
           # Test cases
           test_cases=(
-            "test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_eviction.py"
-            "test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_update.py"
+            "test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_model_file_verifier.py"
+            "test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_request_logger.py"
+            "test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_scheduler_status_logger.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: Add NPU utils test cases for model file verifier, request logger, and scheduler status logger
+# test round 5: re-trigger CI for utils test cases
 
 on:
   pull_request:
@@ -7,19 +7,14 @@ on:
       - testcases
     paths:
       - ".github/workflows/single-test-npu.yml"
-  workflow_dispatch:
-    inputs:
-      test_case:
-        description: 'Test case file path (e.g., test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_model_file_verifier.py)'
-        required: true
-        type: string
-        default: 'test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_model_file_verifier.py'
 
-env:
-  TEST_CASE: ${{ github.event.inputs.test_case || 'test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_model_file_verifier.py' }}
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   single-node-poc:
+    name: single-node-poc
     runs-on: linux-aarch64-a3-2
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
@@ -27,47 +22,79 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install dependencies
-        env:
-          TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-          PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-          UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-          GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      - name: Check npu info
         run: |
-          # Clean up potential residual files from previous runs
-          rm -f ./deep_ep_cpp.cpython-311-aarch64-linux-gnu.so
-          rm -rf sgl-kernel-npu
+          npu-smi info
 
-          # speed up by using infra cache services
-          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-          pip config set global.trusted-host "${CACHING_URL}"
-
-          bash scripts/ci/npu/npu_ci_install_dependency.sh a3
-
-          # copy required file from our daily cache
-          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
-          # copy gsm8k dataset
-          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
-
-      - name: Print Log Information
-        run: |
-          bash scripts/ci/npu/npu_log_print.sh
-
-      - name: Run single test case
+      - name: Run test
         timeout-minutes: 120
         env:
           SGLANG_USE_MODELSCOPE: true
-          SGLANG_IS_IN_CI: true
           HF_ENDPOINT: https://hf-mirror.com
-          TORCH_EXTENSIONS_DIR: /tmp/torch_extensions
-          PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-          STREAMS_PER_DEVICE: 32
-          TRANSFORMERS_VERBOSITY: "error"
+          SGLANG_IS_IN_CI: true
+        shell: bash
         run: |
-          cd test
-          # Run all three test files
-          python3 -m pytest registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_model_file_verifier.py -v --timeout=3600
-          python3 -m pytest registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_request_logger.py -v --timeout=3600
-          python3 -m pytest registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_scheduler_status_logger.py -v --timeout=3600
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases
+          test_cases=(
+            "test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_eviction.py"
+            "test/registered/ascend/basic_function/lora/generated_tests_20260521/test_npu_lora_update.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,69 @@
+name: Single Test (NPU)
+# test round 1: Add NPU utils test cases for model file verifier, request logger, and scheduler status logger
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+  workflow_dispatch:
+    inputs:
+      test_case:
+        description: 'Test case file path (e.g., test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_model_file_verifier.py)'
+        required: true
+        type: string
+        default: 'test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_model_file_verifier.py'
+
+env:
+  TEST_CASE: ${{ github.event.inputs.test_case || 'test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_model_file_verifier.py' }}
+
+jobs:
+  single-node-poc:
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        env:
+          TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+          PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+          UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+          GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+        run: |
+          # speed up by using infra cache services
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host "${CACHING_URL}"
+
+          bash scripts/ci/npu/npu_ci_install_dependency.sh a3
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          # copy gsm8k dataset
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+      - name: Print Log Information
+        run: |
+          bash scripts/ci/npu/npu_log_print.sh
+
+      - name: Run single test case
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          SGLANG_IS_IN_CI: true
+          HF_ENDPOINT: https://hf-mirror.com
+          TORCH_EXTENSIONS_DIR: /tmp/torch_extensions
+          PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+          STREAMS_PER_DEVICE: 32
+          TRANSFORMERS_VERBOSITY: "error"
+        run: |
+          cd test
+          # Run all three test files
+          python3 -m pytest registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_model_file_verifier.py -v --timeout=3600
+          python3 -m pytest registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_request_logger.py -v --timeout=3600
+          python3 -m pytest registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_scheduler_status_logger.py -v --timeout=3600

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -34,6 +34,10 @@ jobs:
           UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
           GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
         run: |
+          # Clean up potential residual files from previous runs
+          rm -f ./deep_ep_cpp.cpython-311-aarch64-linux-gnu.so
+          rm -rf sgl-kernel-npu
+
           # speed up by using infra cache services
           CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
           sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list

--- a/test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_model_file_verifier.py
+++ b/test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_model_file_verifier.py
@@ -1,0 +1,357 @@
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import warnings
+from contextlib import nullcontext
+from io import StringIO
+
+import requests
+from huggingface_hub import snapshot_download
+
+from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils.model_file_verifier import (
+    IntegrityError,
+    compute_sha256,
+    generate_checksums,
+    verify,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=180, suite="nightly-2-npu-a3", nightly=True)
+
+MODEL_NAME = "Qwen/Qwen3-0.6B"
+
+
+class _FakeModelTestCase(unittest.TestCase):
+
+    FAKE_FILES = {
+        "model.safetensors": b"fake safetensors content " * 100,
+        "config.json": b'{"model_type": "llama"}',
+        "tokenizer.json": b'{"version": "1.0"}',
+    }
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        for filename, content in self.FAKE_FILES.items():
+            _create_test_file(self.test_dir, filename, content)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+
+class _RealModelTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.original_model_path = snapshot_download(MODEL_NAME)
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        shutil.copytree(self.original_model_path, self.test_dir, dirs_exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+
+class TestNPUModelFileVerifier(_FakeModelTestCase):
+    """Test model file verifier on NPU.
+
+    [Test Category] Verification
+    [Test Target] Model file integrity verification
+    """
+
+    def test_detect_bit_rot(self):
+        checksums_file = os.path.join(self.test_dir, "checksums.json")
+        generate_checksums(source=self.test_dir, output_path=checksums_file)
+
+        target_file = os.path.join(self.test_dir, "model.safetensors")
+        _flip_bit_in_file(target_file, byte_offset=50, bit_position=3)
+
+        with self.assertRaises(IntegrityError) as ctx:
+            verify(model_path=self.test_dir, checksums_source=checksums_file)
+
+        self.assertIn("model.safetensors", str(ctx.exception))
+        self.assertIn("mismatch", str(ctx.exception).lower())
+
+    def test_detect_missing_file(self):
+        checksums_file = os.path.join(self.test_dir, "checksums.json")
+        generate_checksums(source=self.test_dir, output_path=checksums_file)
+
+        os.remove(os.path.join(self.test_dir, "config.json"))
+
+        with self.assertRaises(IntegrityError) as ctx:
+            verify(model_path=self.test_dir, checksums_source=checksums_file)
+
+        self.assertIn("config.json", str(ctx.exception))
+
+    def test_compute_sha256(self):
+        test_file = os.path.join(self.test_dir, "test.bin")
+        content = b"hello world"
+        with open(test_file, "wb") as f:
+            f.write(content)
+
+        result = compute_sha256(file_path=test_file)
+        expected = hashlib.sha256(content).hexdigest()
+        self.assertEqual(result, expected)
+
+    def test_parallel_checksum_computation(self):
+        for i in range(10):
+            _create_test_file(
+                self.test_dir, f"shard_{i}.safetensors", f"content_{i}".encode() * 1000
+            )
+
+        checksums_file = os.path.join(self.test_dir, "checksums.json")
+        result = generate_checksums(
+            source=self.test_dir, output_path=checksums_file, max_workers=4
+        )
+
+        self.assertGreaterEqual(len(result.files), 10)
+
+    def test_generated_json_snapshot(self):
+        checksums_file = os.path.join(self.test_dir, "checksums.json")
+        generate_checksums(source=self.test_dir, output_path=checksums_file)
+
+        with open(checksums_file) as f:
+            data = json.load(f)
+
+        expected = {
+            "files": {
+                "config.json": {
+                    "sha256": "81dddc8c379baae137d99d24c5fa081d3a5ce52b6a221ddc22fe364711f8beaf",
+                    "size": 23,
+                },
+                "model.safetensors": {
+                    "sha256": "eb0c73a48a89fefb6b68dd41af830d75610c885135eac99139373b04705d05f3",
+                    "size": 2500,
+                },
+                "tokenizer.json": {
+                    "sha256": "4e3043229142b64d998563bc543ce034e0a2251af5d404995e3afcb8ce8850df",
+                    "size": 18,
+                },
+            }
+        }
+        self.assertEqual(data, expected)
+
+    def test_legacy_checksums_format_deprecated(self):
+        legacy_data = {
+            "checksums": {
+                "model.safetensors": "eb0c73a48a89fefb6b68dd41af830d75610c885135eac99139373b04705d05f3",
+                "config.json": "81dddc8c379baae137d99d24c5fa081d3a5ce52b6a221ddc22fe364711f8beaf",
+                "tokenizer.json": "4e3043229142b64d998563bc543ce034e0a2251af5d404995e3afcb8ce8850df",
+            }
+        }
+        legacy_file = os.path.join(self.test_dir, "legacy_checksums.json")
+        with open(legacy_file, "w") as f:
+            json.dump(legacy_data, f)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            verify(model_path=self.test_dir, checksums_source=legacy_file)
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertIn("deprecated", str(w[0].message).lower())
+
+
+class TestNPUModelFileVerifierCLI(_FakeModelTestCase):
+    """Test model file verifier CLI on NPU.
+
+    [Test Category] Verification
+    [Test Target] Model file verifier CLI functionality
+    """
+
+    def test_cli_generate(self):
+        checksums_file = os.path.join(self.test_dir, "checksums.json")
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "sglang.srt.utils.model_file_verifier",
+                "generate",
+                "--model-path",
+                self.test_dir,
+                "--model-checksum",
+                checksums_file,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+        self.assertTrue(os.path.exists(checksums_file))
+
+        with open(checksums_file) as f:
+            data = json.load(f)
+        self.assertIn("files", data)
+        self.assertEqual(len(data["files"]), 3)
+
+    def test_cli_verify_success(self):
+        checksums_file = os.path.join(self.test_dir, "checksums.json")
+        generate_checksums(source=self.test_dir, output_path=checksums_file)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "sglang.srt.utils.model_file_verifier",
+                "verify",
+                "--model-path",
+                self.test_dir,
+                "--model-checksum",
+                checksums_file,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+        self.assertIn("verified successfully", result.stdout)
+
+    def test_cli_verify_fails_on_corruption(self):
+        checksums_file = os.path.join(self.test_dir, "checksums.json")
+        generate_checksums(source=self.test_dir, output_path=checksums_file)
+
+        target_file = os.path.join(self.test_dir, "model.safetensors")
+        _flip_bit_in_file(target_file, byte_offset=50, bit_position=3)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "sglang.srt.utils.model_file_verifier",
+                "verify",
+                "--model-path",
+                self.test_dir,
+                "--model-checksum",
+                checksums_file,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        combined = result.stdout + result.stderr
+        self.assertTrue(
+            "IntegrityError" in combined or "mismatch" in combined.lower(),
+            f"Expected integrity error, got: {combined}",
+        )
+
+
+class TestNPUModelFileVerifierHF(_RealModelTestCase):
+    """Test model file verifier with HuggingFace on NPU.
+
+    [Test Category] Verification
+    [Test Target] HuggingFace checksums verification
+    """
+
+    def test_generate_checksums_from_hf(self):
+        checksums_file = os.path.join(self.test_dir, "checksums.json")
+        result = generate_checksums(source=MODEL_NAME, output_path=checksums_file)
+
+        self.assertTrue(os.path.exists(checksums_file))
+        self.assertGreater(len(result.files), 0)
+        for filename, file_info in result.files.items():
+            self.assertEqual(len(file_info.sha256), 64)
+
+    def test_verify_with_hf_checksums_source(self):
+        verify(model_path=self.test_dir, checksums_source=MODEL_NAME)
+
+
+class TestNPUModelFileVerifierWithRealModel(_RealModelTestCase, CustomTestCase):
+    """Test model file verifier with real model server on NPU.
+
+    [Test Category] Verification
+    [Test Target] Server-side model file integrity verification
+    """
+
+    def _run_server_test(self, *, corrupt_weights: bool, use_hf_checksum: bool):
+        if use_hf_checksum:
+            checksum_arg = MODEL_NAME
+        else:
+            checksums_file = os.path.join(self.test_dir, "checksums.json")
+            generate_checksums(source=self.test_dir, output_path=checksums_file)
+            checksum_arg = checksums_file
+
+        corrupted_file = None
+        if corrupt_weights:
+            safetensors_files = [
+                f for f in os.listdir(self.test_dir) if f.endswith(".safetensors")
+            ]
+            self.assertTrue(len(safetensors_files) > 0, "No safetensors files found")
+            corrupted_file = safetensors_files[0]
+            _flip_bit_in_file(os.path.join(self.test_dir, corrupted_file))
+
+        stdout_io, stderr_io = StringIO(), StringIO()
+        ctx = self.assertRaises(Exception) if corrupt_weights else nullcontext()
+        with ctx:
+            process = popen_launch_server(
+                model=self.test_dir,
+                base_url=DEFAULT_URL_FOR_TEST,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    "--attention-backend",
+                    "ascend",
+                    "--disable-cuda-graph",
+                    "--model-checksum",
+                    checksum_arg,
+                ],
+                return_stdout_stderr=(stdout_io, stderr_io),
+            )
+
+        if corrupt_weights:
+            output = stdout_io.getvalue() + stderr_io.getvalue()
+            self.assertIn(corrupted_file, output)
+            self.assertIn("mismatch", output.lower())
+        else:
+            try:
+                response = requests.post(
+                    f"{DEFAULT_URL_FOR_TEST}/generate",
+                    json={"text": "Hello", "sampling_params": {"max_new_tokens": 8}},
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertIn("text", response.json())
+            finally:
+                kill_process_tree(process.pid)
+
+    def test_server_launch_with_checksum_intact(self):
+        self._run_server_test(corrupt_weights=False, use_hf_checksum=False)
+
+    def test_server_launch_fails_with_corrupted_weights(self):
+        self._run_server_test(corrupt_weights=True, use_hf_checksum=False)
+
+    def test_server_launch_with_hf_checksum_intact(self):
+        self._run_server_test(corrupt_weights=False, use_hf_checksum=True)
+
+    def test_server_launch_with_hf_checksum_corrupted(self):
+        self._run_server_test(corrupt_weights=True, use_hf_checksum=True)
+
+
+def _create_test_file(directory: str, filename: str, content: bytes) -> str:
+    path = os.path.join(directory, filename)
+    with open(path, "wb") as f:
+        f.write(content)
+    return path
+
+
+def _flip_bit_in_file(file_path: str, byte_offset: int = 100, bit_position: int = 0):
+    file_size = os.path.getsize(file_path)
+    assert (
+        byte_offset < file_size
+    ), f"byte_offset {byte_offset} >= file_size {file_size}"
+
+    with open(file_path, "r+b") as f:
+        f.seek(byte_offset)
+        original_byte = f.read(1)[0]
+        f.seek(byte_offset)
+        f.write(bytes([original_byte ^ (1 << bit_position)]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_request_logger.py
+++ b/test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_request_logger.py
@@ -1,0 +1,323 @@
+import io
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import requests
+
+from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_0_6B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=180, suite="nightly-2-npu-a3", nightly=True)
+
+TEST_ROUTING_KEY = "test-routing-key-12345"
+TEST_CUSTOM_HEADER_NAME = "X-Test-Header"
+TEST_CUSTOM_HEADER_VALUE = "test-header-value-67890"
+
+
+class BaseTestNPURequestLogger:
+    log_requests_format = None
+    env_vars: dict[str, str] = {}
+    request_headers: dict[str, str] = {"X-SMG-Routing-Key": TEST_ROUTING_KEY}
+
+    @classmethod
+    def setUpClass(cls):
+        cls._temp_dir_obj = tempfile.TemporaryDirectory()
+        cls.temp_dir = cls._temp_dir_obj.name
+        cls.stdout = io.StringIO()
+        cls.stderr = io.StringIO()
+        other_args = [
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--log-requests",
+            "--log-requests-level",
+            "2",
+            "--log-requests-format",
+            cls.log_requests_format,
+            "--skip-server-warmup",
+            "--log-requests-target",
+            "stdout",
+            cls.temp_dir,
+        ]
+        cls._old_env_vars = {}
+        for key, value in cls.env_vars.items():
+            cls._old_env_vars[key] = os.environ.get(key)
+            os.environ[key] = value
+
+        cls.process = popen_launch_server(
+            QWEN3_0_6B_WEIGHTS_PATH,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+            return_stdout_stderr=(cls.stdout, cls.stderr),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+        cls.stdout.close()
+        cls.stderr.close()
+        cls._temp_dir_obj.cleanup()
+        for key, old_value in cls._old_env_vars.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+
+    def _verify_logs(self, content: str, source_name: str):
+        raise NotImplementedError
+
+    def _verify_openai_logs(self, content: str, source_name: str):
+        raise NotImplementedError
+
+    def _wait_until_verified(
+        self,
+        verify_fn,
+        get_content_fn,
+        source_name: str,
+        timeout: float = 10.0,
+        interval: float = 0.1,
+    ):
+        deadline = time.time() + timeout
+        last_error = None
+
+        while time.time() < deadline:
+            content = get_content_fn()
+            try:
+                verify_fn(content, source_name)
+                return
+            except AssertionError as err:
+                last_error = err
+                time.sleep(interval)
+
+        if last_error is not None:
+            raise last_error
+
+    def test_logging(self):
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={
+                "text": "Hello",
+                "sampling_params": {"max_new_tokens": 8, "temperature": 0},
+            },
+            headers=self.request_headers,
+            timeout=30,
+        )
+        self.assertEqual(response.status_code, 200)
+        self._wait_until_verified(
+            self._verify_logs,
+            lambda: self.stdout.getvalue() + self.stderr.getvalue(),
+            "stdout",
+        )
+        self._wait_until_verified(
+            self._verify_logs,
+            lambda: "".join(f.read_text() for f in Path(self.temp_dir).glob("*.log")),
+            "log files",
+        )
+
+        log_files = list(Path(self.temp_dir).glob("*.log"))
+        self.assertGreater(len(log_files), 0, "No log files found in temp directory")
+
+    def test_openai_chat_logging(self):
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/v1/chat/completions",
+            json={
+                "model": QWEN3_0_6B_WEIGHTS_PATH,
+                "messages": [{"role": "user", "content": "hello request logger"}],
+                "max_tokens": 8,
+                "temperature": 0,
+            },
+            headers=self.request_headers,
+            timeout=30,
+        )
+        self.assertEqual(response.status_code, 200)
+        self._wait_until_verified(
+            self._verify_openai_logs,
+            lambda: self.stdout.getvalue() + self.stderr.getvalue(),
+            "stdout",
+        )
+        self._wait_until_verified(
+            self._verify_openai_logs,
+            lambda: "".join(f.read_text() for f in Path(self.temp_dir).glob("*.log")),
+            "log files",
+        )
+
+        log_files = list(Path(self.temp_dir).glob("*.log"))
+        self.assertGreater(len(log_files), 0, "No log files found in temp directory")
+
+
+class TestNPURequestLoggerText(BaseTestNPURequestLogger, CustomTestCase):
+    """Test request logger with text format on NPU.
+
+    [Test Category] Logging
+    [Test Target] Request logging functionality with text format
+    """
+
+    log_requests_format = "text"
+
+    def _verify_logs(self, content: str, source_name: str):
+        self.assertIn("Receive:", content, f"'Receive:' not found in {source_name}")
+        self.assertIn("Finish:", content, f"'Finish:' not found in {source_name}")
+        self.assertIn(
+            TEST_ROUTING_KEY, content, f"Routing key not found in {source_name}"
+        )
+        self.assertIn(
+            "x-smg-routing-key", content, f"Header name not found in {source_name}"
+        )
+
+    def _verify_openai_logs(self, content: str, source_name: str):
+        self.assertIn(
+            "Receive OpenAI:", content, f"OpenAI receive log not found in {source_name}"
+        )
+        self.assertIn("'messages':", content, f"Messages not found in {source_name}")
+        self.assertIn(
+            "hello request logger",
+            content,
+            f"OpenAI user prompt not found in {source_name}",
+        )
+
+
+class TestNPURequestLoggerJson(BaseTestNPURequestLogger, CustomTestCase):
+    """Test request logger with JSON format on NPU.
+
+    [Test Category] Logging
+    [Test Target] Request logging functionality with JSON format
+    """
+
+    log_requests_format = "json"
+
+    def _verify_logs(self, content: str, source_name: str):
+        received_found = False
+        finished_found = False
+        for line in content.splitlines():
+            idx = line.find("{")
+            if idx == -1:
+                continue
+            try:
+                data = json.loads(line[idx:])
+            except json.JSONDecodeError:
+                continue
+
+            rid = data.get("rid", "")
+            if rid.startswith(HEALTH_CHECK_RID_PREFIX):
+                continue
+
+            if data.get("event") == "request.received":
+                self.assertIn("rid", data)
+                self.assertIn("obj", data)
+                self.assertEqual(
+                    data.get("headers", {}).get("x-smg-routing-key"), TEST_ROUTING_KEY
+                )
+                received_found = True
+            elif data.get("event") == "request.finished":
+                self.assertIn("rid", data)
+                self.assertIn("obj", data)
+                self.assertIn("out", data)
+                self.assertEqual(
+                    data.get("headers", {}).get("x-smg-routing-key"), TEST_ROUTING_KEY
+                )
+                finished_found = True
+
+        self.assertTrue(
+            received_found, f"request.received event not found in {source_name}"
+        )
+        self.assertTrue(
+            finished_found, f"request.finished event not found in {source_name}"
+        )
+
+    def _verify_openai_logs(self, content: str, source_name: str):
+        openai_received_found = False
+        for line in content.splitlines():
+            idx = line.find("{")
+            if idx == -1:
+                continue
+            try:
+                data = json.loads(line[idx:])
+            except json.JSONDecodeError:
+                continue
+            if data.get("event") != "request.received.openai":
+                continue
+
+            obj = data.get("obj", {})
+            self.assertEqual(obj.get("model"), QWEN3_0_6B_WEIGHTS_PATH)
+            self.assertIsInstance(obj.get("messages"), list)
+            self.assertGreater(len(obj.get("messages")), 0)
+            self.assertEqual(obj["messages"][0].get("content"), "hello request logger")
+            self.assertEqual(
+                data.get("headers", {}).get("x-smg-routing-key"), TEST_ROUTING_KEY
+            )
+            openai_received_found = True
+            break
+
+        self.assertTrue(
+            openai_received_found,
+            f"request.received.openai event not found in {source_name}",
+        )
+
+
+class TestNPUCustomHeaderViaEnvVar(BaseTestNPURequestLogger, CustomTestCase):
+    """Test custom headers via environment variable on NPU.
+
+    [Test Category] Logging
+    [Test Target] Custom header logging via SGLANG_LOG_REQUEST_HEADERS env var
+    """
+
+    log_requests_format = "text"
+    env_vars = {"SGLANG_LOG_REQUEST_HEADERS": TEST_CUSTOM_HEADER_NAME}
+    request_headers = {
+        "X-SMG-Routing-Key": TEST_ROUTING_KEY,
+        TEST_CUSTOM_HEADER_NAME: TEST_CUSTOM_HEADER_VALUE,
+    }
+
+    def _verify_logs(self, content: str, source_name: str):
+        self.assertIn(
+            TEST_CUSTOM_HEADER_NAME.lower(),
+            content,
+            f"Custom header name not found in {source_name}",
+        )
+        self.assertIn(
+            TEST_CUSTOM_HEADER_VALUE,
+            content,
+            f"Custom header value not found in {source_name}",
+        )
+        self.assertIn(
+            "x-smg-routing-key",
+            content,
+            f"Default header should still be in whitelist in {source_name}",
+        )
+        self.assertIn(
+            TEST_ROUTING_KEY,
+            content,
+            f"Default header value not found in {source_name}",
+        )
+
+    def _verify_openai_logs(self, content: str, source_name: str):
+        self.assertIn(
+            "Receive OpenAI:", content, f"OpenAI receive log not found in {source_name}"
+        )
+        self.assertIn(
+            TEST_CUSTOM_HEADER_NAME.lower(),
+            content,
+            f"Custom header name not found in {source_name}",
+        )
+        self.assertIn(
+            TEST_CUSTOM_HEADER_VALUE,
+            content,
+            f"Custom header value not found in {source_name}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_scheduler_status_logger.py
+++ b/test/registered/ascend/basic_function/utils/GENERATED_20260526/test_npu_scheduler_status_logger.py
@@ -1,0 +1,91 @@
+import json
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_0_6B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=180, suite="nightly-2-npu-a3", nightly=True)
+
+
+class TestNPUSchedulerStatusLogger(CustomTestCase):
+    """Test scheduler status logger on NPU.
+
+    [Test Category] Logging
+    [Test Target] Scheduler status logging functionality
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = tempfile.mkdtemp()
+        cls.addClassCleanup(shutil.rmtree, cls.temp_dir)
+        env = os.environ.copy()
+        env["SGLANG_LOG_SCHEDULER_STATUS_TARGET"] = cls.temp_dir
+        env["SGLANG_LOG_SCHEDULER_STATUS_INTERVAL"] = "1"
+        other_args = [
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--skip-server-warmup",
+            "--enable-metrics",
+        ]
+        cls.process = popen_launch_server(
+            QWEN3_0_6B_WEIGHTS_PATH,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+            env=env,
+        )
+        cls.addClassCleanup(kill_process_tree, cls.process.pid)
+
+    def test_scheduler_status_dump(self):
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/generate",
+            json={
+                "text": "Hello",
+                "sampling_params": {"max_new_tokens": 8, "temperature": 0},
+            },
+            timeout=30,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        time.sleep(2)
+
+        events = list(_find_log_events(self.temp_dir, "scheduler.status"))
+        self.assertGreater(len(events), 0, "scheduler.status event not found")
+        data = events[0]
+        for field in ["timestamp", "rank", "running_rids", "queued_rids"]:
+            self.assertIn(field, data)
+        self.assertIsInstance(data["running_rids"], list)
+        self.assertIsInstance(data["queued_rids"], list)
+
+
+def _find_log_events(log_dir: str, event_name: str):
+    for f in Path(log_dir).glob("*.log"):
+        for line in f.read_text().splitlines():
+            idx = line.find("{")
+            if idx == -1:
+                continue
+            try:
+                data = json.loads(line[idx:])
+            except json.JSONDecodeError:
+                continue
+            if data.get("event") == event_name:
+                yield data
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds three NPU test cases for utils functionality:

1. **test_npu_model_file_verifier.py** - Tests model file integrity verification including checksums, CLI, and server integration
2. **test_npu_request_logger.py** - Tests request logging functionality with text and JSON formats
3. **test_npu_scheduler_status_logger.py** - Tests scheduler status logging functionality

All tests are registered for the nightly-2-npu-a3 suite.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->