### PR TITLE
Add NPU model loading test cases

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,100 @@
+﻿name: Single Test (NPU)
+# test round 1: Model loading - external models and prefetch checkpoints
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260605
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases
+          test_cases=(
+              "test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py"
+              "test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 7: Model loading - external models and prefetch checkpoints (use 0.5B model)
+# test round 8: Model loading - external models and prefetch checkpoints (use GGUF model)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 11: Model loading - prefetch checkpoints only (revert to original config)
+# test round 12: Model loading - prefetch checkpoints only (add trust_remote_code)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 2: Model loading - external models and prefetch checkpoints (fix mem_fraction)
+# test round 3: Model loading - external models and prefetch checkpoints (fix mem_fraction to 0.8)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 12: Model loading - prefetch checkpoints only (add trust_remote_code)
+# test round 13: Model loading - both external models and prefetch checkpoints tests
 
 on:
   pull_request:
@@ -40,6 +40,7 @@ jobs:
 
           # Test cases
           test_cases=(
+              "test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py"
               "test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py"
           )
 

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 1: Model loading - external models and prefetch checkpoints
+# test round 2: Model loading - external models and prefetch checkpoints (fix mem_fraction)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 9: Model loading - external models and prefetch checkpoints (reduce memory usage)
+# test round 10: Model loading - prefetch checkpoints only
 
 on:
   pull_request:
@@ -40,7 +40,6 @@ jobs:
 
           # Test cases
           test_cases=(
-              "test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py"
               "test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py"
           )
 

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 6: Model loading - external models and prefetch checkpoints (use 4B model)
+# test round 7: Model loading - external models and prefetch checkpoints (use 0.5B model)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 4: Model loading - external models and prefetch checkpoints (fix mem_fraction to 0.9)
+# test round 5: Model loading - external models and prefetch checkpoints (fix mem_fraction to 0.95)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 10: Model loading - prefetch checkpoints only
+# test round 11: Model loading - prefetch checkpoints only (revert to original config)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 5: Model loading - external models and prefetch checkpoints (fix mem_fraction to 0.95)
+# test round 6: Model loading - external models and prefetch checkpoints (use 4B model)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 8: Model loading - external models and prefetch checkpoints (use GGUF model)
+# test round 9: Model loading - external models and prefetch checkpoints (reduce memory usage)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 ﻿name: Single Test (NPU)
-# test round 3: Model loading - external models and prefetch checkpoints (fix mem_fraction to 0.8)
+# test round 4: Model loading - external models and prefetch checkpoints (fix mem_fraction to 0.9)
 
 on:
   pull_request:

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
@@ -1,0 +1,40 @@
+import unittest
+
+import sglang as sgl
+from sglang.srt.environ import envs
+from sglang.test.ascend.test_ascend_utils import QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(est_time=45, suite="nightly-2-npu-a3", nightly=True)
+
+
+class TestNPUExternalModels(CustomTestCase):
+    """Test external model loading functionality on NPU.
+
+    [Test Category] Model Loading
+    [Test Target] External model package; Multimodal model loading
+    """
+
+    def test_external_model(self):
+        envs.SGLANG_EXTERNAL_MODEL_PACKAGE.set("sglang.test.external_models")
+        envs.SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE.set("sglang.test.external_models")
+        prompt = "Today is a sunny day and I like"
+        model_path = QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH
+
+        engine = sgl.Engine(
+            model_path=model_path,
+            attention_backend="ascend",
+            disable_cuda_graph=True,
+            mem_fraction_static=0.3,
+            max_total_tokens=64,
+            enable_multimodal=True,
+        )
+        out = engine.generate(prompt)["text"]
+        engine.shutdown()
+
+        self.assertGreater(len(out), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
@@ -26,7 +26,7 @@ class TestNPUExternalModels(CustomTestCase):
             model_path=model_path,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.3,
+            mem_fraction_static=0.6,
             max_total_tokens=64,
             enable_multimodal=True,
         )

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
@@ -2,7 +2,7 @@ import unittest
 
 import sglang as sgl
 from sglang.srt.environ import envs
-from sglang.test.ascend.test_ascend_utils import QWEN2_0_5B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ascend.test_ascend_utils import QWEN3_4B_GGUF_Q4_K_M_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -20,13 +20,13 @@ class TestNPUExternalModels(CustomTestCase):
         envs.SGLANG_EXTERNAL_MODEL_PACKAGE.set("sglang.test.external_models")
         envs.SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE.set("sglang.test.external_models")
         prompt = "Today is a sunny day and I like"
-        model_path = QWEN2_0_5B_INSTRUCT_WEIGHTS_PATH
+        model_path = QWEN3_4B_GGUF_Q4_K_M_WEIGHTS_PATH
 
         engine = sgl.Engine(
             model_path=model_path,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.6,
+            mem_fraction_static=0.4,
             max_total_tokens=64,
         )
         out = engine.generate(prompt)["text"]

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
@@ -26,8 +26,9 @@ class TestNPUExternalModels(CustomTestCase):
             model_path=model_path,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.45,
-            max_total_tokens=32,
+            mem_fraction_static=0.3,
+            max_total_tokens=512,
+            trust_remote_code=True,
         )
         out = engine.generate(prompt)["text"]
         engine.shutdown()

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
@@ -26,7 +26,7 @@ class TestNPUExternalModels(CustomTestCase):
             model_path=model_path,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.6,
