### PR TITLE
Support LFM2 on sglang

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -37,9 +37,6 @@ from sglang.srt.layers.dp_attention import (
     get_attention_tp_size,
 )
 from sglang.srt.server_args import ServerArgs, get_global_server_args
-from sglang.srt.utils import (
-    format_tcp_address,
-)
 from sglang.srt.utils.network import (
     NetworkAddress,
     get_local_ip_auto,
@@ -787,7 +784,7 @@ class CommonKVReceiver(BaseKVReceiver):
             self.required_prefill_response_num
         )
 
-if self.kv_mgr.enable_staging:
+        if self.kv_mgr.enable_staging:
             self.require_staging = (
                 self.prefill_info.attn_tp_size != 0
                 and self.prefill_info.attn_tp_size != self.kv_mgr.attn_tp_size

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -44,11 +44,9 @@ from sglang.srt.distributed.parallel_state import get_mooncake_transfer_engine
 from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs, get_global_server_args
 from sglang.srt.utils import (
-    format_tcp_address,
     get_split_kv_page_range,
-    is_valid_ipv6_address,
 )
-from sglang.srt.utils.network import NetworkAddress
+from sglang.srt.utils.network import NetworkAddress, is_valid_ipv6_address
 
 logger = logging.getLogger(__name__)
 
@@ -1797,7 +1795,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
             self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
             return
 
-if get_global_server_args().enable_kv_storage_optimization_mla:
+        if get_global_server_args().enable_kv_storage_optimization_mla:
             kv_indices_origin = kv_indices
 
         if (

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -62,7 +62,6 @@ from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool, NSATokenToKVPoo
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.observability.req_time_stats import set_schedule_time_batch
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.tracing.trace import trace_event_batch, trace_slice, trace_slice_end
 from sglang.srt.utils import get_split_kv_page_range
 
 if TYPE_CHECKING:

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -254,6 +254,8 @@ def _cp_allgather_and_save_kv_npu(forward_batch, layer, k, v, cp_size):
 class AscendAttnBackend(AttentionBackend):
 
     def __init__(self, model_runner: ModelRunner, speculative_step_id: int = 0):
+        _arches = model_runner.model_config.hf_config.architectures
+
         super().__init__()
         self.forward_metadata = None
         self.device = model_runner.device
@@ -282,6 +284,13 @@ class AscendAttnBackend(AttentionBackend):
             if (
                 "Gemma2ForSequenceClassification"
                 in model_runner.model_config.hf_config.architectures
+            ):
+                self.use_native_sdpa = True
+            # LFM2 attention shapes hit an Ascend flash-attention accuracy issue;
+            # route them through the existing torch SDPA fallback.
+            if any(
+                a in _arches
+                for a in ("Lfm2ForCausalLM", "Lfm2VlForConditionalGeneration")
             ):
                 self.use_native_sdpa = True
         self.native_attn = AscendTorchNativeAttnBackend()
@@ -2046,7 +2055,13 @@ class AscendAttnBackend(AttentionBackend):
                     )
             # there are some accuracy issues in cross attention scene to use torch_npu._npu_flash_attention_qlens
             # forward_batch.encoder_lens is not None in cross attention scend, we add native attn to solve accuracy issues
-            elif forward_batch.encoder_lens is None and layer.logit_cap == 0:
+            elif (
+                forward_batch.encoder_lens is None
+                and layer.logit_cap == 0
+                # Keep the flash-attn path disabled for architectures that were
+                # explicitly marked to use the SDPA fallback in __init__.
+                and not getattr(self, "use_native_sdpa", False)
+            ):
                 query = q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
                 num_tokens = query.shape[0]
                 if not self.use_alibi:

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -37,7 +37,7 @@ from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.layers.attention.nsa.utils import is_nsa_prefill_cp_in_seq_split
 from sglang.srt.layers.attention.nsa.utils import is_nsa_prefill_cp_in_seq_split
 from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
-from sglang.srt.managers.schedule_batch import DllmStagingReqs, Req, ScheduleBatch
+from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.utils import recalculate_request_max_len
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2597,10 +2597,9 @@ class Scheduler(
             self.enable_overlap,
             self.spec_algorithm,
             chunked_req=self.chunked_req,
-            dllm_staging_reqs=self.dllm_staging_reqs,
             dllm_config=self.dllm_config,
-            split_kv_size=self.attn_tp_size,
-            split_kv_rank=self.attn_tp_rank,
+            split_kv_size=self.ps.attn_tp_size,
+            split_kv_rank=self.ps.attn_tp_rank,
         )
         self.max_prefill_bs = max(self.max_prefill_bs, len(can_run_list))
         if self.enable_hierarchical_cache:

--- a/python/sglang/srt/models/lfm2.py
+++ b/python/sglang/srt/models/lfm2.py
@@ -20,10 +20,23 @@ from torch import nn
 
 from sglang.srt.configs.lfm2 import Lfm2Config
 from sglang.srt.distributed import get_pp_group, get_tensor_model_parallel_world_size
-from sglang.srt.layers.attention.mamba.causal_conv1d import (
-    causal_conv1d_fn,
-    causal_conv1d_update,
-)
+from sglang.srt.utils import is_npu as _lfm2_is_npu
+
+_LFM2_IS_NPU = _lfm2_is_npu()
+# LFM2 conv layers share the Mamba cache path. On Ascend, the generic wrapper
+# can fall back to Triton, whose cache layout check does not match the NPU pool.
+if _LFM2_IS_NPU:
+    from sgl_kernel_npu.mamba.causal_conv1d import (
+        causal_conv1d_fn_npu as causal_conv1d_fn,
+    )
+    from sgl_kernel_npu.mamba.causal_conv1d import (
+        causal_conv1d_update_npu as causal_conv1d_update,
+    )
+else:
+    from sglang.srt.layers.attention.mamba.causal_conv1d import (
+        causal_conv1d_fn,
+        causal_conv1d_update,
+    )
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
     ColumnParallelLinear,
@@ -277,14 +290,28 @@ class Lfm2ShortConv(nn.Module):
 
         if forward_batch.forward_mode.is_decode():
             # Decode: single token per request, use optimized update kernel
-            conv_out = causal_conv1d_update(
-                Bx,
-                conv_state,
-                self.conv_weight,
-                self.conv_bias,
-                activation=None,
-                conv_state_indices=mamba_indices.to(torch.int32),
-            )
+            if _LFM2_IS_NPU:
+                # NPU MambaPool stores cache as (pool, kernel-1, dim), while
+                # the Ascend conv kernel consumes (pool, dim, kernel-1).
+                conv_state_kernel = conv_state.transpose(1, 2).contiguous()
+                conv_out = causal_conv1d_update(
+                    Bx,
+                    conv_state_kernel,
+                    self.conv_weight,
+                    self.conv_bias,
+                    activation=None,
+                    conv_state_indices=mamba_indices.to(torch.int32),
+                )
+                conv_state.copy_(conv_state_kernel.transpose(1, 2))
+            else:
+                conv_out = causal_conv1d_update(
+                    Bx,
+                    conv_state,
+                    self.conv_weight,
+                    self.conv_bias,
+                    activation=None,
+                    conv_state_indices=mamba_indices.to(torch.int32),
+                )
         else:
             # Prefill: multiple tokens, use varlen kernel
             T = hidden_states.shape[0]
@@ -310,16 +337,49 @@ class Lfm2ShortConv(nn.Module):
                 cache_indices = mamba_indices[:1].to(torch.int32)
                 has_initial_state = forward_batch.extend_prefix_lens[:1] > 0
 
-            conv_out = causal_conv1d_fn(
-                Bx_t,
-                self.conv_weight,
-                self.conv_bias,
-                query_start_loc=query_start_loc,
-                cache_indices=cache_indices,
-                has_initial_state=has_initial_state,
-                conv_states=conv_state,
-                activation=None,
-            ).transpose(0, 1)
+            if _LFM2_IS_NPU:
+                # The Ascend varlen conv kernel requires an explicit per-request
+                # initial-state mask instead of the CUDA/Triton None shortcut.
+                extend_prefix_lens = forward_batch.extend_prefix_lens
+                if (
+                    extend_prefix_lens is not None
+                    and extend_prefix_lens.numel() == cache_indices.numel()
+                ):
+                    has_initial_state = (extend_prefix_lens > 0).to(
+                        device=hidden_states.device
+                    )
+                else:
+                    has_initial_state = torch.zeros(
+                        cache_indices.numel(),
+                        dtype=torch.bool,
+                        device=hidden_states.device,
+                    )
+
+                # Convert the NPU pool layout to the kernel layout and copy back
+                # because the kernel updates the cache in place.
+                conv_state_kernel = conv_state.transpose(1, 2).contiguous()
+                conv_out = causal_conv1d_fn(
+                    Bx_t,
+                    self.conv_weight,
+                    self.conv_bias,
+                    query_start_loc=query_start_loc,
+                    cache_indices=cache_indices,
+                    has_initial_state=has_initial_state,
+                    conv_states=conv_state_kernel,
+                    activation=None,
+                ).transpose(0, 1)
+                conv_state.copy_(conv_state_kernel.transpose(1, 2))
+            else:
+                conv_out = causal_conv1d_fn(
+                    Bx_t,
+                    self.conv_weight,
+                    self.conv_bias,
+                    query_start_loc=query_start_loc,
+                    cache_indices=cache_indices,
+                    has_initial_state=None,
+                    conv_states=conv_state,
+                    activation=None,
+                ).transpose(0, 1)
 
         output, _ = self.out_proj(C_gate * conv_out)
         return output

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2401,7 +2401,10 @@ class ServerArgs:
                     sm100_default_attention_backend="triton",
                 )
 
