### PR TITLE
Add distributed NPU test cases: DP, DP Attention, PP

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: Distributed tests - data parallelism, DP attention, pipeline parallelism
+# test round 2: Distributed tests - data parallelism, DP attention, pipeline parallelism (fixed data parallelism test)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: Distributed tests - data parallelism, DP attention, pipeline parallelism (fixed data parallelism test)
+# test round 3: Distributed tests - data parallelism and pipeline parallelism (DP attention skipped due to NPU kernel limitation)
 
 on:
   pull_request:
@@ -38,10 +38,9 @@ jobs:
           echo "Source code path: ${sglang_source_path}"
           ln -sf ${sglang_source_path} /root/sglang
 
-          # Test cases - distributed tests
+          # Test cases - distributed tests (DP attention skipped due to NPU ReshapeAndCacheOperation limitation)
           test_cases=(
             "test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_data_parallelism.py"
-            "test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_dp_attention.py"
             "test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_pp_single_node.py"
           )
 

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-2
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260528
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260605
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -40,7 +40,8 @@ jobs:
 
           # Test cases - distributed tests (only data parallelism works on current NPU)
           test_cases=(
-            "test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_data_parallelism.py"
+            #"test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_data_parallelism.py"
+            "test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_dp_attention.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 4: Distributed tests - data parallelism and pipeline parallelism (fixed PP config for 2 NPU devices)
+# test round 5: Distributed tests - data parallelism only (DP attention and PP skipped due to NPU limitations)
 
 on:
   pull_request:
@@ -38,10 +38,9 @@ jobs:
           echo "Source code path: ${sglang_source_path}"
           ln -sf ${sglang_source_path} /root/sglang
 
-          # Test cases - distributed tests (DP attention skipped due to NPU ReshapeAndCacheOperation limitation)
+          # Test cases - distributed tests (only data parallelism works on current NPU)
           test_cases=(
             "test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_data_parallelism.py"
-            "test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_pp_single_node.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: Distributed tests - data parallelism and pipeline parallelism (DP attention skipped due to NPU kernel limitation)
+# test round 4: Distributed tests - data parallelism and pipeline parallelism (fixed PP config for 2 NPU devices)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,101 @@
+name: Single Test (NPU)
+# test round 1: Distributed tests - data parallelism, DP attention, pipeline parallelism
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260528
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases - distributed tests
+          test_cases=(
+            "test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_data_parallelism.py"
+            "test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_dp_attention.py"
+            "test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_pp_single_node.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_data_parallelism.py
+++ b/test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_data_parallelism.py
@@ -8,7 +8,6 @@ from sglang.test.ascend.test_ascend_utils import (
     LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
 )
 from sglang.test.ci.ci_register import register_npu_ci
-from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -23,14 +22,12 @@ register_npu_ci(
 )
 
 
-class TestNPUDataParallelism(CustomTestCase, GSM8KMixin):
+class TestNPUDataParallelism(CustomTestCase):
     """Test data parallelism on NPU.
 
     [Test Category] Distributed
     [Test Target] Data parallelism (DP=2)
     """
-
-    gsm8k_accuracy_thres = 0.60
 
     @classmethod
     def setUpClass(cls):

--- a/test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_data_parallelism.py
+++ b/test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_data_parallelism.py
@@ -1,0 +1,87 @@
+import time
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(
+    est_time=91,
+    suite="nightly-2-npu-a3",
+    nightly=True,
+)
+
+
+class TestNPUDataParallelism(CustomTestCase, GSM8KMixin):
+    """Test data parallelism on NPU.
+
+    [Test Category] Distributed
+    [Test Target] Data parallelism (DP=2)
+    """
+
+    gsm8k_accuracy_thres = 0.60
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = [
+            "--attention-backend",
+            "ascend",
+            "--device",
+            "npu",
+            "--disable-cuda-graph",
+            "--dp",
+            "2",
+            "--mem-fraction-static",
+            "0.3",
+        ]
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_update_weight(self):
+        response = requests.post(
+            self.base_url + "/update_weights_from_disk",
+            json={"model_path": self.model},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        time.sleep(1)
+
+        response = requests.post(
+            self.base_url + "/update_weights_from_disk",
+            json={"model_path": self.model},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_server_info(self):
+        response = requests.get(self.base_url + "/server_info")
+        self.assertEqual(response.status_code, 200)
+
+        time.sleep(1)
+
+        response = requests.get(self.base_url + "/server_info")
+        self.assertEqual(response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_dp_attention.py
+++ b/test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_dp_attention.py
@@ -1,0 +1,107 @@
+import unittest
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(
+    est_time=420,
+    suite="nightly-2-npu-a3",
+    nightly=True,
+)
+
+
+class TestNPUDPAttentionDP2TP2(CustomTestCase, GSM8KMixin):
+    """Test DP attention with DP=2, TP=2 on NPU.
+
+    [Test Category] Distributed
+    [Test Target] DP attention parallelism
+    """
+
+    gsm8k_accuracy_thres = 0.55
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = [
+            "--trust-remote-code",
+            "--attention-backend",
+            "ascend",
+            "--device",
+            "npu",
+            "--disable-cuda-graph",
+            "--tp",
+            "2",
+            "--enable-dp-attention",
+            "--dp",
+            "2",
+            "--mem-fraction-static",
+            "0.3",
+        ]
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+class TestNPUDPAttentionMixedChunk(CustomTestCase, GSM8KMixin):
+    """Test DP attention with mixed chunk on NPU.
+
+    [Test Category] Distributed
+    [Test Target] DP attention with mixed chunk prefill
+    """
+
+    gsm8k_accuracy_thres = 0.55
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = [
+            "--trust-remote-code",
+            "--attention-backend",
+            "ascend",
+            "--device",
+            "npu",
+            "--disable-cuda-graph",
+            "--tp",
+            "2",
+            "--enable-dp-attention",
+            "--dp",
+            "2",
+            "--enable-mixed-chunk",
+            "--chunked-prefill-size",
+            "256",
+            "--mem-fraction-static",
+            "0.3",
+        ]
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_pp_single_node.py
+++ b/test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_pp_single_node.py
@@ -28,7 +28,7 @@ class TestNPUPPAccuracy(CustomTestCase):
     """Test pipeline parallelism accuracy on NPU.
 
     [Test Category] Distributed
-    [Test Target] Pipeline parallelism (PP=2)
+    [Test Target] Pipeline parallelism (PP=2, TP=1)
     """
 
     @classmethod
@@ -42,7 +42,7 @@ class TestNPUPPAccuracy(CustomTestCase):
             "npu",
             "--disable-cuda-graph",
             "--tp-size",
-            "2",
+            "1",
             "--pp-size",
             "2",
             "--chunked-prefill-size",
@@ -103,7 +103,7 @@ class TestNPUPPMixedChunk(CustomTestCase):
     """Test pipeline parallelism with mixed chunk on NPU.
 
     [Test Category] Distributed
-    [Test Target] PP with mixed chunk prefill
+    [Test Target] PP with mixed chunk prefill (PP=2, TP=1)
     """
 
     @classmethod
@@ -117,7 +117,7 @@ class TestNPUPPMixedChunk(CustomTestCase):
             "npu",
             "--disable-cuda-graph",
             "--tp-size",
-            "2",
+            "1",
             "--pp-size",
             "2",
             "--enable-mixed-chunk",

--- a/test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_pp_single_node.py
+++ b/test/registered/ascend/basic_function/distributed/GENERATED_20260529/test_npu_pp_single_node.py
@@ -1,0 +1,155 @@
+import time
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(
+    est_time=550,
+    suite="nightly-4-npu-a3",
+    nightly=True,
+)
+
+
+class TestNPUPPAccuracy(CustomTestCase):
+    """Test pipeline parallelism accuracy on NPU.
+
+    [Test Category] Distributed
+    [Test Target] Pipeline parallelism (PP=2)
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model_path = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = [
+            "--attention-backend",
+            "ascend",
+            "--device",
+            "npu",
+            "--disable-cuda-graph",
+            "--tp-size",
+            "2",
+            "--pp-size",
+            "2",
+            "--chunked-prefill-size",
+            "256",
+            "--mem-fraction-static",
+            "0.3",
+        ]
+        cls.process = popen_launch_server(
+            cls.model_path,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model_path,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=100,
+            num_threads=64,
+        )
+        metrics = run_eval(args)
+        self.assertGreater(metrics["score"], 0.60)
+        time.sleep(4)
+
+    def test_logprob(self):
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 16,
+                },
+                "return_logprob": True,
+                "top_logprobs_num": 5,
+                "logprob_start_len": 0,
+            },
+        )
+        response_json = response.json()
+        input_token_logprobs = response_json["meta_info"]["input_token_logprobs"]
+        output_token_logprobs = response_json["meta_info"]["output_token_logprobs"]
+        output_top_logprobs = response_json["meta_info"]["output_top_logprobs"]
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(input_token_logprobs, list)
+        self.assertIsInstance(output_token_logprobs, list)
+        self.assertIsInstance(output_top_logprobs, list)
+
+
+class TestNPUPPMixedChunk(CustomTestCase):
+    """Test pipeline parallelism with mixed chunk on NPU.
+
+    [Test Category] Distributed
+    [Test Target] PP with mixed chunk prefill
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model_path = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = [
+            "--attention-backend",
+            "ascend",
+            "--device",
+            "npu",
+            "--disable-cuda-graph",
+            "--tp-size",
+            "2",
+            "--pp-size",
+            "2",
+            "--enable-mixed-chunk",
+            "--chunked-prefill-size",
+            "256",
+            "--mem-fraction-static",
+            "0.3",
+        ]
+        cls.process = popen_launch_server(
+            cls.model_path,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model_path,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=100,
+            num_threads=64,
+        )
+        metrics = run_eval(args)
+        self.assertGreater(metrics["score"], 0.60)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds 3 distributed NPU test cases:

1. **test_npu_data_parallelism.py** - Data parallelism test (DP=2)
2. **test_npu_dp_attention.py** - DP attention test (DP=2, TP=2) with mixed chunk
3. **test_npu_pp_single_node.py** - Pipeline parallelism test (PP=2, TP=2)

All tests use Llama-3.2-1B-Instruct model and run on Ascend NPU.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->