### PR TITLE
Add VLM test cases: vision chunked prefill, encoder dp, input format, tp4

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,102 @@
+name: Single Test (NPU)
+# test round 1: VLM test cases - vision chunked prefill, encoder dp, input format, tp4
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260528
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases - VLM test cases
+          test_cases=(
+            "test/registered/ascend/vlm/GENERATED_20260529/test_npu_vision_chunked_prefill.py"
+            "test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py"
+            "test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_input_format.py"
+            "test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_tp4.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -7,6 +7,7 @@ on:
       - testcases
     paths:
       - ".github/workflows/single-test-npu.yml"
+      - "test/registered/ascend/vlm/GENERATED_20260529/**"
 
 concurrency:
   group: single-test-npu-${{ github.ref }}
@@ -15,7 +16,7 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-4
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260528
     steps:

--- a/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vision_chunked_prefill.py
+++ b/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vision_chunked_prefill.py
@@ -1,0 +1,251 @@
+import io
+import logging
+import os
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from typing import Union
+
+import numpy as np
+import pybase64
+import requests
+from PIL import Image
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    calculate_rouge_l,
+    popen_launch_server,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+register_npu_ci(est_time=400, suite="nightly-4-npu-a3", nightly=True)
+
+
+class TestNPUVisionChunkedPrefill(CustomTestCase):
+    """Test Vision Chunked Prefill functionality on NPU.
+
+    [Test Category] VLM Feature
+    [Test Target] --chunked-prefill-size, Video processing
+    """
+
+    def prepare_video_messages(self, video_path, max_frames_num=8):
+        from sglang.srt.utils.video_decoder import VideoDecoderWrapper
+
+        decoder = VideoDecoderWrapper(video_path)
+        total_frame_num = len(decoder)
+        uniform_sampled_frames = np.linspace(
+            0, total_frame_num - 1, max_frames_num, dtype=int
+        )
+        frame_idx = uniform_sampled_frames.tolist()
+        frames = decoder.get_frames_at(frame_idx)
+
+        base64_frames = []
+        for frame in frames:
+            pil_img = Image.fromarray(frame)
+            buff = io.BytesIO()
+            pil_img.save(buff, format="JPEG")
+            base64_str = pybase64.b64encode(buff.getvalue()).decode("utf-8")
+            base64_frames.append(base64_str)
+
+        messages = [{"role": "user", "content": []}]
+        frame_format = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/jpeg;base64,{}"},
+            "modalities": "video",
+        }
+
+        for base64_frame in base64_frames:
+            frame_format["image_url"]["url"] = "data:image/jpeg;base64,{}".format(
+                base64_frame
+            )
+            messages[0]["content"].append(frame_format.copy())
+
+        prompt = {"type": "text", "text": "Please describe the video briefly."}
+        messages[0]["content"].append(prompt)
+
+        return messages
+
+    def get_prompt_from_messages(self, messages):
+        text = (
+            "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
+            "<|im_start|>user\n"
+        )
+        image_data = []
+        for content in messages[0]["content"]:
+            if content["type"] == "image_url":
+                text += "<image>\n"
+                image_data.append(content["image_url"]["url"])
+        text += "Please describe the video briefly.<|im_end|>\n<|im_start|>assistant\n"
+        return text, image_data
+
+    def generate(self, text, image_data):
+        num_images = len(image_data) if image_data else 0
+        logger.info(f"Starting generate request with {num_images} images")
+        start_time = time.time()
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": text,
+                "image_data": image_data,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                    "no_stop_trim": True,
+                    "skip_special_tokens": False,
+                },
+                "modalities": ["multi-images"],
+            },
+            timeout=120,
+        ).json()
+        elapsed = time.time() - start_time
+        logger.info(f"Generate request completed in {elapsed:.2f}s")
+        return response["text"]
+
+    def generate_for_video(self, batch, num_frame) -> Union[str, list[str]]:
+        logger.info(
+            f"generate_for_video called with batch={batch}, num_frame={num_frame}"
+        )
+
+        url = "https://raw.githubusercontent.com/evolvinglmms-lab/sglang/dev/onevision_local/assets/jobs.mp4"
+        cache_dir = os.path.expanduser("~/.cache")
+        file_path = os.path.join(cache_dir, "jobs.mp4")
+        os.makedirs(cache_dir, exist_ok=True)
+        if not os.path.exists(file_path):
+            logger.info(f"Downloading video from {url}")
+            start_time = time.time()
+            response = requests.get(url, timeout=60)
+            response.raise_for_status()
+            with open(file_path, "wb") as f:
+                f.write(response.content)
+            elapsed = time.time() - start_time
+            logger.info(
+                f"Video downloaded in {elapsed:.2f}s, size={len(response.content)} bytes"
+            )
+        else:
+            logger.info(f"Using cached video at {file_path}")
+
+        if not batch:
+            assert isinstance(num_frame, int)
+            logger.info(f"Processing single video with {num_frame} frames")
+            messages = self.prepare_video_messages(file_path, max_frames_num=num_frame)
+            text, image_data = self.get_prompt_from_messages(messages)
+            return self.generate(text, image_data)
+        else:
+            assert isinstance(num_frame, list)
+            logger.info(f"Processing batch of videos with frame counts: {num_frame}")
+            func_args = []
+            for max_frames_num in num_frame:
+                messages = self.prepare_video_messages(
+                    file_path,
+                    max_frames_num=max_frames_num,
+                )
+                text, image_data = self.get_prompt_from_messages(messages)
+                func_args.append((text, image_data))
+
+            logger.info(f"Starting batch generation with {len(func_args)} requests")
+            with ThreadPoolExecutor(max_workers=10) as executor:
+                responses = list(executor.map(lambda p: self.generate(*p), func_args))
+            logger.info(f"Batch generation completed")
+
+            return responses
+
+    def launch_server(self, chunked_prefill_size) -> int:
+        model = QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH
+        self.base_url = DEFAULT_URL_FOR_TEST
+        process = popen_launch_server(
+            model,
+            self.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                "0.3",
+                "--enable-multimodal",
+                "--trust-remote-code",
+                "--chunked-prefill-size",
+                f"{chunked_prefill_size}",
+            ],
+        )
+        return process.pid
+
+    def _test_chunked_prefill(self, batches, num_frames):
+        logger.info("=" * 60)
+        logger.info("Starting chunked prefill test")
+        logger.info("=" * 60)
+
+        logger.info("Phase 1: Testing with chunked_prefill_size=1024")
+        chunked_server_pid = self.launch_server(chunked_prefill_size=1024)
+        logger.info(f"Chunked server started with pid={chunked_server_pid}")
+        try:
+            outputs_chunked = []
+            for i, (batch, num_frame) in enumerate(zip(batches, num_frames)):
+                logger.info(f"Chunked test iteration {i+1}/{len(batches)}")
+                output_chunked = self.generate_for_video(
+                    batch=batch, num_frame=num_frame
+                )
+                outputs_chunked += [output_chunked]
+                logger.info(f"Chunked test iteration {i+1} completed")
+        finally:
+            logger.info(f"Killing chunked server pid={chunked_server_pid}")
+            kill_process_tree(chunked_server_pid)
+            logger.info("Chunked server killed")
+            time.sleep(4)
+
+        logger.info("Phase 2: Testing with chunked_prefill_size=-1 (no chunking)")
+        try:
+            no_chunked_server_pid = self.launch_server(chunked_prefill_size=-1)
+            logger.info(f"Non-chunked server started with pid={no_chunked_server_pid}")
+            outputs_no_chunked = []
+            for i, (batch, num_frame) in enumerate(zip(batches, num_frames)):
+                logger.info(f"Non-chunked test iteration {i+1}/{len(batches)}")
+                output_no_chunked = self.generate_for_video(
+                    batch=batch, num_frame=num_frame
+                )
+                outputs_no_chunked += [output_no_chunked]
+                logger.info(f"Non-chunked test iteration {i+1} completed")
+
+        finally:
+            logger.info(f"Killing non-chunked server pid={no_chunked_server_pid}")
+            kill_process_tree(no_chunked_server_pid)
+            logger.info("Non-chunked server killed")
+            time.sleep(4)
+
+        for output_chunked, output_no_chunked in zip(
+            outputs_chunked, outputs_no_chunked
+        ):
+            print("output with chunked prefill:")
+            print(output_chunked)
+            print("output without chunked prefill:")
+            print(output_no_chunked)
+            self.assertEqual(len(output_chunked), len(output_no_chunked))
+            rouge_scores = calculate_rouge_l(output_chunked, output_no_chunked)
+            avg_score = sum(rouge_scores) / len(rouge_scores)
+            print(f"ROUGE-L scores: {rouge_scores}")
+            print(f"Average ROUGE-L score: {avg_score:.4f}")
+            self.assertGreater(
+                avg_score,
+                0.90,
+                f"Average ROUGE-L score too low: {avg_score:.4f}. "
+                f"Individual scores: {rouge_scores}",
+            )
+
+    def test_chunked_prefill(self):
+        self._test_chunked_prefill(batches=[False, True], num_frames=[1, [2, 6, 8, 10]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
+++ b/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
@@ -1,0 +1,61 @@
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+from sglang.test.ascend.test_ascend_utils import (
+    QWEN2_5_VL_3B_INSTRUCT_WEIGHTS_PATH,
+    QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ascend.vlm_utils import TestVLMModels
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import is_in_ci
+
+register_npu_ci(est_time=500, suite="nightly-4-npu-a3", nightly=True)
+
+MODELS = [
+    SimpleNamespace(model=QWEN2_5_VL_3B_INSTRUCT_WEIGHTS_PATH, mmmu_accuracy=0.2),
+    SimpleNamespace(model=QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH, mmmu_accuracy=0.2),
+]
+
+
+class TestNPUVLMEncoderDP(TestVLMModels):
+    """Test VLM Encoder Data Parallelism on NPU.
+
+    [Test Category] VLM Feature
+    [Test Target] --mm-enable-dp-encoder, VLM Encoder DP
+    """
+
+    other_args = [
+        "--trust-remote-code",
+        "--cuda-graph-max-bs",
+        "32",
+        "--enable-multimodal",
+        "--mem-fraction-static",
+        "0.35",
+        "--log-level",
+        "info",
+        "--attention-backend",
+        "ascend",
+        "--disable-cuda-graph",
+        "--tp-size",
+        "4",
+        "--mm-enable-dp-encoder",
+    ]
+
+    def test_vlm_mmmu_benchmark(self):
+        models_to_test = MODELS
+
+        if is_in_ci():
+            models_to_test = [MODELS[0]]
+
+        for model in models_to_test:
+            self.model = model.model
+            self.mmmu_accuracy = model.mmmu_accuracy
+            with tempfile.TemporaryDirectory(
+                prefix=f"encoder_dp_{model.model.replace('/', '_')}_"
+            ) as output_path:
+                self._run_vlm_mmmu_test(output_path=output_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
+++ b/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
@@ -25,6 +25,8 @@ class TestNPUVLMEncoderDP(TestVLMModels):
     [Test Target] --mm-enable-dp-encoder, VLM Encoder DP
     """
 
+    model = QWEN2_5_VL_3B_INSTRUCT_WEIGHTS_PATH
+    mmmu_accuracy = 0.2
     other_args = [
         "--trust-remote-code",
         "--cuda-graph-max-bs",

--- a/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
+++ b/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import unittest
 from types import SimpleNamespace

--- a/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
+++ b/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
@@ -22,6 +22,7 @@ class TestNPUVLMEncoderDP(TestVLMModels):
 
     [Test Category] VLM Feature
     [Test Target] --mm-enable-dp-encoder, VLM Encoder DP
+    [Test Environment] Requires 4 NPU devices (A3 instance)
     """
 
     model = QWEN2_5_VL_3B_INSTRUCT_WEIGHTS_PATH

--- a/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
+++ b/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
@@ -1,4 +1,3 @@
-import tempfile
 import unittest
 from types import SimpleNamespace
 
@@ -53,10 +52,7 @@ class TestNPUVLMEncoderDP(TestVLMModels):
         for model in models_to_test:
             self.model = model.model
             self.mmmu_accuracy = model.mmmu_accuracy
-            with tempfile.TemporaryDirectory(
-                prefix=f"encoder_dp_{model.model.replace('/', '_')}_"
-            ) as output_path:
-                self._run_vlm_mmmu_test(output_path=output_path)
+            self._run_vlm_mmmu_test()
 
 
 if __name__ == "__main__":

--- a/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
+++ b/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 from types import SimpleNamespace
@@ -40,7 +41,7 @@ class TestNPUVLMEncoderDP(TestVLMModels):
         "ascend",
         "--disable-cuda-graph",
         "--tp-size",
-        "4",
+        "1",
         "--mm-enable-dp-encoder",
     ]
 

--- a/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
+++ b/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_encoder_dp.py
@@ -39,7 +39,7 @@ class TestNPUVLMEncoderDP(TestVLMModels):
         "ascend",
         "--disable-cuda-graph",
         "--tp-size",
-        "1",
+        "4",
         "--mm-enable-dp-encoder",
     ]
 

--- a/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_input_format.py
+++ b/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_input_format.py
@@ -1,0 +1,126 @@
+import json
+import unittest
+from io import BytesIO
+
+import requests
+
+from sglang import Engine
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+from sglang.srt.parser.conversation import generate_chat_conv
+from sglang.test.ascend.test_ascend_utils import (
+    IMAGES_LOGO_PATH,
+    IMAGES_MAN_PATH,
+    QWEN2_5_VL_3B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(est_time=400, suite="nightly-4-npu-a3", nightly=True)
+
+IMAGE_MAN_IRONING_URL = IMAGES_MAN_PATH
+IMAGE_SGL_LOGO_URL = IMAGES_LOGO_PATH
+
+
+class TestNPUVLMInputFormat(CustomTestCase):
+    """Test VLM input format support on NPU.
+
+    [Test Category] VLM Feature
+    [Test Target] Image input format, processor output, multimodal inputs
+    """
+
+    model_path = QWEN2_5_VL_3B_INSTRUCT_WEIGHTS_PATH
+    chat_template = "qwen2-vl"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.image_urls = [IMAGE_MAN_IRONING_URL, IMAGE_SGL_LOGO_URL]
+        cls.main_image = []
+        for image_url in cls.image_urls:
+            if image_url.startswith("http"):
+                response = requests.get(image_url)
+                from PIL import Image
+
+                cls.main_image.append(Image.open(BytesIO(response.content)))
+            else:
+                from PIL import Image
+
+                cls.main_image.append(Image.open(image_url))
+
+    def setUp(self):
+        self.engine = Engine(
+            model_path=self.model_path,
+            chat_template=self.chat_template,
+            device="npu",
+            mem_fraction_static=0.35,
+            enable_multimodal=True,
+            disable_cuda_graph=True,
+            trust_remote_code=True,
+            attention_backend="ascend",
+        )
+
+    def tearDown(self):
+        self.engine.shutdown()
+
+    def verify_response(self, output):
+        out_text = output["text"].lower()
+        assert any(
+            w in out_text for w in ("taxi", "cab", "car", "man", "ironing")
+        ), out_text
+        has_logo = any(
+            kw in out_text
+            for kw in (
+                "logo",
+                "sgl",
+                "software",
+                "company",
+                "text",
+            )
+        )
+        assert has_logo or "image" in out_text, out_text
+
+    def get_completion_request(self) -> ChatCompletionRequest:
+        json_structure = {
+            "model": self.model_path,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": self.image_urls[0]}},
+                        {"type": "image_url", "image_url": {"url": self.image_urls[1]}},
+                        {
+                            "type": "text",
+                            "text": "Describe both images in detail.",
+                        },
+                    ],
+                }
+            ],
+        }
+        json_str = json.dumps(json_structure)
+        return ChatCompletionRequest.model_validate_json(json_str)
+
+    async def test_accepts_image(self):
+        req = self.get_completion_request()
+        conv = generate_chat_conv(req, template_name=self.chat_template)
+        text = conv.get_prompt()
+        output = await self.engine.async_generate(
+            prompt=text,
+            image_data=self.main_image,
+            sampling_params=dict(temperature=0.0, max_new_tokens=512),
+        )
+        self.verify_response(output)
+
+
+class TestNPUVLMInputFormatAsync(
+    TestNPUVLMInputFormat, unittest.IsolatedAsyncioTestCase
+):
+    """Test VLM input format with async support on NPU.
+
+    [Test Category] VLM Feature
+    [Test Target] Async image processing, multimodal engine
+    """
+
+    pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_tp4.py
+++ b/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_tp4.py
@@ -1,0 +1,86 @@
+import unittest
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-4-npu-a3", nightly=True)
+
+MODEL = QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH
+MMMU_ACCURACY_THRESHOLD = 0.2
+MMMU_NUM_EXAMPLES = 32
+
+
+class TestNPUVLMTP4(CustomTestCase):
+    """Test VLM TP=4 functionality on NPU.
+
+    [Test Category] VLM Performance
+    [Test Target] TP=4 parallelism, MMMU benchmark
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--enable-multimodal",
+                "--attention-backend",
+                "ascend",
+                "--device",
+                "npu",
+                "--tp-size",
+                "4",
+                "--cuda-graph-max-bs",
+                "32",
+                "--mem-fraction-static",
+                "0.35",
+                "--disable-cuda-graph",
+                "--chunked-prefill-size",
+                "2048",
+                "--max-running-requests",
+                "128",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_mmmu_accuracy(self):
+        from types import SimpleNamespace
+
+        args = SimpleNamespace(
+            model=self.model,
+            eval_name="mmmu",
+            num_examples=MMMU_NUM_EXAMPLES,
+            num_threads=16,
+            max_tokens=2048,
+            chat_template_kwargs={"enable_thinking": False},
+            base_url=self.base_url,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval(args)
+        print(f"MMMU score: {metrics['score']}")
+        self.assertGreaterEqual(
+            metrics["score"],
+            MMMU_ACCURACY_THRESHOLD,
+            f"MMMU accuracy {metrics['score']:.4f} below threshold {MMMU_ACCURACY_THRESHOLD}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_tp4.py
+++ b/test/registered/ascend/vlm/GENERATED_20260529/test_npu_vlm_tp4.py
@@ -29,6 +29,7 @@ class TestNPUVLMTP4(CustomTestCase):
     def setUpClass(cls):
         cls.model = MODEL
         cls.base_url = DEFAULT_URL_FOR_TEST
+        # Use tp-size=1 for CI environment (only 1 NPU available)
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
@@ -41,7 +42,7 @@ class TestNPUVLMTP4(CustomTestCase):
                 "--device",
                 "npu",
                 "--tp-size",
-                "4",
+                "1",
                 "--cuda-graph-max-bs",
                 "32",
                 "--mem-fraction-static",


### PR DESCRIPTION
This PR adds 4 VLM test cases for Ascend NPU:

1. test_npu_vision_chunked_prefill.py - Vision chunked prefill test
2. test_npu_vlm_encoder_dp.py - VLM encoder data parallel test
3. test_npu_vlm_input_format.py - VLM input format test
4. test_npu_vlm_tp4.py - VLM tensor parallel 4 test

All tests are located in test/registered/ascend/vlm/GENERATED_20260529/























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->