### PR TITLE
[NPU] Add PD disaggregation basic test (NPU-adapted from GPU version)

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: PD disaggregation basic test (NPU) - apply black formatting
+# test round 4: PD disaggregation basic test (NPU) - fix pause_generate_url
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: PD disaggregation basic test (NPU) - fix empty file content
+# test round 3: PD disaggregation basic test (NPU) - apply black formatting
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: PD disaggregation basic test (NPU)
+# test round 2: PD disaggregation basic test (NPU) - fix empty file content
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,99 @@
+name: Single Test (NPU)
+# test round 1: PD disaggregation basic test (NPU)
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260605
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases - 使用时替换为实际的测试用例路径
+          test_cases=(
+            "test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/__test_npu_disaggregation_basic.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/__test_npu_disaggregation_basic.py
+++ b/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/__test_npu_disaggregation_basic.py
@@ -16,12 +16,15 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     popen_launch_pd_server,
 )
+
 # QWEN3_8B_WEIGHTS_PATH="/home/weights/Qwen/Qwen3-8B"
 
 register_npu_ci(est_time=400, suite="nightly-2-npu-a3", nightly=True)
 
 
-class TestNPUDisaggregationAccuracy(PauseResumeInPlaceMixin,PDDisaggregationServerBase):
+class TestNPUDisaggregationAccuracy(
+    PauseResumeInPlaceMixin, PDDisaggregationServerBase
+):
     """Test disaggregation accuracy features on NPU.
 
     [Test Category] Functional
@@ -156,7 +159,6 @@ class TestNPUDisaggregationAccuracy(PauseResumeInPlaceMixin,PDDisaggregationServ
         self.assertIsNotNone(first_top_logprobs)
         self.assertGreater(len(first_top_logprobs), 0)
         self.assertIsInstance(first_top_logprobs[0].token, str)
-
 
     def test_structured_output(self):
         json_schema = json.dumps(

--- a/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/__test_npu_disaggregation_basic.py
+++ b/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/__test_npu_disaggregation_basic.py
@@ -35,6 +35,8 @@ class TestNPUDisaggregationAccuracy(
     def setUpClass(cls):
         super().setUpClass()
         cls.model = QWEN3_8B_WEIGHTS_PATH
+        cls.pause_generate_url = cls.lb_url
+        cls.pause_target_urls = [cls.prefill_url, cls.decode_url]
         # Use ascend transfer backend for NPU
         cls.transfer_backend = ["--disaggregation-transfer-backend", "ascend"]
         # No RDMA devices needed for ascend backend

--- a/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/__test_npu_disaggregation_basic.py
+++ b/test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/__test_npu_disaggregation_basic.py
@@ -1,0 +1,238 @@
+import json
+import os
+import unittest
+
+import openai
+import requests
+from transformers import AutoTokenizer
+
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.kits.pause_generation_kit import PauseResumeInPlaceMixin
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_pd_server,
+)
+# QWEN3_8B_WEIGHTS_PATH="/home/weights/Qwen/Qwen3-8B"
+
+register_npu_ci(est_time=400, suite="nightly-2-npu-a3", nightly=True)
+
+
+class TestNPUDisaggregationAccuracy(PauseResumeInPlaceMixin,PDDisaggregationServerBase):
+    """Test disaggregation accuracy features on NPU.
+
+    [Test Category] Functional
+    [Test Target] PD disaggregation accuracy in prefill-decode mode
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model = QWEN3_8B_WEIGHTS_PATH
+        # Use ascend transfer backend for NPU
+        cls.transfer_backend = ["--disaggregation-transfer-backend", "ascend"]
+        # No RDMA devices needed for ascend backend
+        cls.rdma_devices = []
+        cls.extra_prefill_args = [
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.5",
+        ]
+        cls.extra_decode_args = [
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.5",
+        ]
+        cls.launch_all()
+
+    @classmethod
+    def start_prefill(cls):
+        prefill_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "prefill",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            "1",
+        ] + list(cls.extra_prefill_args)
+        prefill_args += cls.transfer_backend + cls.rdma_devices
+        env = {
+            **os.environ,
+            "ASCEND_MF_STORE_URL": "tcp://127.0.0.1:26666",
+        }
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+            env=env,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        decode_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "decode",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            "1",
+            "--base-gpu-id",
+            "1",
+        ] + list(cls.extra_decode_args)
+        decode_args += cls.transfer_backend + cls.rdma_devices
+        env = {
+            **os.environ,
+            "ASCEND_MF_STORE_URL": "tcp://127.0.0.1:26666",
+        }
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+            env=env,
+        )
+
+    def test_logprob(self):
+        prompt = "The capital of france is "
+        response = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {"temperature": 0},
+                "return_logprob": True,
+                "return_input_logprob": True,
+                "logprob_start_len": 0,
+            },
+        )
+
+        j = response.json()
+        completion_tokens = j["meta_info"]["completion_tokens"]
+        input_logprobs = j["meta_info"]["input_token_logprobs"]
+        output_logprobs = j["meta_info"]["output_token_logprobs"]
+
+        self.assertEqual(
+            len(output_logprobs),
+            completion_tokens,
+            f"output_logprobs and completion_tokens should have the same length, but got {len(output_logprobs)} and {completion_tokens}",
+        )
+        self.assertGreater(
+            len(input_logprobs),
+            0,
+            f"input_logprobs should have at least one token, but got {len(input_logprobs)}",
+        )
+
+    def test_chat_completion_top_logprobs(self):
+        client = openai.Client(api_key="empty", base_url=f"{self.lb_url}/v1")
+        response = client.chat.completions.create(
+            model="dummy",
+            messages=[
+                {"role": "system", "content": "You are a helpful AI assistant."},
+                {"role": "user", "content": "What is the capital of France?"},
+            ],
+            temperature=0,
+            max_tokens=8,
+            logprobs=True,
+            top_logprobs=5,
+        )
+
+        self.assertIsNotNone(response.choices[0].logprobs)
+        content_logprobs = response.choices[0].logprobs.content
+        self.assertGreater(len(content_logprobs), 0)
+
+        first_top_logprobs = next(
+            (item.top_logprobs for item in content_logprobs if item.top_logprobs),
+            None,
+        )
+        self.assertIsNotNone(first_top_logprobs)
+        self.assertGreater(len(first_top_logprobs), 0)
+        self.assertIsInstance(first_top_logprobs[0].token, str)
+
+
+    def test_structured_output(self):
+        json_schema = json.dumps(
+            {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "pattern": "^[\\w]+$"},
+                    "population": {"type": "integer"},
+                },
+                "required": ["name", "population"],
+            }
+        )
+
+        response = requests.post(
+            f"{self.lb_url}/generate",
+            json={
+                "text": "Here is the information of the capital of France in the JSON format.\n",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 64,
+                    "json_schema": json_schema,
+                },
+            },
+        )
+        output = response.json()["text"]
+        json.loads(output)
+
+    def test_first_token_finish(self):
+        client = openai.Client(api_key="empty", base_url=f"{self.lb_url}/v1")
+        tokenizer = AutoTokenizer.from_pretrained(self.model)
+        eos_token = tokenizer.eos_token_id
+        prompt = "The best programming language for AI is"
+
+        # First token EOS
+        res = client.completions.create(
+            model="dummy", prompt=prompt, logit_bias={eos_token: 42}
+        ).model_dump()
+
+        self.assertEqual(
+            res["usage"]["completion_tokens"],
+            1,
+            "Expected completion_tokens to be 1 when first token is EOS, "
+            f"but got {res['usage']['completion_tokens']}",
+        )
+
+        # First token EOS with ignore_eos
+        res = client.completions.create(
+            model="dummy",
+            prompt=prompt,
+            logit_bias={eos_token: 42},
+            extra_body={"ignore_eos": True},
+        ).model_dump()
+
+        self.assertGreater(
+            res["usage"]["completion_tokens"],
+            1,
+            "Expected completion_tokens to be greater than 1 when ignore_eos is True, "
+            f"but got {res['usage']['completion_tokens']}",
+        )
+
+        # First token with specified stop token
+        stop_token_id = tokenizer.encode(" hello", add_special_tokens=False)[0]
+        res = client.completions.create(
+            model="dummy",
+            prompt=prompt,
+            logit_bias={stop_token_id: 42},
+            stop=[" hello"],
+        ).model_dump()
+
+        self.assertEqual(
+            res["usage"]["completion_tokens"],
+            1,
+            "Expected completion_tokens to be 1 when first token is stop token, "
+            f"but got {res['usage']['completion_tokens']}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add NPU-adapted version of `test_disaggregation_basic.py` for PD (prefill-decode) disaggregation.

## Test File
- `test/registered/ascend/basic_function/pd_disaggregation/GENERATED_20260608/__test_npu_disaggregation_basic.py`

## NPU Adaptations
| Item | GPU | NPU |
|------|-----|-----|
| Model | DEFAULT_MODEL_NAME_FOR_TEST | QWEN3-8B (TP=1) |
| Attention backend | Triton | ascend |
| Transfer backend | mooncake/custom | ascend |
| CI registration | register_cuda_ci | register_npu_ci (nightly-2-npu-a3) |

## Tests Covered
- `test_logprob`: Validates input/output logprob lengths
- `test_chat_completion_top_logprobs`: Validates OpenAI chat completion logprobs
- `test_structured_output`: Validates JSON schema-constrained generation
- `test_first_token_finish`: Validates EOS / stop token first-token termination

## Notes
- Source: `test_npu_disaggregation_basic.py` (GPU version) in same directory
- Uses `--disaggregation-transfer-backend ascend` and ASCEND_MF_STORE_URL env var
- `register_npu_ci(est_time=400, suite="nightly-2-npu-a3", nightly=True)`













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->