### PR TITLE
Add EPLB and MoE test cases for NPU

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: retrigger PR CI for EPLB and MoE test cases
+# test round 5: expert_parallelism test cases
 
 on:
   pull_request:
@@ -40,8 +40,9 @@ jobs:
 
           # Test cases
           test_cases=(
-            "test/registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py"
-            "test/registered/ascend/basic_function/pr/test_npu_moe_a2a_backend.py"
+            "test/registered/ascend/basic_function/expert_parallelism/test_npu_moe_a2a_backend.py"
+            "test/registered/ascend/basic_function/expert_parallelism/test_npu_eplb_dispatch_algorithm.py"
+            "test/registered/ascend/basic_function/expert_parallelism/test_npu_expert_distribution_recorder_mode.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: eplb dispatch algorithm, expert distribution recorder mode, moe a2a backend
+# test round 2: retrigger PR CI for EPLB and MoE test cases
 
 on:
   pull_request:
@@ -7,76 +7,94 @@ on:
       - testcases
     paths:
       - ".github/workflows/single-test-npu.yml"
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Git ref (branch, tag, or SHA) to test. If not provided, uses the default branch.'
-        required: false
-        type: string
-        default: ''
-      test_case:
-        description: 'Test case file path (relative to test directory)'
-        required: false
-        type: string
-        default: 'registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py'
-
-env:
-  TEST_CASE: ${{ github.event.inputs.test_case || 'registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py' }}
 
 concurrency:
   group: single-test-npu-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   single-node-poc:
+    name: single-node-poc
     runs-on: linux-aarch64-a3-2
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.ref || github.ref }}
 
-      - name: Install dependencies
-        env:
-          TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-          PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-          UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-          GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      - name: Check npu info
         run: |
-          # speed up by using infra cache services
-          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-          pip config set global.trusted-host "${CACHING_URL}"
-
-          sglang_source_path=$(pwd)
-          echo "Source code path: ${sglang_source_path}"
-
-          bash scripts/ci/npu/npu_ci_install_dependency.sh a3
-
-          # copy required file from our daily cache
-          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
-          # copy gsm8k dataset
-          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
-
-      - name: Print Log Information
-        run: |
-          bash scripts/ci/npu/npu_log_print.sh
+          npu-smi info
 
       - name: Run test
         timeout-minutes: 120
         env:
           SGLANG_USE_MODELSCOPE: true
-          SGLANG_IS_IN_CI: true
           HF_ENDPOINT: https://hf-mirror.com
-          TORCH_EXTENSIONS_DIR: /tmp/torch_extensions
-          PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-          STREAMS_PER_DEVICE: 32
-          TRANSFORMERS_VERBOSITY: "error"
+          SGLANG_IS_IN_CI: true
+        shell: bash
         run: |
