### PR TITLE
test: add GPT-OSS-120B NPU test case (MXFP4 and MXFP4+Parsers+EAGLE3 variants)

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: GPT-OSS-120B MXFP4 and MXFP4+Parsers+EAGLE3 variants performance and accuracy test
+# test round 3: GPT-OSS-120B MXFP4 and MXFP4+Parsers+EAGLE3 variants performance and accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: GPT-OSS-120B MXFP4 and MXFP4+Parsers+EAGLE3 variants performance and accuracy test
+# test round 4: GPT-OSS-120B MXFP4 and MXFP4+Parsers+EAGLE3 variants performance and accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 4: GPT-OSS-120B MXFP4 and MXFP4+Parsers+EAGLE3 variants performance and accuracy test
+# test round 5: GPT-OSS-120B MXFP4 and MXFP4+Parsers+EAGLE3 variants performance and accuracy test
 
 on:
   pull_request:
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-2
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260605
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260611
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: GPT-OSS-120B MXFP4 and MXFP4+Parsers+EAGLE3 variants performance and accuracy test
+# test round 2: GPT-OSS-120B MXFP4 and MXFP4+Parsers+EAGLE3 variants performance and accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 5: GPT-OSS-120B MXFP4 and MXFP4+Parsers+EAGLE3 variants performance and accuracy test
+# test round 6: GPT-OSS-120B MXFP4 and MXFP4+Parsers+EAGLE3 variants performance and accuracy test
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-8
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260611
     steps:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,99 @@
