### PR TITLE
Add PD disaggregation accuracy test case

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,99 @@
+name: Single Test (NPU)
+# test round 1: PD disaggregation accuracy test
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260605
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases - PD disaggregation accuracy test
+          test_cases=(
+            "test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from source code"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          # Backup original sglang package
+          mv ${sglang_pkg_path}/sglang ${sglang_pkg_path}/sglang_bak
+          # Copy sglang from source code
+          cp -r ${sglang_source_path}/python/sglang ${sglang_pkg_path}/sglang
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: PD disaggregation accuracy test - fix black formatting
+# test round 4: PD disaggregation accuracy test - fix BOM and newline
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 6: PD disaggregation accuracy test - apply black formatting
+# test round 7: PD disaggregation accuracy test - remove BOM
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 7: PD disaggregation accuracy test - remove BOM
+# test round 8: PD disaggregation accuracy test - apply black formatting locally
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: PD disaggregation accuracy test - fix ascend backend
+# test round 3: PD disaggregation accuracy test - fix black formatting
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 4: PD disaggregation accuracy test - fix BOM and newline
+# test round 5: PD disaggregation accuracy test - add ASCEND_MF_STORE_URL
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: PD disaggregation accuracy test
+# test round 2: PD disaggregation accuracy test - fix ascend backend
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 5: PD disaggregation accuracy test - add ASCEND_MF_STORE_URL
+# test round 6: PD disaggregation accuracy test - apply black formatting
 
 on:
   pull_request:

--- a/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
+++ b/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
@@ -1,0 +1,161 @@
+import json
+import os
+import unittest
+from types import SimpleNamespace
+
+import openai
+import requests
+from transformers import AutoTokenizer
+
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.few_shot_gsm8k import run_eval
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+
+register_npu_ci(est_time=400, suite="nightly-2-npu-a3", nightly=True)
+
+
+class TestNPUDisaggregationAccuracy(PDDisaggregationServerBase):
+    """Test disaggregation accuracy features on NPU.
+
+    [Test Category] Functional
+    [Test Target] PD disaggregation accuracy in prefill-decode mode
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model = QWEN3_8B_WEIGHTS_PATH
+        cls.extra_prefill_args = [
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.5",
+        ]
+        cls.extra_decode_args = [
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.5",
+        ]
+        cls.launch_all()
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host=f"http://{self.base_host}",
+            port=int(self.lb_port),
+        )
+        metrics = run_eval(args)
+        self.assertGreater(metrics["accuracy"], 0.50)
+
+    def test_logprob(self):
+        prompt = "The capital of france is "
+        response = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {"temperature": 0},
+                "return_logprob": True,
+                "return_input_logprob": True,
+                "logprob_start_len": 0,
+            },
+        )
+
+        j = response.json()
+        completion_tokens = j["meta_info"]["completion_tokens"]
+        input_logprobs = j["meta_info"]["input_token_logprobs"]
+        output_logprobs = j["meta_info"]["output_token_logprobs"]
+
+        self.assertEqual(
+            len(output_logprobs), completion_tokens,
+            f"output_logprobs and completion_tokens should have the same length, but got {len(output_logprobs)} and {completion_tokens}"
+        )
+        self.assertGreater(
+            len(input_logprobs), 0,
+            f"input_logprobs should have at least one token, but got {len(input_logprobs)}"
+        )
+
+    def test_structured_output(self):
+        json_schema = json.dumps(
+            {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "pattern": "^[\\w]+$"},
+                    "population": {"type": "integer"},
+                },
+                "required": ["name", "population"],
+            }
+        )
+
+        response = requests.post(
+            f"{self.lb_url}/generate",
+            json={
+                "text": "Here is the information of the capital of France in the JSON format.\n",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 64,
+                    "json_schema": json_schema,
+                },
+            },
+        )
+        output = response.json()["text"]
+        json.loads(output)
+
+    def test_first_token_finish(self):
+        client = openai.Client(api_key="empty", base_url=f"{self.lb_url}/v1")
+        tokenizer = AutoTokenizer.from_pretrained(self.model)
+        eos_token = tokenizer.eos_token_id
+        prompt = "The best programming language for AI is"
+
+        # First token EOS
+        res = client.completions.create(
+            model="dummy", prompt=prompt, logit_bias={eos_token: 42}
+        ).model_dump()
+
+        self.assertEqual(
+            res["usage"]["completion_tokens"], 1,
+            "Expected completion_tokens to be 1 when first token is EOS, "
+            f"but got {res['usage']['completion_tokens']}"
+        )
+
+        # First token EOS with ignore_eos
+        res = client.completions.create(
+            model="dummy",
+            prompt=prompt,
+            logit_bias={eos_token: 42},
+            extra_body={"ignore_eos": True},
+        ).model_dump()
+
+        self.assertGreater(
+            res["usage"]["completion_tokens"], 1,
+            "Expected completion_tokens to be greater than 1 when ignore_eos is True, "
+            f"but got {res['usage']['completion_tokens']}"
+        )
+
+        # First token with specified stop token
+        stop_token_id = tokenizer.encode(" hello", add_special_tokens=False)[0]
+        res = client.completions.create(
+            model="dummy",
+            prompt=prompt,
+            logit_bias={stop_token_id: 42},
+            stop=[" hello"],
+        ).model_dump()
+
+        self.assertEqual(
+            res["usage"]["completion_tokens"], 1,
+            "Expected completion_tokens to be 1 when first token is stop token, "
+            f"but got {res['usage']['completion_tokens']}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
+++ b/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
@@ -1,4 +1,4 @@
-import json
+﻿import json
 import os
 import unittest
 from types import SimpleNamespace
@@ -163,3 +163,4 @@ class TestNPUDisaggregationAccuracy(PDDisaggregationServerBase):
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
+++ b/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
@@ -1,4 +1,4 @@
-﻿import json
+﻿﻿import json
 import os
 import unittest
 from types import SimpleNamespace

--- a/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
+++ b/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
@@ -13,6 +13,10 @@ from sglang.test.few_shot_gsm8k import run_eval
 from sglang.test.server_fixtures.disaggregation_fixture import (
     PDDisaggregationServerBase,
 )
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_pd_server,
+)
 
 register_npu_ci(est_time=400, suite="nightly-2-npu-a3", nightly=True)
 
@@ -47,6 +51,56 @@ class TestNPUDisaggregationAccuracy(PDDisaggregationServerBase):
             "0.5",
         ]
         cls.launch_all()
+
+    @classmethod
+    def start_prefill(cls):
+        prefill_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "prefill",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            "1",
+        ] + list(cls.extra_prefill_args)
+        prefill_args += cls.transfer_backend + cls.rdma_devices
+        env = {
+            **os.environ,
+            "ASCEND_MF_STORE_URL": "tcp://127.0.0.1:26666",
+        }
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+            env=env,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        decode_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "decode",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            "1",
+            "--base-gpu-id",
+            "1",
+        ] + list(cls.extra_decode_args)
+        decode_args += cls.transfer_backend + cls.rdma_devices
+        env = {
+            **os.environ,
+            "ASCEND_MF_STORE_URL": "tcp://127.0.0.1:26666",
+        }
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+            env=env,
+        )
 
     def test_gsm8k(self):
         args = SimpleNamespace(

--- a/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
+++ b/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
@@ -163,4 +163,3 @@ class TestNPUDisaggregationAccuracy(PDDisaggregationServerBase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
+++ b/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
@@ -134,12 +134,14 @@ class TestNPUDisaggregationAccuracy(PDDisaggregationServerBase):
         output_logprobs = j["meta_info"]["output_token_logprobs"]
 
         self.assertEqual(
-            len(output_logprobs), completion_tokens,
-            f"output_logprobs and completion_tokens should have the same length, but got {len(output_logprobs)} and {completion_tokens}"
+            len(output_logprobs),
+            completion_tokens,
+            f"output_logprobs and completion_tokens should have the same length, but got {len(output_logprobs)} and {completion_tokens}",
         )
         self.assertGreater(
-            len(input_logprobs), 0,
-            f"input_logprobs should have at least one token, but got {len(input_logprobs)}"
+            len(input_logprobs),
+            0,
+            f"input_logprobs should have at least one token, but got {len(input_logprobs)}",
         )
 
     def test_structured_output(self):
@@ -180,9 +182,10 @@ class TestNPUDisaggregationAccuracy(PDDisaggregationServerBase):
         ).model_dump()
 
         self.assertEqual(
-            res["usage"]["completion_tokens"], 1,
+            res["usage"]["completion_tokens"],
+            1,
             "Expected completion_tokens to be 1 when first token is EOS, "
-            f"but got {res['usage']['completion_tokens']}"
+            f"but got {res['usage']['completion_tokens']}",
         )
 
         # First token EOS with ignore_eos
@@ -194,9 +197,10 @@ class TestNPUDisaggregationAccuracy(PDDisaggregationServerBase):
         ).model_dump()
 
         self.assertGreater(
-            res["usage"]["completion_tokens"], 1,
+            res["usage"]["completion_tokens"],
+            1,
             "Expected completion_tokens to be greater than 1 when ignore_eos is True, "
-            f"but got {res['usage']['completion_tokens']}"
+            f"but got {res['usage']['completion_tokens']}",
         )
 
         # First token with specified stop token
@@ -209,9 +213,10 @@ class TestNPUDisaggregationAccuracy(PDDisaggregationServerBase):
         ).model_dump()
 
         self.assertEqual(
-            res["usage"]["completion_tokens"], 1,
+            res["usage"]["completion_tokens"],
+            1,
             "Expected completion_tokens to be 1 when first token is stop token, "
-            f"but got {res['usage']['completion_tokens']}"
+            f"but got {res['usage']['completion_tokens']}",
         )
 
 

--- a/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
+++ b/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
@@ -28,6 +28,10 @@ class TestNPUDisaggregationAccuracy(PDDisaggregationServerBase):
     def setUpClass(cls):
         super().setUpClass()
         cls.model = QWEN3_8B_WEIGHTS_PATH
+        # Use ascend transfer backend for NPU
+        cls.transfer_backend = ["--disaggregation-transfer-backend", "ascend"]
+        # No RDMA devices needed for ascend backend
+        cls.rdma_devices = []
         cls.extra_prefill_args = [
             "--attention-backend",
             "ascend",

--- a/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
+++ b/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
@@ -1,4 +1,4 @@
-﻿﻿import json
+﻿import json
 import os
 import unittest
 from types import SimpleNamespace


### PR DESCRIPTION
This PR adds the PD disaggregation accuracy test case.

- Test file: test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/test_npu_disaggregation_accuracy.py
- Tests: GSM8K accuracy, logprob, structured output, first token finish



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->