-          cd test
-          python3 -m pytest registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py -v --timeout=3600
-          python3 -m pytest registered/ascend/basic_function/pr/test_npu_expert_distribution_recorder_mode.py -v --timeout=3600
-          python3 -m pytest registered/ascend/basic_function/pr/test_npu_moe_a2a_backend.py -v --timeout=3600
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases
+          test_cases=(
+            "test/registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py"
+            "test/registered/ascend/basic_function/pr/test_npu_moe_a2a_backend.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,82 @@
+name: Single Test (NPU)
+# test round 1: eplb dispatch algorithm, expert distribution recorder mode, moe a2a backend
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (branch, tag, or SHA) to test. If not provided, uses the default branch.'
+        required: false
+        type: string
+        default: ''
+      test_case:
+        description: 'Test case file path (relative to test directory)'
+        required: false
+        type: string
+        default: 'registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py'
+
+env:
+  TEST_CASE: ${{ github.event.inputs.test_case || 'registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py' }}
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  single-node-poc:
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Install dependencies
+        env:
+          TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+          PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+          UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+          GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+        run: |
+          # speed up by using infra cache services
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host "${CACHING_URL}"
+
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+
+          bash scripts/ci/npu/npu_ci_install_dependency.sh a3
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          # copy gsm8k dataset
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+      - name: Print Log Information
+        run: |
+          bash scripts/ci/npu/npu_log_print.sh
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          SGLANG_IS_IN_CI: true
+          HF_ENDPOINT: https://hf-mirror.com
+          TORCH_EXTENSIONS_DIR: /tmp/torch_extensions
+          PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+          STREAMS_PER_DEVICE: 32
+          TRANSFORMERS_VERBOSITY: "error"
+        run: |
+          cd test
+          python3 -m pytest registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py -v --timeout=3600
+          python3 -m pytest registered/ascend/basic_function/pr/test_npu_expert_distribution_recorder_mode.py -v --timeout=3600
+          python3 -m pytest registered/ascend/basic_function/pr/test_npu_moe_a2a_backend.py -v --timeout=3600

--- a/test/registered/ascend/basic_function/expert_parallelism/test_npu_eplb_dispatch_algorithm.py
+++ b/test/registered/ascend/basic_function/expert_parallelism/test_npu_eplb_dispatch_algorithm.py
@@ -1,0 +1,86 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-16-npu-a3", nightly=True)
+
+
+class TestEPLBDispatchAlgorithmStatic(CustomTestCase):
+    """Testcase: Verify that the model accuracy remains uncompromised when the parameter --moe-dense-tp-size is configured to 1.
+
+    [Test Category] Parameter
+    [Test Target] --ep-dispatch-algorithm, --moe-a2a-backend
+    """
+
+    model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+    ep_dispatch_algorithm = "static"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.process = popen_launch_server(
+            cls.model,
+            DEFAULT_URL_FOR_TEST,
+            DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                "0.5",
+                "--tp-size",
+                "8",
+                "--expert-parallel-size",
+                "2",
+                "--enable-eplb",
+                "--ep-num-redundant-experts",
+                "4",
+                "--ep-dispatch-algorithm",
+                cls.ep_dispatch_algorithm,
+            ],
+            env={
+                "SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT": "1",
+                "HCCL_BUFFSIZE": "1024",
+                "SGLANG_NPU_FUSED_MOE_MODE": "1",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            max_new_tokens=512,
+            base_url=DEFAULT_URL_FOR_TEST,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            num_examples=200,
+            num_threads=128,
+            num_shots=5,
+        )
+        metrics = run_eval(args)
+        self.assertGreater(metrics["score"], 0.79)
+
+
+class TestEPLBDispatchAlgorithmDynamic(TestEPLBDispatchAlgorithmStatic):
+    ep_dispatch_algorithm = "dynamic"
+
+
+class TestEPLBDispatchAlgorithmFake(TestEPLBDispatchAlgorithmStatic):
+    ep_dispatch_algorithm = "fake"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/expert_parallelism/test_npu_eplb_dispatch_algorithm.py
+++ b/test/registered/ascend/basic_function/expert_parallelism/test_npu_eplb_dispatch_algorithm.py
@@ -21,7 +21,6 @@ class TestEPLBDispatchAlgorithmStatic(CustomTestCase):
     [Test Category] Parameter
     [Test Target] --ep-dispatch-algorithm, --moe-a2a-backend
     """
-
     model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
     ep_dispatch_algorithm = "static"
 
@@ -37,9 +36,9 @@ class TestEPLBDispatchAlgorithmStatic(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                "0.5",
+                "0.8",
                 "--tp-size",
-                "8",
+                "2",
                 "--expert-parallel-size",
                 "2",
                 "--enable-eplb",
@@ -47,6 +46,7 @@ class TestEPLBDispatchAlgorithmStatic(CustomTestCase):
                 "4",
                 "--ep-dispatch-algorithm",
                 cls.ep_dispatch_algorithm,
+
             ],
             env={
                 "SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT": "1",

--- a/test/registered/ascend/basic_function/expert_parallelism/test_npu_expert_distribution_recorder_mode.py
+++ b/test/registered/ascend/basic_function/expert_parallelism/test_npu_expert_distribution_recorder_mode.py
@@ -1,0 +1,131 @@
+import glob
+import os
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH,
+    run_command,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-16-npu-a3", nightly=True)
+
+
+class TestExpertDistributionRecorderModeStatic(CustomTestCase):
+    """Testcase: Verify that the model accuracy remains uncompromised when the parameter --moe-dense-tp-size is configured to 1.
+
+    [Test Category] Parameter
+    [Test Target] --expert-distribution-recorder-mode
+    """
+
+    expert_distribution_recorder_mode = "stat"
+
+    path = "/tmp/pt"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.process = popen_launch_server(
+            DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH,
+            DEFAULT_URL_FOR_TEST,
+            DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                "0.5",
+                "--tp-size",
+                "2",
+                "--expert-parallel-size",
+                "2",
+                "--enable-eplb",
+                "--moe-a2a-backend",
+                "deepep",
+                "--deepep-mode",
+                "normal",
+                "--ep-num-redundant-experts",
+                "4",
+                "--expert-distribution-recorder-mode",
+                cls.expert_distribution_recorder_mode,
+                "--base-gpu-id",
+                "12",
+            ],
+            env={
+                "SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT": "1",
+                "HCCL_BUFFSIZE": "1024",
+                "SGLANG_EXPERT_DISTRIBUTION_RECORDER_DIR": f"{cls.path}",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+        run_command(f"rm -rf {cls.path}")
+
+    def test_recorder_mode(self):
+        # Start recording
+        requests.post(f"{DEFAULT_URL_FOR_TEST}/start_expert_distribution_record")
+
+        response = requests.post(
+            f"{DEFAULT_URL_FOR_TEST}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                },
+            },
+        )
+        self.assertEqual(
+            response.status_code, 200, "The request status code is not 200."
+        )
+        self.assertIn(
+            "Paris", response.text, "The inference result does not include Paris."
+        )
+
+        # Stop recording
+        requests.post(f"{DEFAULT_URL_FOR_TEST}/stop_expert_distribution_record")
+
+        # Export the .pt file
+        requests.post(f"{DEFAULT_URL_FOR_TEST}/dump_expert_distribution_record")
+
+        # Check distribution_recorder_files
+        distribution_recorder_suffixes = "*.pt"
+        distribution_recorder_files = []
+        for suffix in distribution_recorder_suffixes:
+            distribution_recorder_files.extend(
+                glob.glob(os.path.join(self.path, "**", suffix), recursive=True)
+            )
+        self.assertGreater(
+            len(distribution_recorder_files),
+            0,
+            msg=f"No distribution recorder",
+        )
+
+
+class TestExpertDistributionRecorderModeStatApprox(
+    TestExpertDistributionRecorderModeStatic
+):
+    expert_distribution_recorder_mode = "stat_approx"
+
+
+class TestExpertDistributionRecorderPerPass(TestExpertDistributionRecorderModeStatic):
+    expert_distribution_recorder_mode = "per_pass"
+
+
+class TestExpertDistributionRecorderPerToken(TestExpertDistributionRecorderModeStatic):
+    expert_distribution_recorder_mode = "per_token"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/expert_parallelism/test_npu_expert_distribution_recorder_mode.py
+++ b/test/registered/ascend/basic_function/expert_parallelism/test_npu_expert_distribution_recorder_mode.py
@@ -5,10 +5,8 @@ import unittest
 import requests
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ascend.test_ascend_utils import (
-    DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH,
-    run_command,
-)
+from sglang.test.ascend.test_ascend_utils import run_command
+from sglang.test.ascend.test_ascend_utils import DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -43,7 +41,7 @@ class TestExpertDistributionRecorderModeStatic(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                "0.5",
+                "0.8",
                 "--tp-size",
                 "2",
                 "--expert-parallel-size",
@@ -57,8 +55,6 @@ class TestExpertDistributionRecorderModeStatic(CustomTestCase):
                 "4",
                 "--expert-distribution-recorder-mode",
                 cls.expert_distribution_recorder_mode,
-                "--base-gpu-id",
-                "12",
             ],
             env={
                 "SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT": "1",
@@ -113,9 +109,7 @@ class TestExpertDistributionRecorderModeStatic(CustomTestCase):
         )
 
 
-class TestExpertDistributionRecorderModeStatApprox(
-    TestExpertDistributionRecorderModeStatic
-):
+class TestExpertDistributionRecorderModeStatApprox(TestExpertDistributionRecorderModeStatic):
     expert_distribution_recorder_mode = "stat_approx"
 
 

--- a/test/registered/ascend/basic_function/expert_parallelism/test_npu_moe_a2a_backend.py
+++ b/test/registered/ascend/basic_function/expert_parallelism/test_npu_moe_a2a_backend.py
@@ -1,0 +1,95 @@
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-16-npu-a3", nightly=True)
+
+
+class TestMoreRunnerBackendTriton(CustomTestCase):
+    """Testcase：Verify set --moe-a2a-backend, the inference request is successfully processed.
+
+    [Test Category] Parameter
+    [Test Target] --moe-a2a-backend
+    """
+
+    moe_runner_backend = "triton"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.process = popen_launch_server(
+            DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH,
+            DEFAULT_URL_FOR_TEST,
+            DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                "0.5",
+                "--tp-size",
+                "2",
+                "--ep",
+                "2",
+                # "--enable-eplb",
+                "--moe-a2a-backend",
+                "ascend_fuseep",  # It is incompatible with eplb
+                # "--moe-a2a-backend",
+                # "deepep",
+                # "--deepep-mode",
+                # "normal",
+                # "--ep-num-redundant-experts",
+                # "4",
+                # "--expert-distribution-recorder-buffer-size",
+                # "50",
+                # "--moe-runner-backend",
+                # cls.moe_runner_backend,
+                "--base-gpu-id",
+                "2",
+            ],
+            env={
+                "SGLANG_NPUDISABLE_ACL_FORMAT_WEIGHT": "1",
+                "HCCL_BUFFSIZE": "1024",
+                "SGLANG_NPU_FUSED_MOE_MODE": "1",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_moe_runner_backend(self):
+        response = requests.post(
+            f"{DEFAULT_URL_FOR_TEST}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                },
+            },
+        )
+        self.assertEqual(
+            response.status_code, 200, "The request status code is not 200."
+        )
+        self.assertIn(
+            "Paris", response.text, "The inference result does not include Paris."
+        )
+
+
+# class TestMoreRunnerBackendTritonDefault(TestMoreRunnerBackendTriton):
+#     moe_runner_backend = "auto"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/expert_parallelism/test_npu_moe_a2a_backend.py
+++ b/test/registered/ascend/basic_function/expert_parallelism/test_npu_moe_a2a_backend.py
@@ -36,7 +36,7 @@ class TestMoreRunnerBackendTriton(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                "0.5",
+                "0.8",
                 "--tp-size",
                 "2",
                 "--ep",
@@ -55,7 +55,7 @@ class TestMoreRunnerBackendTriton(CustomTestCase):
                 # "--moe-runner-backend",
                 # cls.moe_runner_backend,
                 "--base-gpu-id",
-                "2",
+                "0"
             ],
             env={
                 "SGLANG_NPUDISABLE_ACL_FORMAT_WEIGHT": "1",

--- a/test/registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py
+++ b/test/registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py
@@ -1,0 +1,86 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-16-npu-a3", nightly=True)
+
+
+class TestEPLBDispatchAlgorithmStatic(CustomTestCase):
+    """Testcase: Verify that the model accuracy remains uncompromised when the parameter --moe-dense-tp-size is configured to 1.
+
+    [Test Category] Parameter
+    [Test Target] --ep-dispatch-algorithm, --moe-a2a-backend
+    """
+    model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+    ep_dispatch_algorithm = "static"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.process = popen_launch_server(
+            cls.model,
+            DEFAULT_URL_FOR_TEST,
+            DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                "0.5",
+                "--tp-size",
+                "8",
+                "--expert-parallel-size",
+                "2",
+                "--enable-eplb",
+                "--ep-num-redundant-experts",
+                "4",
+                "--ep-dispatch-algorithm",
+                cls.ep_dispatch_algorithm,
+
+            ],
+            env={
+                "SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT": "1",
+                "HCCL_BUFFSIZE": "1024",
+                "SGLANG_NPU_FUSED_MOE_MODE": "1",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            max_new_tokens=512,
+            base_url=DEFAULT_URL_FOR_TEST,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            num_examples=200,
+            num_threads=128,
+            num_shots=5,
+        )
+        metrics = run_eval(args)
+        self.assertGreater(metrics["score"], 0.79)
+
+
+class TestEPLBDispatchAlgorithmDynamic(TestEPLBDispatchAlgorithmStatic):
+    ep_dispatch_algorithm = "dynamic"
+
+
+class TestEPLBDispatchAlgorithmFake(TestEPLBDispatchAlgorithmStatic):
+    ep_dispatch_algorithm = "fake"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py
+++ b/test/registered/ascend/basic_function/pr/test_npu_eplb_dispatch_algorithm.py
@@ -21,6 +21,7 @@ class TestEPLBDispatchAlgorithmStatic(CustomTestCase):
     [Test Category] Parameter
     [Test Target] --ep-dispatch-algorithm, --moe-a2a-backend
     """
+
     model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
     ep_dispatch_algorithm = "static"
 
@@ -46,7 +47,6 @@ class TestEPLBDispatchAlgorithmStatic(CustomTestCase):
                 "4",
                 "--ep-dispatch-algorithm",
                 cls.ep_dispatch_algorithm,
-
             ],
             env={
                 "SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT": "1",

--- a/test/registered/ascend/basic_function/pr/test_npu_expert_distribution_recorder_mode.py
+++ b/test/registered/ascend/basic_function/pr/test_npu_expert_distribution_recorder_mode.py
@@ -1,0 +1,127 @@
+import glob
+import os
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import run_command
+from sglang.test.ascend.test_ascend_utils import DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-16-npu-a3", nightly=True)
+
+
+class TestExpertDistributionRecorderModeStatic(CustomTestCase):
+    """Testcase: Verify that the model accuracy remains uncompromised when the parameter --moe-dense-tp-size is configured to 1.
+
+    [Test Category] Parameter
+    [Test Target] --expert-distribution-recorder-mode
+    """
+
+    expert_distribution_recorder_mode = "stat"
+
+    path = "/tmp/pt"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.process = popen_launch_server(
+            DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH,
+            DEFAULT_URL_FOR_TEST,
+            DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                "0.5",
+                "--tp-size",
+                "2",
+                "--expert-parallel-size",
+                "2",
+                "--enable-eplb",
+                "--moe-a2a-backend",
+                "deepep",
+                "--deepep-mode",
+                "normal",
+                "--ep-num-redundant-experts",
+                "4",
+                "--expert-distribution-recorder-mode",
+                cls.expert_distribution_recorder_mode,
+                "--base-gpu-id",
+                "12",
+            ],
+            env={
+                "SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT": "1",
+                "HCCL_BUFFSIZE": "1024",
+                "SGLANG_EXPERT_DISTRIBUTION_RECORDER_DIR": f"{cls.path}",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+        run_command(f"rm -rf {cls.path}")
+
+    def test_recorder_mode(self):
+        # Start recording
+        requests.post(f"{DEFAULT_URL_FOR_TEST}/start_expert_distribution_record")
+
+        response = requests.post(
+            f"{DEFAULT_URL_FOR_TEST}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                },
+            },
+        )
+        self.assertEqual(
+            response.status_code, 200, "The request status code is not 200."
+        )
+        self.assertIn(
+            "Paris", response.text, "The inference result does not include Paris."
+        )
+
+        # Stop recording
+        requests.post(f"{DEFAULT_URL_FOR_TEST}/stop_expert_distribution_record")
+
+        # Export the .pt file
+        requests.post(f"{DEFAULT_URL_FOR_TEST}/dump_expert_distribution_record")
+
+        # Check distribution_recorder_files
+        distribution_recorder_suffixes = "*.pt"
+        distribution_recorder_files = []
+        for suffix in distribution_recorder_suffixes:
+            distribution_recorder_files.extend(
+                glob.glob(os.path.join(self.path, "**", suffix), recursive=True)
+            )
+        self.assertGreater(
+            len(distribution_recorder_files),
+            0,
+            msg=f"No distribution recorder",
+        )
+
+
+class TestExpertDistributionRecorderModeStatApprox(TestExpertDistributionRecorderModeStatic):
+    expert_distribution_recorder_mode = "stat_approx"
+
+
+class TestExpertDistributionRecorderPerPass(TestExpertDistributionRecorderModeStatic):
+    expert_distribution_recorder_mode = "per_pass"
+
+
+class TestExpertDistributionRecorderPerToken(TestExpertDistributionRecorderModeStatic):
+    expert_distribution_recorder_mode = "per_token"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/pr/test_npu_expert_distribution_recorder_mode.py
+++ b/test/registered/ascend/basic_function/pr/test_npu_expert_distribution_recorder_mode.py
@@ -5,8 +5,10 @@ import unittest
 import requests
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ascend.test_ascend_utils import run_command
-from sglang.test.ascend.test_ascend_utils import DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+from sglang.test.ascend.test_ascend_utils import (
+    DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH,
+    run_command,
+)
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -111,7 +113,9 @@ class TestExpertDistributionRecorderModeStatic(CustomTestCase):
         )
 
 
