### PR TITLE
Add NPU Engine child PIDs test case

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,99 @@
+﻿name: Single Test (NPU)
+# test round 1: NPU Engine child PIDs test
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260611
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases
+          test_cases=(
+            "test/registered/ascend/basic_function/core/test_npu_engine_child_pids.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/test/registered/ascend/basic_function/core/test_npu_engine_child_pids.py
+++ b/test/registered/ascend/basic_function/core/test_npu_engine_child_pids.py
@@ -1,0 +1,72 @@
+import os
+import unittest
+
+import psutil
+
+import sglang as sgl
+from sglang.test.ascend.test_ascend_utils import QWEN3_0_6B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(est_time=200, suite="full-1-npu-a3", nightly=True)
+
+
+class TestNpuEngineChildPids(CustomTestCase):
+    """Test Engine child PID management on NPU.
+
+    [Test Category] Core
+    [Test Target] Verifies that launching an Engine exposes the PIDs of all child processes
+    (schedulers, detokenizer) and that those PIDs correspond to live processes.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = sgl.Engine(
+            model_path=QWEN3_0_6B_WEIGHTS_PATH,
+            random_seed=42,
+            attention_backend="ascend",
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.engine.shutdown()
+
+    def test_get_all_child_pids_returns_live_pids(self):
+        pids = self.engine.get_all_child_pids()
+        self.assertIsInstance(pids, list)
+        self.assertGreater(len(pids), 0, "Expected at least one child PID")
+        for pid in pids:
+            self.assertIsInstance(pid, int)
+            self.assertTrue(
+                psutil.pid_exists(pid),
+                f"PID {pid} does not correspond to a running process",
+            )
+        current_proc = psutil.Process(os.getpid())
+        child_pids = {c.pid for c in current_proc.children(recursive=True)}
+        for pid in pids:
+            self.assertIn(
+                pid,
+                child_pids,
+                f"PID {pid} is not a child of the current process",
+            )
+
+    def test_child_pids_include_scheduler_and_detokenizer(self):
+        pids = self.engine.get_all_child_pids()
+        # dp_size=1 gives one scheduler + one detokenizer = at least 2 PIDs
+        self.assertGreaterEqual(
+            len(pids),
+            2,
+            "Expected at least 2 child PIDs (scheduler + detokenizer)",
+        )
+
+    def test_child_pids_no_duplicates(self):
+        pids = self.engine.get_all_child_pids()
+        self.assertEqual(
+            len(pids),
+            len(set(pids)),
+            f"Duplicate PIDs found: {pids}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a test case for NPU Engine child PID management.

Test file: test/registered/ascend/basic_function/core/test_npu_engine_child_pids.py



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->