### PR TITLE
Add NPU bench serving functionality test case

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: NPU bench serving functionality test - fix gsp_group_distribution
+# test round 3: NPU bench serving functionality test - fix gsp_zipf_alpha
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 6: NPU bench serving functionality test - fix lint
+# test round 7: NPU bench serving functionality test - fix model name
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 4: NPU bench serving functionality test - set gsp_zipf_alpha to None
+# test round 5: NPU bench serving functionality test - debug custom headers
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 7: NPU bench serving functionality test - fix model name
+# test round 8: NPU bench serving functionality test - fix black format
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,99 @@
+name: Single Test (NPU)
+# test round 1: NPU bench serving functionality test
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260605
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases - 使用时替换为实际的测试用例路径
+          test_cases=(
+            "test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: NPU bench serving functionality test - fix gsp_zipf_alpha
+# test round 4: NPU bench serving functionality test - set gsp_zipf_alpha to None
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 5: NPU bench serving functionality test - debug custom headers
+# test round 6: NPU bench serving functionality test - fix lint
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 8: NPU bench serving functionality test - fix black format
+# test round 9: NPU bench serving functionality test - final cleanup
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: NPU bench serving functionality test
+# test round 2: NPU bench serving functionality test - fix gsp_group_distribution
 
 on:
   pull_request:

--- a/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
+++ b/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
@@ -151,7 +151,9 @@ class TestNpuBenchServingCustomHeaders(CustomTestCase):
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
                 if self.path == "/v1/models":
-                    self.wfile.write(json.dumps({"data": [{"id": "Qwen/Qwen3-0.6B"}]}).encode())
+                    self.wfile.write(
+                        json.dumps({"data": [{"id": "Qwen/Qwen3-0.6B"}]}).encode()
+                    )
                 elif self.path == "/generate":
                     self.wfile.write(
                         json.dumps(

--- a/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
+++ b/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
@@ -2,6 +2,7 @@ import json
 import tempfile
 import threading
 import time
+import traceback
 import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -184,7 +185,6 @@ class TestNpuBenchServingCustomHeaders(CustomTestCase):
             run_benchmark(args)
         except Exception as e:
             print(f"Benchmark failed: {e}")
-            import traceback
             traceback.print_exc()
         finally:
             server.shutdown()

--- a/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
+++ b/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
@@ -71,6 +71,7 @@ class TestNpuBenchServingFunctionality(CustomTestCase):
                     gsp_num_turns=NUM_TURNS,
                 )
                 args.warmup_requests = 0
+                args.gsp_group_distribution = "uniform"
                 res = run_benchmark(args)
                 self.assertEqual(res["completed"], NUM_CONVERSATIONS * NUM_TURNS)
 

--- a/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
+++ b/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
@@ -72,7 +72,7 @@ class TestNpuBenchServingFunctionality(CustomTestCase):
                 )
                 args.warmup_requests = 0
                 args.gsp_group_distribution = "uniform"
-                args.gsp_zipf_alpha = 1.5
+                args.gsp_zipf_alpha = None
                 res = run_benchmark(args)
                 self.assertEqual(res["completed"], NUM_CONVERSATIONS * NUM_TURNS)
 

--- a/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
+++ b/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
@@ -72,6 +72,7 @@ class TestNpuBenchServingFunctionality(CustomTestCase):
                 )
                 args.warmup_requests = 0
                 args.gsp_group_distribution = "uniform"
+                args.gsp_zipf_alpha = 1.5
                 res = run_benchmark(args)
                 self.assertEqual(res["completed"], NUM_CONVERSATIONS * NUM_TURNS)
 