+            mem_fraction_static=0.8,
             max_total_tokens=64,
             enable_multimodal=True,
         )

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
@@ -26,8 +26,8 @@ class TestNPUExternalModels(CustomTestCase):
             model_path=model_path,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.4,
-            max_total_tokens=64,
+            mem_fraction_static=0.45,
+            max_total_tokens=32,
         )
         out = engine.generate(prompt)["text"]
         engine.shutdown()

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
@@ -2,7 +2,7 @@ import unittest
 
 import sglang as sgl
 from sglang.srt.environ import envs
-from sglang.test.ascend.test_ascend_utils import QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ascend.test_ascend_utils import QWEN3_VL_4B_INSTRUCT_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -20,7 +20,7 @@ class TestNPUExternalModels(CustomTestCase):
         envs.SGLANG_EXTERNAL_MODEL_PACKAGE.set("sglang.test.external_models")
         envs.SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE.set("sglang.test.external_models")
         prompt = "Today is a sunny day and I like"
-        model_path = QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH
+        model_path = QWEN3_VL_4B_INSTRUCT_WEIGHTS_PATH
 
         engine = sgl.Engine(
             model_path=model_path,

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
@@ -26,7 +26,7 @@ class TestNPUExternalModels(CustomTestCase):
             model_path=model_path,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.8,
+            mem_fraction_static=0.9,
             max_total_tokens=64,
             enable_multimodal=True,
         )

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
@@ -2,7 +2,7 @@ import unittest
 
 import sglang as sgl
 from sglang.srt.environ import envs
-from sglang.test.ascend.test_ascend_utils import QWEN3_VL_4B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ascend.test_ascend_utils import QWEN2_0_5B_INSTRUCT_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -20,15 +20,14 @@ class TestNPUExternalModels(CustomTestCase):
         envs.SGLANG_EXTERNAL_MODEL_PACKAGE.set("sglang.test.external_models")
         envs.SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE.set("sglang.test.external_models")
         prompt = "Today is a sunny day and I like"
-        model_path = QWEN3_VL_4B_INSTRUCT_WEIGHTS_PATH
+        model_path = QWEN2_0_5B_INSTRUCT_WEIGHTS_PATH
 
         engine = sgl.Engine(
             model_path=model_path,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.95,
+            mem_fraction_static=0.6,
             max_total_tokens=64,
-            enable_multimodal=True,
         )
         out = engine.generate(prompt)["text"]
         engine.shutdown()

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_external_models.py
@@ -26,7 +26,7 @@ class TestNPUExternalModels(CustomTestCase):
             model_path=model_path,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.9,