-class TestExpertDistributionRecorderModeStatApprox(TestExpertDistributionRecorderModeStatic):
+class TestExpertDistributionRecorderModeStatApprox(
+    TestExpertDistributionRecorderModeStatic
+):
     expert_distribution_recorder_mode = "stat_approx"
 
 

--- a/test/registered/ascend/basic_function/pr/test_npu_moe_a2a_backend.py
+++ b/test/registered/ascend/basic_function/pr/test_npu_moe_a2a_backend.py
@@ -1,0 +1,95 @@
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-16-npu-a3", nightly=True)
+
+
+class TestMoreRunnerBackendTriton(CustomTestCase):
+    """Testcase：Verify set --moe-a2a-backend, the inference request is successfully processed.
+
+    [Test Category] Parameter
+    [Test Target] --moe-a2a-backend
+    """
+
+    moe_runner_backend = "triton"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.process = popen_launch_server(
+            DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH,
+            DEFAULT_URL_FOR_TEST,
+            DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                "0.5",
+                "--tp-size",
+                "2",
+                "--ep",
+                "2",
+                # "--enable-eplb",
+                "--moe-a2a-backend",
+                "ascend_fuseep",  # It is incompatible with eplb
+                # "--moe-a2a-backend",
+                # "deepep",
+                # "--deepep-mode",
+                # "normal",
+                # "--ep-num-redundant-experts",
+                # "4",
+                # "--expert-distribution-recorder-buffer-size",
+                # "50",
+                # "--moe-runner-backend",
+                # cls.moe_runner_backend,
+                "--base-gpu-id",
+                "2"
+            ],
+            env={
+                "SGLANG_NPUDISABLE_ACL_FORMAT_WEIGHT": "1",
+                "HCCL_BUFFSIZE": "1024",
+                "SGLANG_NPU_FUSED_MOE_MODE": "1",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_moe_runner_backend(self):
+        response = requests.post(
+            f"{DEFAULT_URL_FOR_TEST}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                },
+            },
+        )
+        self.assertEqual(
+            response.status_code, 200, "The request status code is not 200."
+        )
+        self.assertIn(
+            "Paris", response.text, "The inference result does not include Paris."
+        )
+
+
+# class TestMoreRunnerBackendTritonDefault(TestMoreRunnerBackendTriton):
+#     moe_runner_backend = "auto"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/pr/test_npu_moe_a2a_backend.py
+++ b/test/registered/ascend/basic_function/pr/test_npu_moe_a2a_backend.py
@@ -55,7 +55,7 @@ class TestMoreRunnerBackendTriton(CustomTestCase):
                 # "--moe-runner-backend",
                 # cls.moe_runner_backend,
                 "--base-gpu-id",
-                "2"
+                "2",
             ],
             env={
                 "SGLANG_NPUDISABLE_ACL_FORMAT_WEIGHT": "1",


### PR DESCRIPTION
This PR adds three test cases for NPU:

1. **test_npu_eplb_dispatch_algorithm.py**: Tests for EP dispatch algorithm with different modes (static/dynamic/fake)
2. **test_npu_expert_distribution_recorder_mode.py**: Tests for expert distribution recorder mode (stat/stat_approx/per_pass/per_token)
3. **test_npu_moe_a2a_backend.py**: Tests for MoE A2A backend

All tests are registered with @register_npu_ci decorator for nightly-16-npu-a3 suite.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->