--- a/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
+++ b/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
@@ -1,0 +1,204 @@
+import json
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+from sglang.bench_serving import run_benchmark
+from sglang.benchmark.utils import parse_custom_headers
+from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_0_6B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    get_benchmark_args,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=300, suite="nightly-1-npu-a3", nightly=True)
+
+MODEL = QWEN3_0_6B_WEIGHTS_PATH
+NUM_CONVERSATIONS, NUM_TURNS = 4, 3
+
+
+class TestNpuBenchServingFunctionality(CustomTestCase):
+    """Test bench_serving functionality on NPU.
+
+    [Test Category] Benchmark Functionality
+    [Test Target] bench_serving, multi-turn conversation, GSP dataset
+    """
+
+    def test_gsp_multi_turn(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            process = popen_launch_server(
+                MODEL,
+                DEFAULT_URL_FOR_TEST,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    "--attention-backend",
+                    "ascend",
+                    "--disable-cuda-graph",
+                    "--mem-fraction-static",
+                    "0.7",
+                    "--log-requests",
+                    "--log-requests-level",
+                    "3",
+                    "--log-requests-format",
+                    "json",
+                    "--log-requests-target",
+                    "stdout",
+                    temp_dir,
+                ],
+            )
+            try:
+                args = get_benchmark_args(
+                    base_url=DEFAULT_URL_FOR_TEST,
+                    backend="sglang-oai-chat",
+                    tokenizer=MODEL,
+                    dataset_name="generated-shared-prefix",
+                    num_prompts=NUM_CONVERSATIONS,
+                    request_rate=float("inf"),
+                    gsp_num_groups=2,
+                    gsp_prompts_per_group=2,
+                    gsp_system_prompt_len=64,
+                    gsp_question_len=16,
+                    gsp_output_len=16,
+                    gsp_num_turns=NUM_TURNS,
+                )
+                args.warmup_requests = 0
+                res = run_benchmark(args)
+                self.assertEqual(res["completed"], NUM_CONVERSATIONS * NUM_TURNS)
+
+                time.sleep(1)
+                logs = "".join(f.read_text() for f in Path(temp_dir).glob("*.log"))
+                self._verify_multi_turn_logs(logs)
+            finally:
+                kill_process_tree(process.pid)
+
+    def _verify_multi_turn_logs(self, content: str):
+        reqs = []
+        for line in content.splitlines():
+            idx = line.find("{")
+            if idx == -1:
+                continue
+            try:
+                obj = json.loads(line[idx:])
+            except json.JSONDecodeError:
+                continue
+            if obj.get("event") != "request.finished":
+                continue
+            text = obj.get("obj", {}).get("text")
+            rid = obj.get("rid", "")
+            if text and not rid.startswith(HEALTH_CHECK_RID_PREFIX):
+                reqs.append(text)
+
+        self.assertGreaterEqual(len(reqs), NUM_CONVERSATIONS * NUM_TURNS)
+
+        reqs_sorted = sorted(reqs, key=len)
+        prefix_count = 0
+        for i, text in enumerate(reqs_sorted):
+            for j in range(i + 1, len(reqs_sorted)):
+                if reqs_sorted[j].startswith(text):
+                    prefix_count += 1
+                    break
+
+        expected = NUM_CONVERSATIONS * (NUM_TURNS - 1)
+        self.assertGreaterEqual(
+            prefix_count, expected, f"Expected at least {expected} prefix pairs"
+        )
+
+
+class TestNpuBenchServingCustomHeaders(CustomTestCase):
+    """Test bench_serving custom headers on NPU.
+
+    [Test Category] Benchmark Functionality
+    [Test Target] custom headers parsing, HTTP request headers
+    """
+
+    def test_parse_custom_headers(self):
+        headers = parse_custom_headers(["MyHeader=MY_VALUE", "Another=value=hello"])
+        self.assertEqual(headers, {"MyHeader": "MY_VALUE", "Another": "value=hello"})
+
+        headers = parse_custom_headers(["InvalidNoEquals"])
+        self.assertEqual(headers, {})
+
+        headers = parse_custom_headers(["=NoKey"])
+        self.assertEqual(headers, {})
+
+    def test_custom_headers_sent_to_server(self):
+        import queue
+
+        received_requests = queue.Queue()
+
+        class HeaderEchoHandler(BaseHTTPRequestHandler):
+            def _handle(self):
+                received_requests.put(
+                    {
+                        "method": self.command,
+                        "path": self.path,
+                        "headers": dict(self.headers),
+                    }
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                if self.path == "/v1/models":
+                    self.wfile.write(json.dumps({"data": [{"id": "gpt2"}]}).encode())
+                elif self.path == "/generate":
+                    self.wfile.write(
+                        json.dumps(
+                            {"text": "ok", "meta_info": {"completion_tokens": 1}}
+                        ).encode()
+                    )
+                else:
+                    self.wfile.write(json.dumps({}).encode())
+
+            do_GET = do_POST = _handle
+
+        server = HTTPServer(("127.0.0.1", 0), HeaderEchoHandler)
+        port = server.server_address[1]
+        server_thread = threading.Thread(target=server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+
+        try:
+            args = get_benchmark_args(
+                base_url=f"http://127.0.0.1:{port}",
+                backend="sglang",
+                dataset_name="random",
+                tokenizer="gpt2",
+                num_prompts=1,
+                random_input_len=8,
+                random_output_len=8,
+                header=["X-Custom-Test=TestValue123", "X-Another=AnotherVal"],
+            )
+            args.warmup_requests = 0
+            args.disable_tqdm = True
+            run_benchmark(args)
+        except Exception:
+            pass
+        finally:
+            server.shutdown()
+
+        all_reqs = []
+        while not received_requests.empty():
+            all_reqs.append(received_requests.get_nowait())
+
+        generate_reqs = [r for r in all_reqs if r["path"] == "/generate"]
+        self.assertGreater(
+            len(generate_reqs),
+            0,
+            f"No /generate request. All: {[r['path'] for r in all_reqs]}",
+        )
+        headers = generate_reqs[0]["headers"]
+        self.assertEqual(headers.get("X-Custom-Test"), "TestValue123")
+        self.assertEqual(headers.get("X-Another"), "AnotherVal")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
+++ b/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
@@ -182,8 +182,10 @@ class TestNpuBenchServingCustomHeaders(CustomTestCase):
             args.warmup_requests = 0
             args.disable_tqdm = True
             run_benchmark(args)
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"Benchmark failed: {e}")
+            import traceback
+            traceback.print_exc()
         finally:
             server.shutdown()
 

--- a/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
+++ b/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
@@ -2,7 +2,6 @@ import json
 import tempfile
 import threading
 import time
-import traceback
 import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -185,9 +184,8 @@ class TestNpuBenchServingCustomHeaders(CustomTestCase):
             args.warmup_requests = 0
             args.disable_tqdm = True
             run_benchmark(args)
-        except Exception as e:
-            print(f"Benchmark failed: {e}")
-            traceback.print_exc()
+        except Exception:
+            pass
         finally:
             server.shutdown()
 

--- a/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
+++ b/test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
@@ -151,7 +151,7 @@ class TestNpuBenchServingCustomHeaders(CustomTestCase):
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
                 if self.path == "/v1/models":
-                    self.wfile.write(json.dumps({"data": [{"id": "gpt2"}]}).encode())
+                    self.wfile.write(json.dumps({"data": [{"id": "Qwen/Qwen3-0.6B"}]}).encode())
                 elif self.path == "/generate":
                     self.wfile.write(
                         json.dumps(
@@ -174,7 +174,7 @@ class TestNpuBenchServingCustomHeaders(CustomTestCase):
                 base_url=f"http://127.0.0.1:{port}",
                 backend="sglang",
                 dataset_name="random",
-                tokenizer="gpt2",
+                tokenizer=MODEL,
                 num_prompts=1,
                 random_input_len=8,
                 random_output_len=8,


### PR DESCRIPTION
This PR adds the NPU bench serving functionality test case.

- Test file: test/registered/ascend/bench_fn/GENERATED_20260529/test_npu_bench_serving_functionality.py
- Tests bench_serving functionality with multi-turn conversations and GSP dataset



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->