### PR TITLE
test: add Llama-4-Scout NPU accuracy and performance test

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 4: Llama-4-Scout accuracy and performance test
+# test round 5: Llama-4-Scout accuracy test only
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-8
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
     steps:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 9: Llama-4-Scout with monkey-patched 1800s timeout
+# test round 10: Llama-4-Scout with isort fix + monkey-patched 1800s timeout
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 6: Llama-4-Scout accuracy + performance with 1800s timeout
+# test round 7: Llama-4-Scout with launch_timeout fix
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -41,7 +41,8 @@ jobs:
           # Test cases
           test_cases=(
             #"test/registered/ascend/llm_models/test_npu_llama4.py"
-            "test/registered/ascend/llm_models/test_npu_serving_transcription.py"
+            #"test/registered/ascend/llm_models/test_npu_serving_transcription.py"
+            test/registered/ascend/llm_models/test_npu_input_embeds_chunked (1).py
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: Llama-4-Scout accuracy and performance test
+# test round 3: Llama-4-Scout accuracy and performance test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -41,6 +41,7 @@ jobs:
           # Test cases
           test_cases=(
             "test/registered/ascend/llm_models/test_npu_llama4.py"
+            "test/registered/ascend/llm_models/test_npu_serving_transcription.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,99 @@
+name: Single Test (NPU)
+# test round 1: Llama-4-Scout accuracy and performance test
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases
+          test_cases=(
+            "test/registered/ascend/llm_models/test_npu_llama4.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 8: Llama-4-Scout accuracy test only (final)
+# test round 9: Llama-4-Scout with monkey-patched 1800s timeout
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 7: Llama-4-Scout with launch_timeout fix
+# test round 8: Llama-4-Scout accuracy test only (final)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: Llama-4-Scout accuracy and performance test
+# test round 4: Llama-4-Scout accuracy and performance test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -40,7 +40,7 @@ jobs:
 
           # Test cases
           test_cases=(
-            "test/registered/ascend/llm_models/test_npu_llama4.py"
+            #"test/registered/ascend/llm_models/test_npu_llama4.py"
             "test/registered/ascend/llm_models/test_npu_serving_transcription.py"
           )
 

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: Llama-4-Scout accuracy and performance test
+# test round 2: Llama-4-Scout accuracy and performance test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 5: Llama-4-Scout accuracy test only
+# test round 6: Llama-4-Scout accuracy + performance with 1800s timeout
 
 on:
   pull_request:

--- a/python/sglang/test/ascend/test_ascend_utils.py
+++ b/python/sglang/test/ascend/test_ascend_utils.py
@@ -413,7 +413,9 @@ QWQ_32B_W8A8_WEIGHTS_FOR_TEST = ModelTestConfig(
 
 # Default configuration for testing
 DEFAULT_WEIGHTS_FOR_TEST = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_FOR_TEST
-
+WHISPER_LARGE_V3_WEIGHTS_PATH = os.path.join(
+    MODEL_WEIGHTS_DIR, "openai-mirror/whisper-large-v3"
+)
 
 def run_command(cmd, shell=True):
     """Execute system command and return stdout

--- a/python/sglang/test/performance_test_runner.py
+++ b/python/sglang/test/performance_test_runner.py
@@ -80,6 +80,7 @@ def run_performance_test(
             variant=model.variant or "",
             extra_bench_args=extra_bench_args,
             env=model.env,
+            timeout=model.launch_timeout,
         )
 
         if success and results:

--- a/test/registered/ascend/llm_models/test_npu_input_embeds_chunked (1).py
+++ b/test/registered/ascend/llm_models/test_npu_input_embeds_chunked (1).py
@@ -1,0 +1,190 @@
+"""Regression tests for input_embeds shape-mismatch bugs.
+
+Covers two bugs with the same crash signature
+(RuntimeError: shape mismatch in set_kv_buffer) but opposite polarity:
+
+- Chunked prefill truncation (#20376): PrefillAdder shrinks fill_len and
+  extend_input_len on chunk overflow but not input_embeds, so the full array
+  flows through while out_cache_loc is sized for the truncated length.
+  Polarity: cache_k > loc.
+
+- Retraction with output_ids (#14110): after retraction, get_fill_ids()
+  includes accumulated output_ids but input_embeds only covers
+  origin_input_ids. Polarity: cache_k < loc.
+"""
+
+import unittest
+
+import requests
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_0_6B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
+
+CHUNKED_PREFILL_SIZE = 256
+
+# Shared reference model — loaded once per process, not per test class.
+_MODEL = QWEN3_0_6B_WEIGHTS_PATH
+_tokenizer = None
+_ref_model = None
+
+
+def _load_ref():
+    global _tokenizer, _ref_model
+    if _tokenizer is None:
+        _tokenizer = AutoTokenizer.from_pretrained(_MODEL)
+        _ref_model = AutoModelForCausalLM.from_pretrained(_MODEL)
+
+
+def _embeds_for(text: str) -> list[list[float]]:
+    _load_ref()
+    ids = _tokenizer(text, return_tensors="pt")["input_ids"]
+    embeds = _ref_model.get_input_embeddings()(ids)
+    return embeds.squeeze(0).to(torch.float32).tolist()
+
+
+def _generate(base_url, input_embeds, max_new_tokens, ignore_eos=False, timeout=120):
+    resp = requests.post(
+        f"{base_url}/generate",
+        json={
+            "input_embeds": input_embeds,
+            "sampling_params": {
+                "temperature": 0,
+                "max_new_tokens": max_new_tokens,
+                "ignore_eos": ignore_eos,
+            },
+        },
+        timeout=timeout,
+    )
+    return resp
+
+
+class TestInputEmbedsChunkedAndRetract(CustomTestCase):
+    """Single server launch covering both bugs.
+
+    Both tests require --disable-radix-cache (for input_embeds). The chunked
+    prefill test needs a small --chunked-prefill-size. The retraction test
+    uses SGLANG_TEST_RETRACT to deterministically force retraction every few
+    scheduler iterations regardless of KV pressure.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        # SGLANG_TEST_RETRACT forces retraction periodically; this is
+        # deterministic and doesn't require guessing KV budgets.
+        with envs.SGLANG_TEST_RETRACT.override(True):
+            cls.process = popen_launch_server(
+                _MODEL,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    "--disable-radix-cache",
+                    "--chunked-prefill-size",
+                    str(CHUNKED_PREFILL_SIZE),
+                    "--cuda-graph-max-bs",
+                    "4",
+                    "--attention-backend",
+                    "ascend",
+                ],
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _assert_server_alive(self):
+        self.assertIsNone(self.process.poll(), "server process crashed")
+
+    def test_chunked_prefill_truncation_and_continuation(self):
+        """Regression test for #20376.
+
+        A single request longer than chunked_prefill_size deterministically
+        exercises both (a) first-chunk truncation and (b) chunk continuation,
+        without any concurrent-timing dependency. Pre-fix this crashes in
+        set_kv_buffer on both chunks.
+        """
+        # ~80 tokens each repetition; 6 repetitions exceeds CHUNKED_PREFILL_SIZE
+        # comfortably. Token count is model-dependent so assert it.
+        text = "The quick brown fox jumps over the lazy dog. " * 40
+        embeds = _embeds_for(text)
+        self.assertGreater(
+            len(embeds),
+            CHUNKED_PREFILL_SIZE,
+            f"prompt must exceed chunked_prefill_size={CHUNKED_PREFILL_SIZE} "
+            f"to trigger chunking; got {len(embeds)} tokens",
+        )
+
+        resp = _generate(self.base_url, embeds, max_new_tokens=8)
+        self.assertEqual(resp.status_code, 200, resp.text[:300])
+        body = resp.json()
+        self.assertIn("text", body)
+        self.assertIsInstance(body["text"], str)
+        self._assert_server_alive()
+
+    def test_chunked_prefill_batch_truncation(self):
+        """Regression test for #20376 — multi-request batch case.
+
+        A batch POST with total tokens > chunked_prefill_size goes through a
+        single ZMQ send, so all requests land in the same scheduler iteration
+        and the PrefillAdder is forced to truncate at least one. This matches
+        the original thundering-herd trigger without HTTP timing races.
+        """
+        text = "The quick brown fox jumps over the lazy dog. " * 8
+        embeds = _embeds_for(text)
+        seq_len = len(embeds)
+
+        # Enough batched requests to overflow the chunk budget.
+        n = max(4, CHUNKED_PREFILL_SIZE // seq_len + 2)
+        self.assertGreater(n * seq_len, CHUNKED_PREFILL_SIZE)
+
+        resp = _generate(self.base_url, [embeds] * n, max_new_tokens=8)
+        self.assertEqual(resp.status_code, 200, resp.text[:300])
+        results = resp.json()
+        self.assertEqual(len(results), n)
+        for r in results:
+            self.assertIn("text", r)
+        self._assert_server_alive()
+
+    def test_retraction_with_output_ids(self):
+        """Regression test for #14110.
+
+        SGLANG_TEST_RETRACT forces retraction every few scheduler iterations.
+        Combined with ignore_eos and a reasonable max_new_tokens, at least one
+        request is retracted mid-decode with non-empty output_ids, then
+        re-prefilled. Pre-#14110 this crashes (cache_k < loc) because the
+        filled token sequence includes output_ids but input_embeds does not.
+        """
+        text = "The quick brown fox jumps over the lazy dog. " * 4
+        embeds = _embeds_for(text)
+
+        # Batch of requests with enough decode steps that SGLANG_TEST_RETRACT
+        # (interval=3 by default) fires mid-decode.
+        n = 4
+        resp = _generate(
+            self.base_url,
+            [embeds] * n,
+            max_new_tokens=32,
+            ignore_eos=True,
+        )
+        self.assertEqual(resp.status_code, 200, resp.text[:300])
+        results = resp.json()
+        self.assertEqual(len(results), n)
+        for r in results:
+            self.assertIn("text", r)
+        self._assert_server_alive()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/llm_models/test_npu_llama4.py
+++ b/test/registered/ascend/llm_models/test_npu_llama4.py
@@ -31,7 +31,9 @@ class TestLlama4(unittest.TestCase):
             "--trust-remote-code",
             "--chat-template=llama-4",
             "--mem-fraction-static=0.8",
-            "--context-length=1000000",
+            "--context-length=8192",
+            "--disable-cuda-graph",
+            "--disable-radix-cache",
         ]
 
         variants = [

--- a/test/registered/ascend/llm_models/test_npu_llama4.py
+++ b/test/registered/ascend/llm_models/test_npu_llama4.py
@@ -1,11 +1,17 @@
 import unittest
 
+# Monkey-patch the default server launch timeout before importing test modules.
+# Llama-4-Scout 17B with TP=8 requires more than the default 600s to load.
+import sglang.test.test_utils as _test_utils
+_test_utils.DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH = 1800
+
 from sglang.test.accuracy_test_runner import AccuracyTestParams
 from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.performance_test_runner import PerformanceTestParams
 from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.test_utils import ModelLaunchSettings
 
-register_npu_ci(est_time=1800, suite="full-8-npu-a3", nightly=True)
+register_npu_ci(est_time=3600, suite="full-8-npu-a3", nightly=True)
 
 from sglang.test.ascend.test_ascend_utils import (
     LLAMA_4_SCOUT_17B_16E_INSTRUCT_WEIGHTS_PATH,
@@ -20,7 +26,7 @@ class TestLlama4(unittest.TestCase):
     """
 
     def test_llama4(self):
-        """Run accuracy test for Llama-4-Scout."""
+        """Run performance and accuracy test for Llama-4-Scout."""
         base_args = [
             "--tp=8",
             "--trust-remote-code",
@@ -44,6 +50,9 @@ class TestLlama4(unittest.TestCase):
             models=variants,
             test_name="Llama-4-Scout",
             accuracy_params=AccuracyTestParams(dataset="gsm8k", baseline_accuracy=0.9),
+            performance_params=PerformanceTestParams(
+                profile_dir="performance_profiles_llama4",
+            ),
         )
 
 

--- a/test/registered/ascend/llm_models/test_npu_llama4.py
+++ b/test/registered/ascend/llm_models/test_npu_llama4.py
@@ -2,11 +2,9 @@ import unittest
 
 from sglang.test.accuracy_test_runner import AccuracyTestParams
 from sglang.test.ci.ci_register import register_npu_ci
-from sglang.test.performance_test_runner import PerformanceTestParams
 from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.test_utils import ModelLaunchSettings
 
-# Runs on both H200 and B200 via nightly-8-gpu-common suite
 register_npu_ci(est_time=1800, suite="full-8-npu-a3", nightly=True)
 
 from sglang.test.ascend.test_ascend_utils import (
@@ -15,17 +13,14 @@ from sglang.test.ascend.test_ascend_utils import (
 
 
 class TestLlama4(unittest.TestCase):
-    """Unified test class for Llama-4-Scout performance and accuracy.
+    """Testcase: Verify that the inference accuracy of the meta-llama/Llama-4-Scout-17B-16E-Instruct model on the GSM8K dataset is no less than 0.9.
 
-    Llama4 has local attention mechanism with hybrid sliding window attention.
-    Single variant with TP=8 configuration.
-    Runs BOTH:
-    - Performance test (using NightlyBenchmarkRunner)
-    - Accuracy test (using run_eval with gsm8k)
+    [Test Category] Model
+    [Test Target] meta-llama/Llama-4-Scout-17B-16E-Instruct
     """
 
     def test_llama4(self):
-        """Run performance and accuracy for Llama-4-Scout."""
+        """Run accuracy test for Llama-4-Scout."""
         base_args = [
             "--tp=8",
             "--trust-remote-code",
@@ -49,9 +44,6 @@ class TestLlama4(unittest.TestCase):
             models=variants,
             test_name="Llama-4-Scout",
             accuracy_params=AccuracyTestParams(dataset="gsm8k", baseline_accuracy=0.9),
-            performance_params=PerformanceTestParams(
-                profile_dir="performance_profiles_llama4",
-            ),
         )
 
 

--- a/test/registered/ascend/llm_models/test_npu_llama4.py
+++ b/test/registered/ascend/llm_models/test_npu_llama4.py
@@ -2,10 +2,11 @@ import unittest
 
 from sglang.test.accuracy_test_runner import AccuracyTestParams
 from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.performance_test_runner import PerformanceTestParams
 from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.test_utils import ModelLaunchSettings
 
-register_npu_ci(est_time=1800, suite="full-8-npu-a3", nightly=True)
+register_npu_ci(est_time=3600, suite="full-8-npu-a3", nightly=True)
 
 from sglang.test.ascend.test_ascend_utils import (
     LLAMA_4_SCOUT_17B_16E_INSTRUCT_WEIGHTS_PATH,
@@ -20,7 +21,7 @@ class TestLlama4(unittest.TestCase):
     """
 
     def test_llama4(self):
-        """Run accuracy test for Llama-4-Scout."""
+        """Run performance and accuracy test for Llama-4-Scout."""
         base_args = [
             "--tp=8",
             "--trust-remote-code",
@@ -37,6 +38,7 @@ class TestLlama4(unittest.TestCase):
                 tp_size=8,
                 extra_args=base_args,
                 variant="TP8",
+                launch_timeout=1800,
             ),
         ]
 
@@ -44,6 +46,9 @@ class TestLlama4(unittest.TestCase):
             models=variants,
             test_name="Llama-4-Scout",
             accuracy_params=AccuracyTestParams(dataset="gsm8k", baseline_accuracy=0.9),
+            performance_params=PerformanceTestParams(
+                profile_dir="performance_profiles_llama4",
+            ),
         )
 
 

--- a/test/registered/ascend/llm_models/test_npu_llama4.py
+++ b/test/registered/ascend/llm_models/test_npu_llama4.py
@@ -3,6 +3,7 @@ import unittest
 # Monkey-patch the default server launch timeout before importing test modules.
 # Llama-4-Scout 17B with TP=8 requires more than the default 600s to load.
 import sglang.test.test_utils as _test_utils
+
 _test_utils.DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH = 1800
 
 from sglang.test.accuracy_test_runner import AccuracyTestParams

--- a/test/registered/ascend/llm_models/test_npu_llama4.py
+++ b/test/registered/ascend/llm_models/test_npu_llama4.py
@@ -1,0 +1,57 @@
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+# Runs on both H200 and B200 via nightly-8-gpu-common suite
+register_npu_ci(est_time=1800, suite="full-8-npu-a3", nightly=True)
+
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_4_SCOUT_17B_16E_INSTRUCT_WEIGHTS_PATH,
+)
+
+
+class TestLlama4(unittest.TestCase):
+    """Unified test class for Llama-4-Scout performance and accuracy.
+
+    Llama4 has local attention mechanism with hybrid sliding window attention.
+    Single variant with TP=8 configuration.
+    Runs BOTH:
+    - Performance test (using NightlyBenchmarkRunner)
+    - Accuracy test (using run_eval with gsm8k)
+    """
+
+    def test_llama4(self):
+        """Run performance and accuracy for Llama-4-Scout."""
+        base_args = [
+            "--tp=8",
+            "--trust-remote-code",
+            "--chat-template=llama-4",
+            "--mem-fraction-static=0.8",
+            "--context-length=1000000",
+        ]
+
+        variants = [
+            ModelLaunchSettings(
+                LLAMA_4_SCOUT_17B_16E_INSTRUCT_WEIGHTS_PATH,
+                tp_size=8,
+                extra_args=base_args,
+                variant="TP8",
+            ),
+        ]
+
+        run_combined_tests(
+            models=variants,
+            test_name="Llama-4-Scout",
+            accuracy_params=AccuracyTestParams(dataset="gsm8k", baseline_accuracy=0.9),
+            performance_params=PerformanceTestParams(
+                profile_dir="performance_profiles_llama4",
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/llm_models/test_npu_llama4.py
+++ b/test/registered/ascend/llm_models/test_npu_llama4.py
@@ -2,11 +2,10 @@ import unittest
 
 from sglang.test.accuracy_test_runner import AccuracyTestParams
 from sglang.test.ci.ci_register import register_npu_ci
-from sglang.test.performance_test_runner import PerformanceTestParams
 from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.test_utils import ModelLaunchSettings
 
-register_npu_ci(est_time=3600, suite="full-8-npu-a3", nightly=True)
+register_npu_ci(est_time=1800, suite="full-8-npu-a3", nightly=True)
 
 from sglang.test.ascend.test_ascend_utils import (
     LLAMA_4_SCOUT_17B_16E_INSTRUCT_WEIGHTS_PATH,
@@ -21,7 +20,7 @@ class TestLlama4(unittest.TestCase):
     """
 
     def test_llama4(self):
-        """Run performance and accuracy test for Llama-4-Scout."""
+        """Run accuracy test for Llama-4-Scout."""
         base_args = [
             "--tp=8",
             "--trust-remote-code",
@@ -38,7 +37,6 @@ class TestLlama4(unittest.TestCase):
                 tp_size=8,
                 extra_args=base_args,
                 variant="TP8",
-                launch_timeout=1800,
             ),
         ]
 
@@ -46,9 +44,6 @@ class TestLlama4(unittest.TestCase):
             models=variants,
             test_name="Llama-4-Scout",
             accuracy_params=AccuracyTestParams(dataset="gsm8k", baseline_accuracy=0.9),
-            performance_params=PerformanceTestParams(
-                profile_dir="performance_profiles_llama4",
-            ),
         )
 
 

--- a/test/registered/ascend/llm_models/test_npu_serving_transcription.py
+++ b/test/registered/ascend/llm_models/test_npu_serving_transcription.py
@@ -1,0 +1,231 @@
+"""
+Test the OpenAI-compatible /v1/audio/transcriptions endpoint with Whisper.
+
+"""
+
+import io
+import json
+import unittest
+from typing import List, Optional
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import WHISPER_LARGE_V3_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=100, suite="full-1-npu-a3", nightly=True)
+
+
+AUDIO_URL = "https://raw.githubusercontent.com/sgl-project/sgl-test-files/refs/heads/main/audios/Trump_WEF_2018_10s.mp3"
+
+
+def download_audio_bytes(url=AUDIO_URL):
+    """Download audio file and return raw bytes."""
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.content
+
+
+class TestServingTranscription(CustomTestCase):
+    """Test Whisper transcription via /v1/audio/transcriptions endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = WHISPER_LARGE_V3_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--served-model-name",
+                "whisper",
+                "--attention-backend",
+                "ascend",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def _transcribe(
+        self,
+        language: Optional[str] = "en",
+        response_format: Optional[str] = None,
+        timestamp_granularities: Optional[List[str]] = None,
+    ):
+        """Send a non-streaming transcription request and return the JSON response.
+
+        Passing ``language=None`` omits the field entirely, which exercises
+        the fused auto-detect path.
+        """
+        audio_bytes = download_audio_bytes()
+        data = {"model": "whisper"}
+        if language is not None:
+            data["language"] = language
+        if response_format is not None:
+            data["response_format"] = response_format
+        if timestamp_granularities is not None:
+            # Form-encoded list fields repeat the key
+            data["timestamp_granularities[]"] = timestamp_granularities
+        response = requests.post(
+            self.base_url + "/v1/audio/transcriptions",
+            files={"file": ("audio.mp3", io.BytesIO(audio_bytes), "audio/mpeg")},
+            data=data,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()
+
+    def _transcribe_stream(self, language: Optional[str] = None) -> List[str]:
+        """Send a streaming transcription request and return the delta strings."""
+        audio_bytes = download_audio_bytes()
+        data = {"model": "whisper", "stream": "true"}
+        if language is not None:
+            data["language"] = language
+        with requests.post(
+            self.base_url + "/v1/audio/transcriptions",
+            files={"file": ("audio.mp3", io.BytesIO(audio_bytes), "audio/mpeg")},
+            data=data,
+            stream=True,
+            timeout=120,
+        ) as response:
+            self.assertEqual(response.status_code, 200, response.text)
+            deltas: List[str] = []
+            for raw in response.iter_lines():
+                if not raw:
+                    continue
+                line = raw.decode("utf-8")
+                if not line.startswith("data: "):
+                    continue
+                payload = line[len("data: ") :].strip()
+                if payload == "[DONE]":
+                    break
+                obj = json.loads(payload)
+                for choice in obj.get("choices", []):
+                    content = (choice.get("delta") or {}).get("content")
+                    if content:
+                        deltas.append(content)
+            return deltas
+
+    def test_basic_transcription(self):
+        """Test that transcription returns a valid non-empty response."""
+        result = self._transcribe()
+        self.assertIn("text", result)
+        self.assertTrue(len(result["text"]) > 0, "Transcription should not be empty")
+
+    def test_transcription_content_quality(self):
+        """Test that transcription captures key content from the audio."""
+        result = self._transcribe()
+        text = result["text"].lower()
+        keywords = ["privilege", "leader", "science", "art"]
+        matches = [kw for kw in keywords if kw in text]
+        self.assertGreaterEqual(
+            len(matches),
+            2,
+            f"Expected at least 2 of {keywords} in transcription, "
+            f"found {matches}. Full text: {text}",
+        )
+
+    def test_multiple_sequential_requests(self):
+        """Test that sequential requests produce consistent results."""
+        results = []
+        for _ in range(3):
+            result = self._transcribe()
+            self.assertIn("text", result)
+            self.assertTrue(len(result["text"]) > 0)
+            results.append(result["text"])
+
+        for i in range(1, len(results)):
+            self.assertEqual(
+                results[0],
+                results[i],
+                f"Transcription {i + 1} differs from first transcription",
+            )
+
+    # -- fused auto-detect (language=None) ---------------------------------
+    # The clip is English, so the fused path must both produce a valid
+    # transcription AND expose "en" as the detected language. None of the
+    # deltas / text fields should leak Whisper special tokens.
+
+    def test_auto_detect_language_verbose_json(self):
+        """language omitted + verbose_json returns detected language + clean text."""
+        result = self._transcribe(language=None, response_format="verbose_json")
+        self.assertEqual(result.get("language"), "en")
+        text = result.get("text", "")
+        self.assertTrue(len(text) > 0, "Transcription should not be empty")
+        self.assertNotIn("<|", text, f"Special token leaked into text: {text!r}")
+        # Sanity-check content against the same keywords the English test uses.
+        keywords = ["privilege", "leader", "science", "art"]
+        matches = [kw for kw in keywords if kw in text.lower()]
+        self.assertGreaterEqual(
+            len(matches),
+            2,
+            f"Expected at least 2 of {keywords} in auto-detected transcription, "
+            f"found {matches}. Full text: {text!r}",
+        )
+
+    def test_auto_detect_matches_explicit_english(self):
+        """Auto-detected (language=None) text should match explicit language=en."""
+        auto = self._transcribe(language=None).get("text", "")
+        explicit = self._transcribe(language="en").get("text", "")
+        self.assertEqual(
+            auto.strip(),
+            explicit.strip(),
+            "Auto-detect should produce the same transcription as language=en "
+            "on an English clip.",
+        )
+        self.assertNotIn("<|", auto)
+
+    def test_auto_detect_with_segment_timestamps(self):
+        """language=None + timestamp_granularities uses the timestamps fused regex."""
+        result = self._transcribe(
+            language=None,
+            response_format="verbose_json",
+            timestamp_granularities=["segment"],
+        )
+        self.assertEqual(result.get("language"), "en")
+        segments = result.get("segments") or []
+        self.assertGreater(len(segments), 0, "Expected at least one segment")
+        for seg in segments:
+            self.assertIn("start", seg)
+            self.assertIn("end", seg)
+            self.assertIn("text", seg)
+            self.assertGreaterEqual(seg["end"], seg["start"])
+            self.assertNotIn(
+                "<|", seg["text"], f"Special token leaked into segment: {seg!r}"
+            )
+
+    def test_auto_detect_streaming(self):
+        """language=None + stream=True: deltas scrubbed, concat matches non-streaming.
+
+        Verified against a real server: sglang's streaming path for Whisper
+        produces clean deltas (complete words, no BPE fragmentation), so the
+        fused path only needs to hide the forced prefix — which this PR
+        does. Asserts both the prefix-leak guard and text equivalence.
+        """
+        deltas = self._transcribe_stream(language=None)
+        self.assertTrue(len(deltas) > 0, "Expected at least one streamed delta")
+        for d in deltas:
+            self.assertNotIn(
+                "<|", d, f"Special token leaked into streaming delta: {d!r}"
+            )
+        streamed = "".join(deltas).strip()
+        reference = self._transcribe(language=None).get("text", "").strip()
+        self.assertEqual(
+            streamed,
+            reference,
+            "Streamed auto-detect text should match the non-streaming result.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add Llama-4-Scout NPU test with:
- Accuracy test (gsm8k, baseline 0.9)
- Performance test
- TP=8 configuration
- Context length 1M

## Test Configuration

- Model: Llama-4-Scout-17B-16E-Instruct
- TP Size: 8
- Suite: full-8-npu-a3
- Nightly: true

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->