### PR TITLE
Add multi tokenizer and detokenizer test cases for NPU

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,100 @@
+name: Single Test (NPU)
+# test round 1: Multi tokenizer and detokenizer tests
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases - Multi tokenizer and detokenizer tests
+          test_cases=(
+            "test/registered/ascend/basic_function/model_tokenizer/GENERATED_20260529/test_npu_multi_tokenizer.py"
+            "test/registered/ascend/basic_function/model_tokenizer/GENERATED_20260529/test_npu_multi_detokenizer.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: Multi tokenizer and detokenizer tests
+# test round 2: Multi tokenizer and detokenizer tests - Updated docker image
 
 on:
   pull_request:
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-2
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260528
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/test/registered/ascend/basic_function/model_tokenizer/GENERATED_20260529/test_npu_multi_detokenizer.py
+++ b/test/registered/ascend/basic_function/model_tokenizer/GENERATED_20260529/test_npu_multi_detokenizer.py
@@ -1,0 +1,76 @@
+import unittest
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+    run_bench_serving,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestMultiDetokenizer(CustomTestCase):
+    """Test multi-detokenizer worker performance on NPU.
+
+    [Test Category] Performance
+    [Test Target] --tokenizer-worker-num; --detokenizer-worker-num; TTFT latency
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tokenizer-worker-num",
+                8,
+                "--detokenizer-worker-num",
+                4,
+                "--mem-fraction-static",
+                0.8,
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_multi_detokenizer_ttft(self):
+        res = run_bench_serving(
+            model=self.model,
+            num_prompts=100,
+            request_rate=1,
+            other_server_args=[
+                "--tokenizer-worker-num",
+                8,
+                "--detokenizer-worker-num",
+                4,
+                "--mem-fraction-static",
+                0.8,
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ],
+            dataset_name="random",
+            random_input_len=1024,
+            random_output_len=128,
+        )
+        self.assertLess(res["median_ttft_ms"], 200)
+        self.assertLess(res["median_itl_ms"], 20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/model_tokenizer/GENERATED_20260529/test_npu_multi_tokenizer.py
+++ b/test/registered/ascend/basic_function/model_tokenizer/GENERATED_20260529/test_npu_multi_tokenizer.py
@@ -1,0 +1,72 @@
+import unittest
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+    run_bench_serving,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestMultiTokenizer(CustomTestCase):
+    """Test multi-tokenizer worker performance on NPU.
+
+    [Test Category] Performance
+    [Test Target] --tokenizer-worker-num; TTFT latency
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tokenizer-worker-num",
+                8,
+                "--mem-fraction-static",
+                0.8,
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_multi_tokenizer_ttft(self):
+        res = run_bench_serving(
+            model=self.model,
+            num_prompts=100,
+            request_rate=1,
+            other_server_args=[
+                "--tokenizer-worker-num",
+                8,
+                "--mem-fraction-static",
+                0.8,
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ],
+            dataset_name="random",
+            random_input_len=1024,
+            random_output_len=128,
+        )
+        self.assertLess(res["median_ttft_ms"], 200)
+        self.assertLess(res["median_itl_ms"], 20)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds two NPU test cases for tokenizer and detokenizer performance testing:

- test_npu_multi_tokenizer.py: Tests multi-tokenizer worker performance with 8 workers
- test_npu_multi_detokenizer.py: Tests multi-detokenizer worker performance with 8 tokenizer workers and 4 detokenizer workers

Both tests verify TTFT latency requirements on Ascend NPU.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->