+            mem_fraction_static=0.95,
             max_total_tokens=64,
             enable_multimodal=True,
         )

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
@@ -1,0 +1,55 @@
+import unittest
+
+import sglang as sgl
+from sglang.test.ascend.test_ascend_utils import (
+    QWEN3_4B_GGUF_Q4_K_M_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(est_time=150, suite="nightly-2-npu-a3", nightly=True)
+
+PROMPTS = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+
+
+class TestNPUPrefetchCheckpoints(CustomTestCase):
+    """Test checkpoint prefetch functionality on NPU.
+
+    [Test Category] Model Loading
+    [Test Target] --weight-loader-prefetch-checkpoints
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = sgl.Engine(
+            model_path=QWEN3_4B_GGUF_Q4_K_M_WEIGHTS_PATH,
+            tp_size=1,
+            attention_backend="ascend",
+            disable_cuda_graph=True,
+            mem_fraction_static=0.3,
+            weight_loader_prefetch_checkpoints=True,
+            cuda_graph_max_bs=1,
+            max_total_tokens=256,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "engine") and cls.engine:
+            cls.engine.shutdown()
+
+    def test_generate_with_prefetch(self):
+        outputs = self.engine.generate(PROMPTS)
+        self.assertEqual(len(outputs), len(PROMPTS))
+        for i, output in enumerate(outputs):
+            text = output["text"]
+            self.assertIsInstance(text, str)
+            self.assertGreater(len(text), 0, f"Prompt {i} produced empty output")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
@@ -31,7 +31,7 @@ class TestNPUPrefetchCheckpoints(CustomTestCase):
             tp_size=1,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.6,
+            mem_fraction_static=0.8,
             weight_loader_prefetch_checkpoints=True,
             cuda_graph_max_bs=1,
             max_total_tokens=256,

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
@@ -34,7 +34,8 @@ class TestNPUPrefetchCheckpoints(CustomTestCase):
             mem_fraction_static=0.3,
             weight_loader_prefetch_checkpoints=True,
             cuda_graph_max_bs=1,
-            max_total_tokens=256,
+            max_total_tokens=512,
+            trust_remote_code=True,
         )
 
     @classmethod

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
@@ -31,7 +31,7 @@ class TestNPUPrefetchCheckpoints(CustomTestCase):
             tp_size=1,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.3,
+            mem_fraction_static=0.6,
             weight_loader_prefetch_checkpoints=True,
             cuda_graph_max_bs=1,
             max_total_tokens=256,

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
@@ -31,7 +31,7 @@ class TestNPUPrefetchCheckpoints(CustomTestCase):
             tp_size=1,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.8,
+            mem_fraction_static=0.9,
             weight_loader_prefetch_checkpoints=True,
             cuda_graph_max_bs=1,
             max_total_tokens=256,

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
@@ -31,7 +31,7 @@ class TestNPUPrefetchCheckpoints(CustomTestCase):
             tp_size=1,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.9,
+            mem_fraction_static=0.95,
             weight_loader_prefetch_checkpoints=True,
             cuda_graph_max_bs=1,
             max_total_tokens=256,

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
@@ -31,10 +31,10 @@ class TestNPUPrefetchCheckpoints(CustomTestCase):
             tp_size=1,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.45,
+            mem_fraction_static=0.3,
             weight_loader_prefetch_checkpoints=True,
             cuda_graph_max_bs=1,
-            max_total_tokens=128,
+            max_total_tokens=256,
         )
 
     @classmethod

--- a/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
+++ b/test/registered/ascend/basic_function/model_loading/GENERATED_20260528/test_npu_prefetch_checkpoints.py
@@ -31,10 +31,10 @@ class TestNPUPrefetchCheckpoints(CustomTestCase):
             tp_size=1,
             attention_backend="ascend",
             disable_cuda_graph=True,
-            mem_fraction_static=0.95,
+            mem_fraction_static=0.45,
             weight_loader_prefetch_checkpoints=True,
             cuda_graph_max_bs=1,
-            max_total_tokens=256,
+            max_total_tokens=128,
         )
 
     @classmethod


### PR DESCRIPTION
This PR adds NPU test cases for model loading functionality:

- test_npu_external_models.py: Test external model package loading and multimodal models
- test_npu_prefetch_checkpoints.py: Test checkpoint prefetch functionality

Both tests are registered for the nightly-2-npu-a3 test suite.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->