+name: Single Test (NPU)
+# test round 1: GPT-OSS-120B MXFP4 and MXFP4+Parsers+EAGLE3 variants performance and accuracy test
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260605
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases - 使用时替换为实际的测试用例路径
+          test_cases=(
+            "test/registered/ascend/llm_models/test_npu_gpt_oss_120b.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/python/sglang/test/ascend/test_ascend_utils.py
+++ b/python/sglang/test/ascend/test_ascend_utils.py
@@ -86,7 +86,9 @@ GLM_5_1_W4A8_MODEL_PATH = os.path.join(MODEL_WEIGHTS_DIR, "Eco-Tech/GLM-5.1-w4a8
 GPT_OSS_120B_BF16_WEIGHTS_PATH = os.path.join(
     MODEL_WEIGHTS_DIR, "eigen-ai-labs/gpt-oss-120b-bf16"
 )
-GPT_OSS_120B_EAGLE3_DRAFT_MODEL_PATH = "lmsys/EAGLE3-gpt-oss-120b-bf16"
+GPT_OSS_120B_EAGLE3_DRAFT_MODEL_PATH = os.path.join(
+    MODEL_WEIGHTS_DIR, "eigen-ai-labs/EAGLE3-gpt-oss-120b-bf16"
+)
 GPT_OSS_120B_MXFP4_MODEL_PATH = "openai/gpt-oss-120b"
 GRANITE_3_0_3B_A800M_INSTRUCT_WEIGHTS_PATH = os.path.join(
     MODEL_WEIGHTS_DIR, "ibm-granite/granite-3.0-3b-a800m-instruct"

--- a/python/sglang/test/ascend/test_ascend_utils.py
+++ b/python/sglang/test/ascend/test_ascend_utils.py
@@ -89,7 +89,9 @@ GPT_OSS_120B_BF16_WEIGHTS_PATH = os.path.join(
 GPT_OSS_120B_EAGLE3_DRAFT_MODEL_PATH = os.path.join(
     MODEL_WEIGHTS_DIR, "eigen-ai-labs/EAGLE3-gpt-oss-120b-bf16"
 )
-GPT_OSS_120B_MXFP4_MODEL_PATH = "openai/gpt-oss-120b"
+GPT_OSS_120B_MXFP4_MODEL_PATH = os.path.join(
+    MODEL_WEIGHTS_DIR, "openai-mirror/gpt-oss-120b"
+)
 GRANITE_3_0_3B_A800M_INSTRUCT_WEIGHTS_PATH = os.path.join(
     MODEL_WEIGHTS_DIR, "ibm-granite/granite-3.0-3b-a800m-instruct"
 )

--- a/python/sglang/test/ascend/test_ascend_utils.py
+++ b/python/sglang/test/ascend/test_ascend_utils.py
@@ -86,6 +86,8 @@ GLM_5_1_W4A8_MODEL_PATH = os.path.join(MODEL_WEIGHTS_DIR, "Eco-Tech/GLM-5.1-w4a8
 GPT_OSS_120B_BF16_WEIGHTS_PATH = os.path.join(
     MODEL_WEIGHTS_DIR, "eigen-ai-labs/gpt-oss-120b-bf16"
 )
+GPT_OSS_120B_EAGLE3_DRAFT_MODEL_PATH = "lmsys/EAGLE3-gpt-oss-120b-bf16"
+GPT_OSS_120B_MXFP4_MODEL_PATH = "openai/gpt-oss-120b"
 GRANITE_3_0_3B_A800M_INSTRUCT_WEIGHTS_PATH = os.path.join(
     MODEL_WEIGHTS_DIR, "ibm-granite/granite-3.0-3b-a800m-instruct"
 )

--- a/test/registered/ascend/llm_models/test_npu_gpt_oss_120b.py
+++ b/test/registered/ascend/llm_models/test_npu_gpt_oss_120b.py
@@ -1,5 +1,9 @@
 import unittest
 
+from sglang.test.ascend.test_ascend_utils import (
+    GPT_OSS_120B_EAGLE3_DRAFT_MODEL_PATH,
+    GPT_OSS_120B_MXFP4_MODEL_PATH,
+)
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.performance_test_runner import PerformanceTestParams
 from sglang.test.run_combined_tests import run_combined_tests
@@ -12,9 +16,6 @@ register_npu_ci(
     suite="full-8-npu-a3",
     nightly=True,
 )
-
-from sglang.test.ascend.test_ascend_utils import GPT_OSS_120B_EAGLE3_DRAFT_MODEL_PATH
-from sglang.test.ascend.test_ascend_utils import GPT_OSS_120B_BF16_WEIGHTS_PATH
 
 
 

--- a/test/registered/ascend/llm_models/test_npu_gpt_oss_120b.py
+++ b/test/registered/ascend/llm_models/test_npu_gpt_oss_120b.py
@@ -18,7 +18,6 @@ register_npu_ci(
 )
 
 
-
 class TestGptOss120B(unittest.TestCase):
     """Unified test class for GPT-OSS-120B performance and accuracy.
 

--- a/test/registered/ascend/llm_models/test_npu_gpt_oss_120b.py
+++ b/test/registered/ascend/llm_models/test_npu_gpt_oss_120b.py
@@ -1,8 +1,8 @@
 import unittest
 
 from sglang.test.ascend.test_ascend_utils import (
+    GPT_OSS_120B_BF16_WEIGHTS_PATH,
     GPT_OSS_120B_EAGLE3_DRAFT_MODEL_PATH,
-    GPT_OSS_120B_MXFP4_MODEL_PATH,
 )
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.performance_test_runner import PerformanceTestParams
@@ -33,8 +33,6 @@ class TestGptOss120B(unittest.TestCase):
             "--trust-remote-code",
             "--cuda-graph-max-bs=200",
             "--mem-fraction-static=0.93",
-            "--base-gpu-id",
-            "2",
         ]
         # Lower batch size for EAGLE3 variants to avoid OOM
         base_args_eagle3 = [
@@ -42,8 +40,6 @@ class TestGptOss120B(unittest.TestCase):
             "--trust-remote-code",
             "--cuda-graph-max-bs=100",
             "--mem-fraction-static=0.85",
-            "--base-gpu-id",
-            "2",
         ]
         parser_args = [
             "--reasoning-parser=gpt-oss",
@@ -63,14 +59,14 @@ class TestGptOss120B(unittest.TestCase):
         variants = [
             # Variant 1: MXFP4 baseline
             ModelLaunchSettings(
-                GPT_OSS_120B_MXFP4_MODEL_PATH,
+                GPT_OSS_120B_BF16_WEIGHTS_PATH,
                 tp_size=8,
                 extra_args=base_args,
                 variant="MXFP4",
             ),
             # Variant 2: MXFP4 + Parsers + EAGLE3 (full featured quantized, lower batch size)
             ModelLaunchSettings(
-                GPT_OSS_120B_MXFP4_MODEL_PATH,
+                GPT_OSS_120B_BF16_WEIGHTS_PATH,
                 tp_size=8,
                 extra_args=base_args_eagle3 + parser_args + eagle3_args,
                 env=eagle3_env,

--- a/test/registered/ascend/llm_models/test_npu_gpt_oss_120b.py
+++ b/test/registered/ascend/llm_models/test_npu_gpt_oss_120b.py
@@ -1,0 +1,92 @@
+import unittest
+
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+# Runs on both H200 and B200 via nightly-8-gpu-common suite
+# Higher est_time due to 6 variants with both performance and accuracy tests
+register_npu_ci(
+    est_time=400,
+    suite="full-8-npu-a3",
+    nightly=True,
+)
+
+from sglang.test.ascend.test_ascend_utils import GPT_OSS_120B_EAGLE3_DRAFT_MODEL_PATH
+from sglang.test.ascend.test_ascend_utils import GPT_OSS_120B_BF16_WEIGHTS_PATH
+
+
+
+class TestGptOss120B(unittest.TestCase):
+    """Unified test class for GPT-OSS-120B performance and accuracy.
+
+    Testing:
+    - Basic configs for MXFP4
+    - Full config for MXFP4 with reasoning-parser, tool-call-parser, and MTP
+    """
+
+    def test_gpt_oss_120b_all_variants(self):
+        """Run performance and accuracy for all GPT-OSS-120B variants."""
+        base_args = [
+            "--tp=8",
+            "--trust-remote-code",
+            "--cuda-graph-max-bs=200",
+            "--mem-fraction-static=0.93",
+            "--base-gpu-id",
+            "2",
+        ]
+        # Lower batch size for EAGLE3 variants to avoid OOM
+        base_args_eagle3 = [
+            "--tp=8",
+            "--trust-remote-code",
+            "--cuda-graph-max-bs=100",
+            "--mem-fraction-static=0.85",
+            "--base-gpu-id",
+            "2",
+        ]
+        parser_args = [
+            "--reasoning-parser=gpt-oss",
+            "--tool-call-parser=gpt-oss",
+        ]
+        eagle3_args = [
+            "--speculative-algorithm=EAGLE3",
+            f"--speculative-draft-model-path={GPT_OSS_120B_EAGLE3_DRAFT_MODEL_PATH}",
+            "--speculative-num-steps=3",
+            "--speculative-eagle-topk=1",
+            "--speculative-num-draft-tokens=4",
+        ]
+        eagle3_env = {
+            "SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN": "1",
+        }
+
+        variants = [
+            # Variant 1: MXFP4 baseline
+            ModelLaunchSettings(
+                GPT_OSS_120B_MXFP4_MODEL_PATH,
+                tp_size=8,
+                extra_args=base_args,
+                variant="MXFP4",
+            ),
+            # Variant 2: MXFP4 + Parsers + EAGLE3 (full featured quantized, lower batch size)
+            ModelLaunchSettings(
+                GPT_OSS_120B_MXFP4_MODEL_PATH,
+                tp_size=8,
+                extra_args=base_args_eagle3 + parser_args + eagle3_args,
+                env=eagle3_env,
+                variant="MXFP4+Parsers+EAGLE3",
+            ),
+        ]
+
+        run_combined_tests(
+            models=variants,
+            test_name="GPT-OSS-120B",
+            accuracy_params=None,
+            performance_params=PerformanceTestParams(
+                profile_dir="performance_profiles_gpt_oss_120b",
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds NPU test case for GPT-OSS-120B (120B MoE model):\n\n- Variant 1: MXFP4 baseline (tp=8, cuda-graph-max-bs=200, mem-fraction-static=0.93)\n- Variant 2: MXFP4 + reasoning-parser + tool-call-parser + EAGLE3 speculative decoding (tp=8, cuda-graph-max-bs=100, mem-fraction-static=0.85)\n\nTest file: test/registered/ascend/llm_models/test_npu_gpt_oss_120b.py\nCI config: .github/workflows/single-test-npu.yml (test round 1)













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->