### PR TITLE
[NPU][A5] Support FP8 for Ascend NPU

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
@@ -5,6 +5,7 @@ import torch
 
 from sglang.srt.hardware_backend.npu.utils import npu_format_cast
 from sglang.srt.layers.quantization.base_config import FusedMoEMethodBase
+from sglang.srt.utils import is_npu_before_atlas_a5
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
@@ -12,6 +13,241 @@ if TYPE_CHECKING:
         StandardDispatchOutput,
     )
     from sglang.srt.layers.quantization.base_config import QuantizationConfig
+
+
+_is_npu_before_atlas_a5 = is_npu_before_atlas_a5()
+
+
+def npu_fused_experts_fp8(
+    hidden_states: torch.Tensor,
+    w13: torch.Tensor,
+    w13_weight_scale_inv: torch.Tensor,
+    w2: torch.Tensor,
+    w2_weight_scale_inv: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    top_k: int,
+    **kwargs,
+):
+    if torch.npu.is_current_stream_capturing():
+        return npu_fused_experts_fp8_decode(
+            hidden_states=hidden_states,
+            w13=w13,
+            w13_weight_scale_inv=w13_weight_scale_inv,
+            w2=w2,
+            w2_weight_scale_inv=w2_weight_scale_inv,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            top_k=top_k,
+            **kwargs,
+        )
+
+    del kwargs
+
+    original_shape = hidden_states.shape
+    original_dtype = hidden_states.dtype
+    if len(original_shape) == 3:
+        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+    num_tokens = hidden_states.shape[0]
+    num_experts = w13.shape[0]
+    row_idx_len = num_tokens * top_k
+    row_idx = (
+        torch.arange(0, row_idx_len, dtype=torch.int32, device=topk_weights.device)
+        .view(top_k, -1)
+        .permute(1, 0)
+        .contiguous()
+    )
+    hidden_states, expanded_row_idx, expanded_expert_idx = (
+        torch.ops.npu.npu_moe_init_routing(
+            hidden_states,
+            row_idx=row_idx,
+            expert_idx=topk_ids,
+            active_num=num_tokens,
+        )
+    )
+    expert_tokens = torch.ops.npu.npu_moe_compute_expert_tokens(
+        expanded_expert_idx, num_experts
+    )
+    expert_tokens = expert_tokens.to(torch.int64)
+
+    rows = hidden_states.shape[0]
+    row_ids = torch.arange(rows, device=hidden_states.device, dtype=torch.int64)
+    valid_mask = row_ids < expert_tokens[-1]
+    valid_mask_2d = valid_mask.unsqueeze(1)
+
+    hidden_states = fp8_gmm_npu(
+        input=hidden_states,
+        input_scale=None,
+        weight=w13,
+        weight_scale=w13_weight_scale_inv,
+        group_list_type=0,
+        group_list=expert_tokens,
+        output_dtype=original_dtype,
+    )
+    hidden_states = torch.ops.npu.npu_swiglu(hidden_states)
+    hidden_states = fp8_gmm_npu(
+        input=hidden_states,
+        input_scale=None,
+        weight=w2,
+        weight_scale=w2_weight_scale_inv,
+        group_list_type=0,
+        group_list=expert_tokens,
+        output_dtype=original_dtype,
+    )
+
+    hidden_states = hidden_states * valid_mask_2d.to(hidden_states.dtype)
+
+    final_hidden_states = torch.ops.npu.npu_moe_finalize_routing(
+        hidden_states,
+        skip1=None,
+        skip2=None,
+        bias=None,
+        scales=topk_weights,
+        expanded_src_to_dst_row=expanded_row_idx,
+        export_for_source_row=topk_ids,
+    )
+
+    if len(original_shape) == 3:
+        final_hidden_states = final_hidden_states.view(original_shape)
+    return final_hidden_states
+
+
+def npu_fused_experts_fp8_decode(
+    hidden_states: torch.Tensor,
+    w13: torch.Tensor,
+    w13_weight_scale_inv: torch.Tensor,
+    w2: torch.Tensor,
+    w2_weight_scale_inv: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    top_k: int,
+    **kwargs,
+):
+    del kwargs
+
+    num_tokens = hidden_states.shape[:-1].numel()
+    global_num_experts = w13.shape[0]
+    original_shape = hidden_states.shape
+    original_dtype = hidden_states.dtype
+    group_list_type = 1
+
+    hidden_states, expanded_row_idx, expert_tokens, _ = (
+        torch.ops.npu.npu_moe_init_routing_v2(
+            hidden_states,
+            topk_ids,
+            active_num=num_tokens * top_k,
+            expert_num=global_num_experts,
+            expert_tokens_num_type=group_list_type,
+            expert_tokens_num_flag=True,
+            active_expert_range=[0, global_num_experts],
+            quant_mode=-1,
+        )
+    )
+    expert_tokens = expert_tokens.to(torch.int64)
+
+    hidden_states = fp8_gmm_npu(
+        input=hidden_states,
+        input_scale=None,
+        weight=w13,
+        weight_scale=w13_weight_scale_inv,
+        group_list_type=group_list_type,
+        group_list=expert_tokens,
+        output_dtype=original_dtype,
+    )
+    hidden_states = torch.ops.npu.npu_swiglu(hidden_states)
+    hidden_states = fp8_gmm_npu(
+        input=hidden_states,
+        input_scale=None,
+        weight=w2,
+        weight_scale=w2_weight_scale_inv,
+        group_list_type=group_list_type,
+        group_list=expert_tokens,
+        output_dtype=original_dtype,
+    )
+
+    final_hidden_states = torch.ops.npu.npu_moe_token_unpermute(
+        permuted_tokens=hidden_states,
+        sorted_indices=torch.abs(expanded_row_idx),
+        probs=topk_weights,
+    )
+
+    if len(original_shape) == 3:
+        final_hidden_states = final_hidden_states.view(original_shape)
+    return final_hidden_states
+
+
+def npu_apply_without_routing_weights_fp8(
+    layer,
+    hidden_states,
+    hidden_states_scale,
+    group_list_type,
+    group_list,
+    output_dtype,
+):
+    hidden_states = fp8_gmm_npu(
+        input=hidden_states,
+        input_scale=hidden_states_scale,
+        weight=layer.w13_weight,
+        weight_scale=layer.w13_weight_scale_inv,
+        group_list_type=group_list_type,
+        group_list=group_list,
+        output_dtype=output_dtype,
+    )
+    hidden_states = torch.ops.npu.npu_swiglu(hidden_states)
+    hidden_states = fp8_gmm_npu(
+        input=hidden_states,
+        input_scale=None,
+        weight=layer.w2_weight,
+        weight_scale=layer.w2_weight_scale_inv,
+        group_list_type=group_list_type,
+        group_list=group_list,
+        output_dtype=output_dtype,
+    )
+    return hidden_states
+
+
+def fp8_gmm_npu(
+    input: torch.Tensor,
+    input_scale: Optional[torch.Tensor],
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_list_type: int,
+    group_list: torch.Tensor,
+    output_dtype=torch.bfloat16,
+) -> torch.Tensor:
+    if _is_npu_before_atlas_a5:
+        assert input.dtype == torch.bfloat16
+        assert output_dtype == torch.bfloat16
+        assert input_scale is None
+
+        if group_list_type == 1:
+            group_list = group_list.cumsum(dim=0).to(torch.int64)
+        return torch.ops.npu.softfp8_w8a16_grouped_matmul(
+            input, weight, weight_scale, group_list, "bf16"
+        )
+
+    group_list = group_list.to(torch.int64)
+    if input_scale is None:
+        x, x_scale = torch.ops.npu.npu_dynamic_block_quant(
+            input,
+            dst_type=torch.float8_e4m3fn,
+            row_block_size=1,
+            col_block_size=128,
+        )
+    else:
+        x, x_scale = input, input_scale
+
+    return torch.ops.npu.npu_grouped_matmul(
+        [x],
+        [weight],
+        scale=[weight_scale],
+        per_token_scale=[x_scale],
+        split_item=2,
+        group_type=0,
+        group_list=group_list,
+        group_list_type=group_list_type,
+        output_dtype=output_dtype,
+    )[0]
 
 
 def npu_fused_experts_w4a4(

--- a/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
@@ -42,8 +42,6 @@ def npu_fused_experts_fp8(
             **kwargs,
         )
 
-    del kwargs
-
     original_shape = hidden_states.shape
     original_dtype = hidden_states.dtype
     if len(original_shape) == 3:
@@ -123,7 +121,6 @@ def npu_fused_experts_fp8_decode(
     top_k: int,
     **kwargs,
 ):
-    del kwargs
 
     num_tokens = hidden_states.shape[:-1].numel()
     global_num_experts = w13.shape[0]

--- a/python/sglang/srt/hardware_backend/npu/quantization/linear_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/linear_method_npu.py
@@ -1,12 +1,58 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import torch
 
 from sglang.srt.hardware_backend.npu.utils import npu_format_cast
 from sglang.srt.layers.quantization.base_config import LinearMethodBase
+from sglang.srt.utils import is_npu_before_atlas_a5
 
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization.base_config import QuantizationConfig
+
+
+_is_npu_before_atlas_a5 = is_npu_before_atlas_a5()
+
+
+def fp8_matmul_npu(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    block_size: List[int],
+    weight_scale: torch.Tensor,
+    input_scale: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    del input_scale, bias
+
+    if block_size != [128, 128]:
+        raise ValueError("fp8_matmul_npu only supports block_size == [128, 128]")
+    if weight.dtype != torch.float8_e4m3fn:
+        raise ValueError("fp8_matmul_npu only supports torch.float8_e4m3fn")
+
+    orig_shape = input.shape
+    k = orig_shape[-1]
+    input_2d = input.reshape(-1, k).contiguous()
+
+    if _is_npu_before_atlas_a5:
+        output_2d = torch.ops.npu.softfp8_w8a16_matmul(
+            input_2d, weight, weight_scale, "bf16"
+        )
+    else:
+        x_fp8, x_scale = torch.ops.npu.npu_dynamic_block_quant(
+            input_2d,
+            dst_type=torch.float8_e4m3fn,
+            row_block_size=1,
+            col_block_size=128,
+        )
+        output_2d = torch.ops.npu.npu_quant_matmul(
+            x_fp8,
+            weight,
+            scale=weight_scale,
+            pertoken_scale=x_scale,
+            output_dtype=torch.bfloat16,
+            group_sizes=(1, 128, 128),
+        )
+
+    return output_2d.reshape(*orig_shape[:-1], output_2d.shape[-1])
 
 
 class _NPULinearMethodBase(LinearMethodBase):

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -41,6 +41,9 @@ _is_npu = is_npu()
 _is_fp8_fnuz = is_fp8_fnuz()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
+if _is_npu:
+    from sglang.srt.hardware_backend.npu.quantization.fused_moe_method_npu import npu_apply_without_routing_weights_fp8
+
 
 logger = logging.getLogger(__name__)
 
@@ -302,6 +305,16 @@ class DeepEPMoE(FusedMoE):
                 hidden_states = npu_fused_moe_without_routing_weights_bf16(
                     self, hidden_states, group_list_type, group_list, output_dtype
                 )
+            elif self.use_fp8_w8a8:
+                # (128,128) block-wise FP8 (B-B quantization, not G-B MXFP8) 
+                hidden_states = npu_apply_without_routing_weights_fp8(
+                    self,
+                    hidden_states,
+                    hidden_states_scale,
+                    group_list_type,
+                    group_list,
+                    output_dtype,
+                )
             else:
                 hidden_states = self.quant_method.apply_without_routing_weights(
                     self,
@@ -328,6 +341,16 @@ class DeepEPMoE(FusedMoE):
             if self.w13_weight.dtype == torch.bfloat16:
                 hidden_states = npu_fused_moe_without_routing_weights_bf16(
                     self, hidden_states, group_list_type, group_list, output_dtype
+                )
+            elif self.use_fp8_w8a8:
+                # (128,128) block-wise FP8 (B-B quantization, not G-B MXFP8)
+                hidden_states = npu_apply_without_routing_weights_fp8(
+                    self,
+                    hidden_states,
+                    hidden_states_scale,
+                    group_list_type,
+                    group_list,
+                    output_dtype,
                 )
             else:
                 hidden_states = self.quant_method.apply_without_routing_weights(

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -88,6 +88,7 @@ from sglang.srt.utils import (
     is_hip,
     is_musa,
     is_npu,
+    is_npu_before_atlas_a5,
     is_sm90_supported,
     is_sm100_supported,
     is_sm120_supported,
@@ -95,6 +96,9 @@ from sglang.srt.utils import (
     print_warning_once,
     set_weight_attrs,
     use_intel_amx_backend,
+)
+from sglang.srt.hardware_backend.npu.quantization.fused_moe_method_npu import (
+    npu_fused_experts_fp8,
 )
 
 if TYPE_CHECKING:
@@ -107,6 +111,7 @@ _is_hip = is_hip()
 _is_cuda = is_cuda()
 _is_musa = is_musa()
 _is_npu = is_npu()
+_is_npu_before_atlas_a5 = is_npu_before_atlas_a5()
 _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
 _is_fp8_fnuz = is_fp8_fnuz()
@@ -521,6 +526,20 @@ class Fp8LinearMethod(LinearMethodBase):
             layer.weight_scale_inv.requires_grad_(False)
             layer.weight_scale_inv.format_ue8m0 = True
             self._process_mxfp8_linear_weight_scale(layer)
+            return
+        elif _is_npu:
+            if _is_npu_before_atlas_a5:
+                layer.weight.data = (
+                    layer.weight.data.view(torch.uint8).transpose(-1, -2).contiguous()
+                )
+                layer.weight_scale_inv.data = layer.weight_scale_inv.data.transpose(
+                    -1, -2
+                ).contiguous()
+            else:
+                layer.weight.data = layer.weight.data.transpose(-1, -2).contiguous()
+                layer.weight_scale_inv.data = layer.weight_scale_inv.data.transpose(
+                    -1, -2
+                ).contiguous()
             return
         else:
             # For fp8 linear weights run with deepgemm, the weights and scales need be requantized to ue8m0
@@ -1280,6 +1299,36 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 _is_cpu_amx_available
             ), "Fp8MoEMethod on CPU requires that CPU has AMX support"
             _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
+        elif _is_npu:
+            if _is_npu_before_atlas_a5:
+                layer.w13_weight.data = (
+                    layer.w13_weight.data.view(torch.uint8)
+                    .transpose(1, 2)
+                    .contiguous()
+                )
+                layer.w2_weight.data = (
+                    layer.w2_weight.data.view(torch.uint8).transpose(1, 2).contiguous()
+                )
+                layer.w13_weight_scale_inv.data = (
+                    layer.w13_weight_scale_inv.data.transpose(1, 2).contiguous()
+                )
+                layer.w2_weight_scale_inv.data = (
+                    layer.w2_weight_scale_inv.data.transpose(1, 2).contiguous()
+                )
+            else:
+                layer.w13_weight.data = layer.w13_weight.data.transpose(
+                    1, 2
+                ).contiguous()
+                layer.w2_weight.data = layer.w2_weight.data.transpose(
+                    1, 2
+                ).contiguous()
+                layer.w13_weight_scale_inv.data = (
+                    layer.w13_weight_scale_inv.data.transpose(1, 2).contiguous()
+                )
+                layer.w2_weight_scale_inv.data = (
+                    layer.w2_weight_scale_inv.data.transpose(1, 2).contiguous()
+                )
+            return
         elif self.use_mxfp8:
             self._process_mxfp8_moe_weights(
                 layer, quantize=not self.quant_config.is_checkpoint_fp8_serialized
@@ -1800,6 +1849,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         x = dispatch_output.hidden_states
         moe_runner_config = self.moe_runner_config
+
+        if _is_npu:
+            topk_weights, topk_ids, _ = dispatch_output.topk_output
+            topk_ids = topk_ids.to(torch.int32)
+            topk_weights = topk_weights.to(x.dtype)
+
+            output = npu_fused_experts_fp8(
+                hidden_states=x,
+                w13=layer.w13_weight,
+                w13_weight_scale_inv=layer.w13_weight_scale_inv,
+                w2=layer.w2_weight,
+                w2_weight_scale_inv=layer.w2_weight_scale_inv,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                top_k=topk_ids.shape[1],
+            )
+            return StandardCombineInput(hidden_states=output)
 
         if use_intel_amx_backend(layer):
             from sglang.srt.layers.moe.topk import apply_topk_weights_cpu

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -43,12 +43,16 @@ from sglang.srt.utils import (
     is_gfx95_supported,
     is_hip,
     is_musa,
+    is_npu,
     is_sm90_supported,
     is_sm100_supported,
     is_sm120_supported,
     offloader,
 )
 from sglang.srt.utils.custom_op import register_custom_op
+from sglang.srt.hardware_backend.npu.quantization.linear_method_npu import (
+    fp8_matmul_npu,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +63,7 @@ _is_sm100_supported = is_sm100_supported()
 _is_sm120_supported = is_sm120_supported()
 _is_gfx95_supported = is_gfx95_supported()
 _is_musa = is_musa()
+_is_npu = is_npu()
 
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _use_aiter_gfx95 = _use_aiter and _is_gfx95_supported
@@ -459,6 +464,8 @@ def _dispatch_auto_backend() -> Callable:
         return cutlass_w8a8_block_fp8_linear_with_fallback
     elif _use_aiter:
         return aiter_w8a8_block_fp8_linear
+    elif _is_npu:
+        return fp8_matmul_npu
     else:
         return triton_w8a8_block_fp8_linear
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -159,6 +159,17 @@ def is_npu() -> bool:
 
 
 @lru_cache(maxsize=1)
+def is_npu_before_atlas_a5() -> bool:
+    if not hasattr(torch, "npu"):
+        return False
+
+    import torch_npu
+
+    device_name = torch_npu.npu.get_device_name(0)
+    return not device_name.startswith("Ascend950")
+
+
+@lru_cache(maxsize=1)
 def is_host_cpu_x86() -> bool:
     machine = platform.machine().lower()
     return (


### PR DESCRIPTION
## Motivation
This PR enables FP8 quantization support for the Ascend NPU backend in SGLang, including both (128,128) block-wise FP8 linear layers and FP8 MoE execution.

It adds native FP8 support for Atlas A5 devices, including Ascend 950 PR/DT, and introduces a SoftFP8 fallback path for pre-Atlas A5 devices that do not support native FP8 hardware compute (910B/C) .

## Modifications
- Added is_npu_before_atlas_a5() in sglang.srt.utils.common to distinguish pre-Atlas A5 devices from Atlas A5-class devices.
- Added fp8_matmul_npu() in hardware_backend/npu/quantization/linear_method_npu.py for block-wise FP8 linear execution on NPU.
- Used softfp8_w8a16_matmul for pre-Atlas A5 devices.
- Used npu_dynamic_block_quant and npu_quant_matmul for Atlas A5 and newer devices.
- Added FP8 fused MoE helper functions in hardware_backend/npu/quantization/fused_moe_method_npu.py :
- npu_fused_experts_fp8
- npu_fused_experts_fp8_decode
- npu_apply_without_routing_weights_fp8
- fp8_gmm_npu
- Updated layers/quantization/fp8_utils.py so auto backend dispatch selects the NPU FP8 block GEMM path on NPU.
- Updated layers/quantization/fp8.py to integrate NPU FP8 support into the main quantization flow:
- added NPU-specific FP8 block-quant weight layout processing for linear layers,
- added NPU-specific FP8 block-quant weight layout processing for MoE layers,
- added an NPU-specific fast path in Fp8MoEMethod.apply() for fused FP8 MoE execution.
- Kept existing CUDA, HIP, CPU, MXFP8, and DeepGEMM behavior unchanged.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->