### PR TITLE
Add LoRA Llama4 test case for NPU CI

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-4
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260515
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260520
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-4
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260515
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -64,12 +64,8 @@ jobs:
           export SGLANG_SET_CPU_AFFINITY=1
           echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
 
-          echo "Use sglang from image"
-          sglang_pkg_path=/sgl-workspace/sglang/python
-          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
-          mkdir -p ${ascend_test_util_path}
-          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
-          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+          echo "Install sglang from source"
+          export PYTHONPATH=${sglang_source_path}/python:$PYTHONPATH
 
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -3,7 +3,8 @@ name: Single Test (NPU)
 
 on:
   pull_request:
-    branches: [ testcases ]
+    branches:
+      - testcases
     paths:
       - ".github/workflows/single-test-npu.yml"
 
@@ -13,6 +14,7 @@ concurrency:
 
 jobs:
   single-node-poc:
+    name: single-node-poc
     runs-on: linux-aarch64-a3-4
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
@@ -30,33 +32,27 @@ jobs:
           SGLANG_USE_MODELSCOPE: true
           HF_ENDPOINT: https://hf-mirror.com
           SGLANG_IS_IN_CI: true
-          TRANSFORMERS_VERBOSITY: "error"
         shell: bash
         run: |
           sglang_source_path=$(pwd)
           echo "Source code path: ${sglang_source_path}"
           ln -sf ${sglang_source_path} /root/sglang
 
-          test_case="test/registered/ascend/basic_function/lora/test_npu_lora_llama4.py"
-          if [ ! -f "${sglang_source_path}/${test_case}" ]; then
-            echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
-            exit 1
-          fi
+          # Test cases
+          test_cases=(
+            "test/registered/ascend/basic_function/lora/test_npu_lora_llama4.py"
+          )
 
-          # prepare for output data
-          current_date=$(date +%Y%m%d)
-          test_data_output_path=/root/.cache/tests/output/accuracy/${current_date}
-          mkdir -p ${test_data_output_path}
-          tc_name=${test_case##*/}
-          tc_name=${tc_name%.*}
-          export METRICS_DATA_FILE=${test_data_output_path}/${tc_name}
-          mkdir -p ${METRICS_DATA_FILE}
-          echo "Metrics file path: ${METRICS_DATA_FILE}"
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
 
           # copy required file from our daily cache
           cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
-          # copy download through proxy
-          curl -o /tmp/test.jsonl -L https://gh-proxy.test.osinfra.cn/https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
 
           echo "scaling_governor performance num: \
             $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
@@ -79,13 +75,25 @@ jobs:
           source /usr/local/Ascend/cann/set_env.sh || true
           source /usr/local/Ascend/nnal/atb/set_env.sh || true
 
-          log_path="/root/.cache/tests/logs/log/${current_date}/${tc_name}/${HOSTNAME}"
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
           rm -rf ${log_path}
           mkdir -p ${log_path}
           echo "Log path: ${log_path}"
 
-          echo "Running test case ${test_case}"
-          python -u ${test_case}
-          echo "Finished test case ${test_case}"
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
 
           plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,91 @@
+name: Single Test (NPU)
+# test round 1: LoRA Llama4 test case
+
+on:
+  pull_request:
+    branches: [ testcases ]
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    runs-on: linux-aarch64-a3-4
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+          TRANSFORMERS_VERBOSITY: "error"
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          test_case="test/registered/ascend/basic_function/lora/test_npu_lora_llama4.py"
+          if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+            echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+            exit 1
+          fi
+
+          # prepare for output data
+          current_date=$(date +%Y%m%d)
+          test_data_output_path=/root/.cache/tests/output/accuracy/${current_date}
+          mkdir -p ${test_data_output_path}
+          tc_name=${test_case##*/}
+          tc_name=${tc_name%.*}
+          export METRICS_DATA_FILE=${test_data_output_path}/${tc_name}
+          mkdir -p ${METRICS_DATA_FILE}
+          echo "Metrics file path: ${METRICS_DATA_FILE}"
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          # copy download through proxy
+          curl -o /tmp/test.jsonl -L https://gh-proxy.test.osinfra.cn/https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          log_path="/root/.cache/tests/logs/log/${current_date}/${tc_name}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          echo "Running test case ${test_case}"
+          python -u ${test_case}
+          echo "Finished test case ${test_case}"
+
+          plog_path="/root/ascend/log/debug/plog"

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-4
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260520
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260528
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_llama4.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_llama4.py
@@ -24,7 +24,7 @@ class TestLoraBasicFunction(CustomTestCase):
     [Test Target] --enable-lora, --lora-path,
     """
 
-    lora_a = "/root/.cache/huggingface/hub/models--kingabzpro--Llama-4-Scout-17B-16E-Instruct-Medical-ChatBot"
+    lora_a = "/root/.cache/huggingface/hub/models--kingabzpro--Llama-4-Scout-17B-16E-Instruct-Medical-ChatBot/"
 
     @classmethod
     def setUpClass(cls):

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_llama4.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_llama4.py
@@ -1,0 +1,75 @@
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_4_SCOUT_17B_16E_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-4-npu-a3", nightly=True)
+
+
+class TestLoraBasicFunction(CustomTestCase):
+    """Testcase：Verify the use llama4 model with lora, inference request succeeded.
+
+    [Test Category] Parameter
+    [Test Target] --enable-lora, --lora-path,
+    """
+
+    lora_a = "/root/.cache/huggingface/hub/models--kingabzpro--Llama-4-Scout-17B-16E-Instruct-Medical-ChatBot"
+
+    @classmethod
+    def setUpClass(cls):
+        other_args = [
+            "--enable-lora",
+            "--lora-path",
+            f"lora_a={cls.lora_a}",
+            "--lora-target-modules",
+            "all",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--tp-size",
+            "4",
+            "--mem-fraction-static",
+            "0.9",
+            "--disable-radix-cache",
+        ]
+        cls.process = popen_launch_server(
+            LLAMA_4_SCOUT_17B_16E_INSTRUCT_WEIGHTS_PATH,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_lama4_lora(self):
+        response = requests.post(
+            f"{DEFAULT_URL_FOR_TEST}/generate",
+            json={
+                "text": "What medicine should be taken for a cold",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                },
+                "lora_path": "lora_a",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        print(response.json())
+        # self.assertIn("Paris", response.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a new test case for testing Llama-4 model with LoRA on Ascend NPU.

## Changes
- Add 	est_npu_lora_llama4.py for testing Llama-4 Scout model with LoRA adapter
- Add single-test-npu.yml workflow for PR CI testing

## Test Case Details
- Model: Llama-4-Scout-17B-16E-Instruct
- LoRA: Medical ChatBot LoRA adapter
- Test: Verify inference request with LoRA succeeds















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->