### PR TITLE
Add MiMo V2 basic and flash NPU tests

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,100 @@
+name: Single Test (NPU)
+# test round 1: MiMo V2 basic and flash tests
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases - 使用时替换为实际的测试用例路径
+          test_cases=(
+            "test/registered/ascend/basic_function/mimo/test_npu_mimo_v2.py"
+            "test/registered/ascend/basic_function/mimo/test_npu_mimo_v2_flash.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
-name: Single Test (NPU)
-# test round 1: MiMo V2 basic and flash tests
+﻿name: Single Test (NPU)
+# test round 2: MiMo V2 basic and flash tests
 
 on:
   pull_request:
@@ -38,8 +38,7 @@ jobs:
           echo "Source code path: ${sglang_source_path}"
           ln -sf ${sglang_source_path} /root/sglang
 
-          # Test cases - 使用时替换为实际的测试用例路径
-          test_cases=(
+          # Test cases - 浣跨敤鏃舵浛鎹负瀹為檯鐨勬祴璇曠敤渚嬭矾寰?          test_cases=(
             "test/registered/ascend/basic_function/mimo/test_npu_mimo_v2.py"
             "test/registered/ascend/basic_function/mimo/test_npu_mimo_v2_flash.py"
           )
@@ -98,3 +97,4 @@ jobs:
             mkdir -p ${target_plog_path}
             cp ${plog_path}/* ${target_plog_path}
           fi
+

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-2
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann8.5.0-a3
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260611
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,4 +1,4 @@
-﻿name: Single Test (NPU)
+name: Single Test (NPU)
 # test round 2: MiMo V2 basic and flash tests
 
 on:
@@ -97,4 +97,3 @@ jobs:
             mkdir -p ${target_plog_path}
             cp ${plog_path}/* ${target_plog_path}
           fi
-

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-8
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260611
     steps:

--- a/python/sglang/test/ascend/test_ascend_utils.py
+++ b/python/sglang/test/ascend/test_ascend_utils.py
@@ -375,6 +375,7 @@ CONFIG_YAML_PATH = (
 MIMO_V2_5_WEIGHTS_PATH = os.path.join(MODEL_WEIGHTS_DIR, "XiaomiMiMo/MiMo-V2.5")
 MIMO_V2_FLASH_WEIGHTS_PATH = os.path.join(MODEL_WEIGHTS_DIR, "XiaomiMiMo/MiMo-V2-Flash")
 
+
 class ModelTestConfig(NamedTuple):
     """
     Configuration for model testing.

--- a/python/sglang/test/ascend/test_ascend_utils.py
+++ b/python/sglang/test/ascend/test_ascend_utils.py
@@ -372,7 +372,8 @@ FR_SPEC_TOKEN_MAP_PATH = "/root/.cache/sglang/FR-Spec/freq_32768.pt"
 CONFIG_YAML_PATH = (
     "/__w/sglang/sglang/test/registered/ascend/basic_function/config/config.yaml"
 )
-
+MIMO_V2_5_WEIGHTS_PATH = os.path.join(MODEL_WEIGHTS_DIR, "XiaomiMiMo/MiMo-V2.5")
+MIMO_V2_FLASH_WEIGHTS_PATH = os.path.join(MODEL_WEIGHTS_DIR, "XiaomiMiMo/MiMo-V2-Flash")
 
 class ModelTestConfig(NamedTuple):
     """

--- a/test/registered/ascend/basic_function/mimo/test_npu_mimo_v2.py
+++ b/test/registered/ascend/basic_function/mimo/test_npu_mimo_v2.py
@@ -2,11 +2,11 @@ import unittest
 
 from sglang.srt.environ import envs
 from sglang.test.ascend.test_ascend_utils import MIMO_V2_5_WEIGHTS_PATH
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
 
-register_cuda_ci(est_time=400, stage="base-c", runner_config="8-gpu-h200")
+register_npu_ci(est_time=400, suite="full-8-npu-a3", nightly=True)
 
 MIMO_V2_OTHER_ARGS = [
     "--tp",

--- a/test/registered/ascend/basic_function/mimo/test_npu_mimo_v2.py
+++ b/test/registered/ascend/basic_function/mimo/test_npu_mimo_v2.py
@@ -1,0 +1,60 @@
+import unittest
+
+from sglang.srt.environ import envs
+from sglang.test.ascend.test_ascend_utils import MIMO_V2_5_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
+
+register_cuda_ci(est_time=400, stage="base-c", runner_config="8-gpu-h200")
+
+MIMO_V2_OTHER_ARGS = [
+    "--tp",
+    "8",
+    "--dp",
+    "2",
+    "--enable-dp-attention",
+    "--mm-enable-dp-encoder",
+    "--attention-backend",
+    "ascend",
+    "--mm-attention-backend",
+    "ascend_attn",
+    "--reasoning-parser",
+    "mimo",
+    "--enable-hierarchical-cache",
+    "--hicache-ratio",
+    "1.5",
+    "--hicache-mem-layout",
+    "page_first_direct",
+    "--hicache-io-backend",
+    "direct",
+]
+MIMO_V2_MTP_OTHER_ARGS = MIMO_V2_OTHER_ARGS + [
+    "--speculative-algorithm",
+    "EAGLE",
+    "--speculative-num-steps",
+    "3",
+    "--speculative-eagle-topk",
+    "1",
+    "--speculative-num-draft-tokens",
+    "4",
+    "--enable-multi-layer-eagle",
+]
+
+
+class TestMiMoV2(GSM8KMixin, MMMUServerBase):
+    gsm8k_accuracy_thres = 0.75
+    gsm8k_accept_length_thres = 2.5
+    model = MIMO_V2_5_WEIGHTS_PATH
+    mem_fraction_static = 0.65
+    server_api_key = None
+    other_args = MIMO_V2_MTP_OTHER_ARGS
+
+    @classmethod
+    def setUpClass(cls):
+        with envs.SGLANG_ENABLE_UNIFIED_RADIX_TREE.override(True):
+            super().setUpClass()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/mimo/test_npu_mimo_v2_flash.py
+++ b/test/registered/ascend/basic_function/mimo/test_npu_mimo_v2_flash.py
@@ -1,0 +1,66 @@
+import unittest
+
+from sglang.srt.environ import envs
+from sglang.test.ascend.test_ascend_utils import MIMO_V2_FLASH_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.kits.spec_decoding_kit import SpecDecodingMixin
+from sglang.test.server_fixtures.default_fixture import DefaultServerBase
+
+register_cuda_ci(est_time=350, stage="base-c", runner_config="8-gpu-h200")
+
+
+class TestMiMoV2Flash(GSM8KMixin, SpecDecodingMixin, DefaultServerBase):
+    gsm8k_accuracy_thres = 0.75
+    gsm8k_num_questions = 1319
+    gsm8k_num_threads = 1319
+    model = MIMO_V2_FLASH_WEIGHTS_PATH
+
+    other_args = [
+        "--tp",
+        "4",
+        "--dp",
+        "2",
+        "--enable-dp-attention",
+        "--trust-remote-code",
+        "--attention-backend",
+        "ascend",
+        "--max-running-requests",
+        "128",
+        "--cuda-graph-max-bs",
+        "64",
+        "--page-size",
+        "64",
+        "--mem-fraction-static",
+        "0.75",
+        "--speculative-algorithm",
+        "EAGLE",
+        "--speculative-num-steps",
+        "3",
+        "--speculative-eagle-topk",
+        "1",
+        "--speculative-num-draft-tokens",
+        "4",
+        "--enable-multi-layer-eagle",
+        "--model-loader-extra-config",
+        '{"enable_multithread_load": true,"num_threads": 64}',
+        "--enable-hierarchical-cache",
+        "--hicache-ratio",
+        "1.5",
+        "--hicache-mem-layout",
+        "page_first_direct",
+        "--hicache-io-backend",
+        "direct",
+    ]
+
+    bs_1_speed_thres = 170
+    accept_length_thres = 3.2
+
+    @classmethod
+    def setUpClass(cls):
+        with envs.SGLANG_ENABLE_UNIFIED_RADIX_TREE.override(True):
+            super().setUpClass()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/mimo/test_npu_mimo_v2_flash.py
+++ b/test/registered/ascend/basic_function/mimo/test_npu_mimo_v2_flash.py
@@ -2,12 +2,12 @@ import unittest
 
 from sglang.srt.environ import envs
 from sglang.test.ascend.test_ascend_utils import MIMO_V2_FLASH_WEIGHTS_PATH
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.spec_decoding_kit import SpecDecodingMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
-register_cuda_ci(est_time=350, stage="base-c", runner_config="8-gpu-h200")
+register_npu_ci(est_time=400, suite="full-8-npu-a3", nightly=True)
 
 
 class TestMiMoV2Flash(GSM8KMixin, SpecDecodingMixin, DefaultServerBase):


### PR DESCRIPTION
This PR adds two NPU test cases for MiMo V2:
- test_npu_mimo_v2.py: Basic function test with GSM8K and MMMU
- test_npu_mimo_v2_flash.py: Flash attention variant with speculative decoding

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->