-        elif model_arch in ["Lfm2ForCausalLM"]:
+        elif model_arch in ["Lfm2ForCausalLM", "Lfm2VlForConditionalGeneration"]:
+            # The VL wrapper still uses the LFM2 text decoder with conv/Mamba
+            # layers, so it needs the same radix-cache page-size handling to
+            # force page_size=1 and allocate the extra Mamba cache buffers.
             self._handle_mamba_radix_cache(
                 model_arch=model_arch,
                 support_mamba_cache=True,


### PR DESCRIPTION
  ## Motivation

  Enable LFM2-VL inference on Ascend NPU in SGLang by fixing the NPU execution path and removing startup blockers caused by stale imports
  and missing runtime assumptions.

  ## Modifications

  - Route LFM2 causal convolution to the Ascend NPU kernel when running on NPU, instead of falling back to the Triton path.
  - Keep the NPU conv cache layout conversion consistent between the SGLang runtime and the Ascend kernel.
  - Make the LFM2-VL path use the same Mamba radix-cache handling as the text-model path.
  - Force native SDPA for LFM2 attention on Ascend to avoid accuracy issues in the flash-attention path.
  - Remove stale or invalid imports and obsolete scheduler arguments that broke startup on the current codebase.
  - Fix scheduler attention TP field access to use `ParallelState`.

  ## Accuracy Tests
<img width="986" height="241" alt="gsm8k" src="https://github.com/user-attachments/assets/a7327468-36a7-4724-8787-521e93e24346" />

  Not run yet.

  ## Speed Tests and Profiling

  Not run yet.

  ## Checklist

  - [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/
  contribution_guide.html#format-code-with-pre-commit).
  - [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-
  add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-
  documentations).
  - [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/
  contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/
  contribution_guide.html#benchmark-the-speed).
  - [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->