### PR TITLE
testcases: add 3 NPU tests (piecewise CUDA graph VLM + elastic EP + hybrid DP/EP/TP/MTP)

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: piecewise CUDA graph VLM + elastic EP + hybrid DP/EP/TP/MTP (3 NPU tests)
+# test round 2: piecewise CUDA graph VLM + elastic EP + hybrid DP/EP/TP/MTP (3 NPU tests, runner upgraded to a3-16)
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-16
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260605
     steps:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: piecewise CUDA graph VLM + elastic EP + hybrid DP/EP/TP/MTP (3 NPU tests, runner upgraded to a3-16)
+# test round 3: piecewise CUDA graph VLM + elastic EP + hybrid DP/EP/TP/MTP (lowered mem-fraction-static to 0.75 to fix OOM)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: piecewise CUDA graph VLM + elastic EP + hybrid DP/EP/TP/MTP (lowered mem-fraction-static to 0.75 to fix OOM)
+# test round 4: piecewise CUDA graph VLM + elastic EP + hybrid DP/EP/TP/MTP (revert mem-fraction-static to 0.82)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,101 @@
+name: Single Test (NPU)
+# test round 1: piecewise CUDA graph VLM + elastic EP + hybrid DP/EP/TP/MTP (3 NPU tests)
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260605
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 240
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases - 使用时替换为实际的测试用例路径
+          test_cases=(
+            "test/registered/ascend/basic_function/optimization_debug/GENERATED_20260606/test_npu_piecewise_cuda_graph_vlm.py"
+            "test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_elastic_ep_hybrid_dp.py"
+            "test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_hybrid_dp_ep_tp_mtp.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/test/registered/ascend/basic_function/optimization_debug/GENERATED_20260606/test_npu_piecewise_cuda_graph_vlm.py
+++ b/test/registered/ascend/basic_function/optimization_debug/GENERATED_20260606/test_npu_piecewise_cuda_graph_vlm.py
@@ -1,0 +1,132 @@
+import os
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang import Engine
+from sglang.lang.chat_template import get_chat_template_by_model_path
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN2_5_VL_3B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_IMAGE_URL,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="stage-b-test-1-npu-a2", nightly=False)
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+NPU_ENV = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+}
+
+
+class TestNPUPiecewiseGraphQwen25VL(CustomTestCase):
+    """Test piecewise CUDA graph on NPU with Qwen2.5-VL-3B-Instruct VLM.
+
+    [Test Category] Piecewise Graph Optimization (VLM)
+    [Test Target] --enforce-piecewise-cuda-graph; --disable-radix-cache; ascend attention backend
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN2_5_VL_3B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--attention-backend",
+                "ascend",
+                "--enforce-piecewise-cuda-graph",
+                "--disable-radix-cache",
+                "--mem-fraction-static",
+                0.8,
+            ],
+            env={**NPU_ENV, **os.environ},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k_accuracy(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.60)
+
+
+class TestNPUPiecewiseGraphQwen25VLEmbedding(CustomTestCase):
+    """Test piecewise CUDA graph on NPU with Qwen2.5-VL-3B-Instruct embedding.
+
+    [Test Category] Piecewise Graph Optimization (VLM Embedding)
+    [Test Target] enforce_piecewise_cuda_graph vs disable_piecewise_cuda_graph (embedding consistency)
+    """
+
+    def test_embedding(self):
+        model_path = QWEN2_5_VL_3B_INSTRUCT_WEIGHTS_PATH
+        chat_template = get_chat_template_by_model_path(model_path)
+        text = f"{chat_template.image_token}What is in this picture? Answer: "
+
+        # Run with piecewise CUDA graph enabled
+        engine = Engine(
+            model_path=model_path,
+            enable_multimodal=True,
+            is_embedding=True,
+            attention_backend="ascend",
+            enforce_piecewise_cuda_graph=True,
+        )
+        out = engine.encode([text], image_data=[DEFAULT_IMAGE_URL])[0]["embedding"]
+        engine.shutdown()
+        self.assertGreater(len(out), 0)
+
+        # Run with piecewise CUDA graph disabled
+        engine = Engine(
+            model_path=model_path,
+            enable_multimodal=True,
+            is_embedding=True,
+            attention_backend="ascend",
+            disable_piecewise_cuda_graph=True,
+        )
+        out_without_pcg = engine.encode([text], image_data=[DEFAULT_IMAGE_URL])[0][
+            "embedding"
+        ]
+        engine.shutdown()
+        self.assertGreater(len(out_without_pcg), 0)
+
+        # Verify embedding consistency between modes
+        t_out = torch.tensor(out)
+        t_out_without_pcg = torch.tensor(out_without_pcg)
+        max_abs_diff = (t_out - t_out_without_pcg).abs().max().item()
+        max_rel_diff = (
+            ((t_out - t_out_without_pcg).abs() / (t_out_without_pcg.abs() + 1e-8))
+            .max()
+            .item()
+        )
+        self.assertTrue(
+            torch.allclose(
+                t_out,
+                t_out_without_pcg,
+                atol=1e-2,
+                rtol=1e-2,
+            ),
+            f"Piecewise CUDA graph embedding mismatch: max_abs_diff={max_abs_diff}, max_rel_diff={max_rel_diff}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/optimization_debug/GENERATED_20260606/test_npu_piecewise_cuda_graph_vlm.py
+++ b/test/registered/ascend/basic_function/optimization_debug/GENERATED_20260606/test_npu_piecewise_cuda_graph_vlm.py
@@ -25,6 +25,8 @@ register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
 NPU_ENV = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "TRANSFORMERS_VERBOSITY": "error",
+    "TRANSFORMERS_NO_ADVISORY_WARNINGS": "1",
+    "PYTHONWARNINGS": "ignore::FutureWarning,ignore::UserWarning,ignore::DeprecationWarning",
 }
 
 

--- a/test/registered/ascend/basic_function/optimization_debug/GENERATED_20260606/test_npu_piecewise_cuda_graph_vlm.py
+++ b/test/registered/ascend/basic_function/optimization_debug/GENERATED_20260606/test_npu_piecewise_cuda_graph_vlm.py
@@ -24,6 +24,7 @@ register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
 
 NPU_ENV = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "TRANSFORMERS_VERBOSITY": "error",
 }
 
 

--- a/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_elastic_ep_hybrid_dp.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_elastic_ep_hybrid_dp.py
@@ -68,6 +68,8 @@ class TestElasticEPTP(CustomTestCase):
                 "HCCL_OP_EXPANSION_MODE": "AIV",
                 "TASK_QUEUE_ENABLE": "0",
                 "TRANSFORMERS_VERBOSITY": "error",
+                "TRANSFORMERS_NO_ADVISORY_WARNINGS": "1",
+                "PYTHONWARNINGS": "ignore::FutureWarning,ignore::UserWarning,ignore::DeprecationWarning",
                 **os.environ,
             },
         )

--- a/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_elastic_ep_hybrid_dp.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_elastic_ep_hybrid_dp.py
@@ -1,0 +1,123 @@
+import os
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-16-npu-a3", nightly=True)
+
+
+class TestElasticEPTP(CustomTestCase):
+    """Test elastic EP on NPU with TP-only hybrid configuration.
+
+    [Test Category] Expert Parallelism
+    [Test Target] --moe-a2a-backend deepep; --ep-num-redundant-experts; --enable-eplb
+    """
+
+    extra_args = []
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "16",
+                "--quantization",
+                "modelslim",
+                "--attention-backend",
+                "ascend",
+                "--moe-a2a-backend",
+                "deepep",
+                "--deepep-mode",
+                "low_latency",
+                "--moe-dense-tp-size",
+                "1",
+                "--enable-dp-lm-head",
+                "--enable-eplb",
+                "--ep-num-redundant-experts",
+                "32",
+                "--chunked-prefill-size",
+                "512",
+                "--disable-cuda-graph",
+                "--disable-radix-cache",
+                "--max-running-requests",
+                "32",
+                "--mem-fraction-static",
+                0.82,
+                *cls.extra_args,
+            ],
+            env={
+                "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+                "HCCL_BUFFSIZE": "2048",
+                "HCCL_OP_EXPANSION_MODE": "AIV",
+                "TASK_QUEUE_ENABLE": "0",
+                **os.environ,
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        self.assertGreater(metrics["score"], 0.60)
+
+
+@unittest.skipIf(is_in_ci(), "Skip in CI: NPU pure-DP EP test is resource intensive.")
+class TestElasticEPPureDP(TestElasticEPTP):
+    """Test elastic EP on NPU with pure DP attention hybrid configuration.
+
+    [Test Category] Expert Parallelism
+    [Test Target] --enable-dp-attention; --dp 16; --moe-a2a-backend deepep
+    """
+
+    extra_args = [
+        "--enable-dp-attention",
+        "--dp",
+        "16",
+    ]
+
+
+@unittest.skipIf(is_in_ci(), "Skip in CI: Hybrid DP+TP EP test is resource intensive.")
+class TestElasticEPHybridDPTP(TestElasticEPTP):
+    """Test elastic EP on NPU with hybrid DP attention + TP configuration.
+
+    [Test Category] Expert Parallelism
+    [Test Target] --enable-dp-attention; --dp 8 (DP+TP hybrid); --moe-a2a-backend deepep
+    """
+
+    extra_args = [
+        "--enable-dp-attention",
+        "--dp",
+        "8",
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_elastic_ep_hybrid_dp.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_elastic_ep_hybrid_dp.py
@@ -59,7 +59,7 @@ class TestElasticEPTP(CustomTestCase):
                 "--max-running-requests",
                 "32",
                 "--mem-fraction-static",
-                0.82,
+                0.9,
                 *cls.extra_args,
             ],
             env={

--- a/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_elastic_ep_hybrid_dp.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_elastic_ep_hybrid_dp.py
@@ -67,6 +67,7 @@ class TestElasticEPTP(CustomTestCase):
                 "HCCL_BUFFSIZE": "2048",
                 "HCCL_OP_EXPANSION_MODE": "AIV",
                 "TASK_QUEUE_ENABLE": "0",
+                "TRANSFORMERS_VERBOSITY": "error",
                 **os.environ,
             },
         )

--- a/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_hybrid_dp_ep_tp_mtp.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_hybrid_dp_ep_tp_mtp.py
@@ -66,7 +66,7 @@ class TestHybridTPOnly(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.82,
+                0.75,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -108,7 +108,7 @@ class TestHybridDPAttention(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.82,
+                0.75,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -150,7 +150,7 @@ class TestHybridFullDPAttention(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.82,
+                0.75,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -191,7 +191,7 @@ class TestHybridDenseTPOne(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.82,
+                0.75,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -234,7 +234,7 @@ class TestHybridDPLMHead(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.82,
+                0.75,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -275,7 +275,7 @@ class TestHybridEPOnly(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.82,
+                0.75,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -319,7 +319,7 @@ class TestHybridDPEPCombined(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.82,
+                0.75,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -362,7 +362,7 @@ class TestHybridDeepEPAuto(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.82,
+                0.75,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -408,7 +408,7 @@ class TestHybridDeepEPDPAttention(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.82,
+                0.75,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -457,7 +457,7 @@ class TestHybridDeepEPFullStack(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.82,
+                0.75,
             ],
             env={**NPU_ENV, **os.environ},
         )

--- a/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_hybrid_dp_ep_tp_mtp.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_hybrid_dp_ep_tp_mtp.py
@@ -66,7 +66,7 @@ class TestHybridTPOnly(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.75,
+                0.82,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -108,7 +108,7 @@ class TestHybridDPAttention(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.75,
+                0.82,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -150,7 +150,7 @@ class TestHybridFullDPAttention(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.75,
+                0.82,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -191,7 +191,7 @@ class TestHybridDenseTPOne(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.75,
+                0.82,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -234,7 +234,7 @@ class TestHybridDPLMHead(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.75,
+                0.82,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -275,7 +275,7 @@ class TestHybridEPOnly(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.75,
+                0.82,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -319,7 +319,7 @@ class TestHybridDPEPCombined(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.75,
+                0.82,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -362,7 +362,7 @@ class TestHybridDeepEPAuto(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.75,
+                0.82,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -408,7 +408,7 @@ class TestHybridDeepEPDPAttention(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.75,
+                0.82,
             ],
             env={**NPU_ENV, **os.environ},
         )
@@ -457,7 +457,7 @@ class TestHybridDeepEPFullStack(CustomTestCase):
                 "ascend",
                 "--disable-cuda-graph",
                 "--mem-fraction-static",
-                0.75,
+                0.82,
             ],
             env={**NPU_ENV, **os.environ},
         )

--- a/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_hybrid_dp_ep_tp_mtp.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_hybrid_dp_ep_tp_mtp.py
@@ -25,6 +25,8 @@ NPU_ENV = {
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "TASK_QUEUE_ENABLE": "0",
     "TRANSFORMERS_VERBOSITY": "error",
+    "TRANSFORMERS_NO_ADVISORY_WARNINGS": "1",
+    "PYTHONWARNINGS": "ignore::FutureWarning,ignore::UserWarning,ignore::DeprecationWarning",
 }
 
 

--- a/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_hybrid_dp_ep_tp_mtp.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_hybrid_dp_ep_tp_mtp.py
@@ -24,6 +24,7 @@ NPU_ENV = {
     "HCCL_BUFFSIZE": "2048",
     "HCCL_OP_EXPANSION_MODE": "AIV",
     "TASK_QUEUE_ENABLE": "0",
+    "TRANSFORMERS_VERBOSITY": "error",
 }
 
 

--- a/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_hybrid_dp_ep_tp_mtp.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/expert_parallelism/GENERATED_20260606/test_npu_hybrid_dp_ep_tp_mtp.py
@@ -1,0 +1,472 @@
+import os
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH,
+    QWEN3_30B_A3B_W8A8_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=3600, suite="weekly-16-npu-a3", nightly=True)
+
+
+NPU_ENV = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "HCCL_BUFFSIZE": "2048",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "TASK_QUEUE_ENABLE": "0",
+}
+
+
+def _mmlu_eval(base_url, model):
+    args = SimpleNamespace(
+        base_url=base_url,
+        model=model,
+        eval_name="mmlu",
+        num_examples=64,
+        num_threads=32,
+    )
+    return run_eval(args)
+
+
+class TestHybridTPOnly(CustomTestCase):
+    """Test hybrid parallelism on NPU with TP-only baseline.
+
+    [Test Category] Hybrid Parallelism
+    [Test Target] --tp 16 (MLA model baseline)
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "16",
+                "--quantization",
+                "modelslim",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                0.82,
+            ],
+            env={**NPU_ENV, **os.environ},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        metrics = _mmlu_eval(self.base_url, self.model)
+        self.assertGreater(metrics["score"], 0.48)
+
+
+class TestHybridDPAttention(CustomTestCase):
+    """Test hybrid parallelism on NPU with DP attention (DP=4).
+
+    [Test Category] Hybrid Parallelism
+    [Test Target] --enable-dp-attention --dp 4 with TP=16
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "16",
+                "--quantization",
+                "modelslim",
+                "--enable-dp-attention",
+                "--dp",
+                "4",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                0.82,
+            ],
+            env={**NPU_ENV, **os.environ},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        metrics = _mmlu_eval(self.base_url, self.model)
+        self.assertGreater(metrics["score"], 0.48)
+
+
+class TestHybridFullDPAttention(CustomTestCase):
+    """Test hybrid parallelism on NPU with full DP attention (DP=16).
+
+    [Test Category] Hybrid Parallelism
+    [Test Target] --enable-dp-attention --dp 16 (full DP)
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "16",
+                "--quantization",
+                "modelslim",
+                "--enable-dp-attention",
+                "--dp",
+                "16",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                0.82,
+            ],
+            env={**NPU_ENV, **os.environ},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        metrics = _mmlu_eval(self.base_url, self.model)
+        self.assertGreater(metrics["score"], 0.48)
+
+
+class TestHybridDenseTPOne(CustomTestCase):
+    """Test hybrid parallelism on NPU with dense FFN TP=1.
+
+    [Test Category] Hybrid Parallelism
+    [Test Target] --moe-dense-tp-size 1 (separate dense and sparse TP)
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "16",
+                "--quantization",
+                "modelslim",
+                "--moe-dense-tp-size",
+                "1",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                0.82,
+            ],
+            env={**NPU_ENV, **os.environ},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        metrics = _mmlu_eval(self.base_url, self.model)
+        self.assertGreater(metrics["score"], 0.48)
+
+
+class TestHybridDPLMHead(CustomTestCase):
+    """Test hybrid parallelism on NPU with DP attention + DP LM head.
+
+    [Test Category] Hybrid Parallelism
+    [Test Target] --enable-dp-attention --enable-dp-lm-head
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "16",
+                "--quantization",
+                "modelslim",
+                "--enable-dp-attention",
+                "--dp",
+                "4",
+                "--enable-dp-lm-head",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                0.82,
+            ],
+            env={**NPU_ENV, **os.environ},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        metrics = _mmlu_eval(self.base_url, self.model)
+        self.assertGreater(metrics["score"], 0.48)
+
+
+class TestHybridEPOnly(CustomTestCase):
+    """Test hybrid parallelism on NPU with EP enabled.
+
+    [Test Category] Hybrid Parallelism
+    [Test Target] --ep 16 (Expert Parallelism)
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "16",
+                "--quantization",
+                "modelslim",
+                "--ep-size",
+                "16",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                0.82,
+            ],
+            env={**NPU_ENV, **os.environ},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        metrics = _mmlu_eval(self.base_url, self.model)
+        self.assertGreater(metrics["score"], 0.48)
+
+
+class TestHybridDPEPCombined(CustomTestCase):
+    """Test hybrid parallelism on NPU with DP attention + EP.
+
+    [Test Category] Hybrid Parallelism
+    [Test Target] --enable-dp-attention --dp 4 --ep 16
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V3_2_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "16",
+                "--quantization",
+                "modelslim",
+                "--enable-dp-attention",
+                "--dp",
+                "4",
+                "--ep-size",
+                "16",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                0.82,
+            ],
+            env={**NPU_ENV, **os.environ},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        metrics = _mmlu_eval(self.base_url, self.model)
+        self.assertGreater(metrics["score"], 0.48)
+
+
+class TestHybridDeepEPAuto(CustomTestCase):
+    """Test hybrid parallelism on NPU with DeepEP backend (auto mode).
+
+    [Test Category] Hybrid Parallelism
+    [Test Target] --moe-a2a-backend deepep --deepep-mode auto
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_30B_A3B_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "16",
+                "--quantization",
+                "modelslim",
+                "--moe-a2a-backend",
+                "deepep",
+                "--deepep-mode",
+                "auto",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                0.82,
+            ],
+            env={**NPU_ENV, **os.environ},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        metrics = _mmlu_eval(self.base_url, self.model)
+        self.assertGreater(metrics["score"], 0.48)
+
+
+class TestHybridDeepEPDPAttention(CustomTestCase):
+    """Test hybrid parallelism on NPU with DeepEP + DP attention.
+
+    [Test Category] Hybrid Parallelism
+    [Test Target] --moe-a2a-backend deepep --enable-dp-attention
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_30B_A3B_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "16",
+                "--quantization",
+                "modelslim",
+                "--enable-dp-attention",
+                "--dp",
+                "4",
+                "--moe-a2a-backend",
+                "deepep",
+                "--deepep-mode",
+                "auto",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                0.82,
+            ],
+            env={**NPU_ENV, **os.environ},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        metrics = _mmlu_eval(self.base_url, self.model)
+        self.assertGreater(metrics["score"], 0.48)
+
+
+class TestHybridDeepEPFullStack(CustomTestCase):
+    """Test hybrid parallelism on NPU with DeepEP + full hybrid stack.
+
+    [Test Category] Hybrid Parallelism
+    [Test Target] DeepEP + DP attention + DP LM head + moe-dense-tp 1
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_30B_A3B_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "16",
+                "--quantization",
+                "modelslim",
+                "--enable-dp-attention",
+                "--dp",
+                "4",
+                "--moe-dense-tp-size",
+                "1",
+                "--enable-dp-lm-head",
+                "--moe-a2a-backend",
+                "deepep",
+                "--deepep-mode",
+                "auto",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                0.82,
+            ],
+            env={**NPU_ENV, **os.environ},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        metrics = _mmlu_eval(self.base_url, self.model)
+        self.assertGreater(metrics["score"], 0.48)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add 3 new NPU test cases:

1. test_npu_piecewise_cuda_graph_vlm.py - VLM piecewise CUDA graph (1-NPU)
2. test_npu_elastic_ep_hybrid_dp.py - Elastic EP with TP-only and DP variants (16-NPU)
3. test_npu_hybrid_dp_ep_tp_mtp.py - Hybrid DP/EP/TP/MTP parallelism (16-NPU, weekly)

Generated by npu-test-gap-v9.1 to fill GPU-NPU test coverage gaps.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->