### PR TITLE
test: add request length validation test for Ascend NPU

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-8
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260611
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 4: Request length validation test - switch to LLAMA_3_2_1B and restore token_ids_logprob tests
+# test round 5: Request length validation test - remove unsupported token_ids_logprob tests (LLAMA model)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: Request length validation test - fix black formatting
+# test round 4: Request length validation test - switch to LLAMA_3_2_1B and restore token_ids_logprob tests
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 5: Request length validation test - remove unsupported token_ids_logprob tests (LLAMA model)
+# test round 7: Request length validation test - restore token_ids_logprob tests
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: Request length validation test - remove unsupported token_ids_logprob tests
+# test round 3: Request length validation test - fix black formatting
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,99 @@
+name: Single Test (NPU)
+# test round 1: Request length validation test
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-8
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260611
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases
+          test_cases=(
+            "test/registered/ascend/interface/_test_request_length_validation.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: Request length validation test
+# test round 2: Request length validation test - remove unsupported token_ids_logprob tests
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 7: Request length validation test - restore token_ids_logprob tests
+# test round 8: Request length validation test - switch back to QWEN3_0_6B model
 
 on:
   pull_request:

--- a/test/registered/ascend/interface/_test_request_length_validation.py
+++ b/test/registered/ascend/interface/_test_request_length_validation.py
@@ -104,6 +104,56 @@ class TestRequestLengthValidation(CustomTestCase):
             str(cm.exception),
         )
 
+    def test_token_ids_logprob_out_of_vocabulary(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        for token_ids_logprob in ([-1], [2_000_000_000]):
+            response = requests.post(
+                f"{self.base_url}/generate",
+                headers=headers,
+                json={
+                    "text": "hi",
+                    "sampling_params": {"max_new_tokens": 1},
+                    "return_logprob": True,
+                    "token_ids_logprob": token_ids_logprob,
+                },
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("out-of-vocabulary", response.text)
+
+    def test_token_ids_logprob_rejects_nested_list(self):
+        # Nested lists are a batch-level wire format; a single request must
+        # pass a flat list of ints. A ragged nested list with in-vocab ids
+        # would otherwise crash the scheduler in the sampler gather.
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        for token_ids_logprob in ([[0]], [[0], [1, 2]]):
+            response = requests.post(
+                f"{self.base_url}/generate",
+                headers=headers,
+                json={
+                    "text": "hi",
+                    "sampling_params": {"max_new_tokens": 1},
+                    "return_logprob": True,
+                    "token_ids_logprob": token_ids_logprob,
+                },
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("flat list of integers", response.text)
+
+    def test_token_ids_logprob_batch_with_one_oov(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        response = requests.post(
+            f"{self.base_url}/generate",
+            headers=headers,
+            json={
+                "text": ["hi", "hi"],
+                "sampling_params": {"max_new_tokens": 1},
+                "return_logprob": True,
+                "token_ids_logprob": [[0], [2_000_000_000]],
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("out-of-vocabulary", response.text)
+
     def test_token_ids_logprob_valid(self):
         headers = {"Authorization": f"Bearer {self.api_key}"}
         response = requests.post(

--- a/test/registered/ascend/interface/_test_request_length_validation.py
+++ b/test/registered/ascend/interface/_test_request_length_validation.py
@@ -140,6 +140,10 @@ class TestRequestLengthValidation(CustomTestCase):
             self.assertIn("flat list of integers", response.text)
 
     def test_token_ids_logprob_batch_with_one_oov(self):
+        # Verify that batch requests are rejected when any single item
+        # contains an out-of-vocabulary token ID in token_ids_logprob.
+        # The first request uses valid id [0], the second uses OOV id [2_000_000_000].
+        # The server should return 400 for the entire batch.
         headers = {"Authorization": f"Bearer {self.api_key}"}
         response = requests.post(
             f"{self.base_url}/generate",

--- a/test/registered/ascend/interface/_test_request_length_validation.py
+++ b/test/registered/ascend/interface/_test_request_length_validation.py
@@ -16,7 +16,6 @@ from sglang.test.test_utils import (
 register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
 
 
-
 class TestRequestLengthValidation(CustomTestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/registered/ascend/interface/_test_request_length_validation.py
+++ b/test/registered/ascend/interface/_test_request_length_validation.py
@@ -1,0 +1,174 @@
+import unittest
+
+import openai
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_0_6B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
+
+
+
+class TestRequestLengthValidation(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.api_key = "sk-123456"
+
+        # Start server with auto truncate disabled
+        cls.process = popen_launch_server(
+            QWEN3_0_6B_WEIGHTS_PATH,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            api_key=cls.api_key,
+            other_args=("--max-total-tokens", "1000", "--context-length", "1000"),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_input_length_longer_than_context_length(self):
+        client = openai.Client(api_key=self.api_key, base_url=f"{self.base_url}/v1")
+
+        long_text = "hello " * 1200  # Will tokenize to more than context length
+
+        with self.assertRaises(openai.BadRequestError) as cm:
+            client.chat.completions.create(
+                model=QWEN3_0_6B_WEIGHTS_PATH,
+                messages=[
+                    {"role": "user", "content": long_text},
+                ],
+                temperature=0,
+            )
+
+        self.assertIn("is longer than the model's context length", str(cm.exception))
+
+    def test_input_length_longer_than_maximum_allowed_length(self):
+        client = openai.Client(api_key=self.api_key, base_url=f"{self.base_url}/v1")
+
+        long_text = "hello " * 999  # the maximum allowed length is 994 tokens
+
+        with self.assertRaises(openai.BadRequestError) as cm:
+            client.chat.completions.create(
+                model=QWEN3_0_6B_WEIGHTS_PATH,
+                messages=[
+                    {"role": "user", "content": long_text},
+                ],
+                temperature=0,
+            )
+
+        self.assertIn("is longer than the model's context length", str(cm.exception))
+
+    def test_input_length_longer_than_context_length_streaming(self):
+        client = openai.Client(api_key=self.api_key, base_url=f"{self.base_url}/v1")
+
+        long_text = "hello " * 1200
+
+        with self.assertRaises(openai.BadRequestError) as cm:
+            client.chat.completions.create(
+                model=QWEN3_0_6B_WEIGHTS_PATH,
+                messages=[
+                    {"role": "user", "content": long_text},
+                ],
+                temperature=0,
+                stream=True,
+            )
+
+        self.assertIn("is longer than the model's context length", str(cm.exception))
+
+    def test_max_tokens_validation(self):
+        client = openai.Client(api_key=self.api_key, base_url=f"{self.base_url}/v1")
+
+        long_text = "hello "
+
+        with self.assertRaises(openai.BadRequestError) as cm:
+            client.chat.completions.create(
+                model=QWEN3_0_6B_WEIGHTS_PATH,
+                messages=[
+                    {"role": "user", "content": long_text},
+                ],
+                temperature=0,
+                max_tokens=1200,
+            )
+
+        self.assertIn(
+            "max_completion_tokens is too large",
+            str(cm.exception),
+        )
+
+    def test_token_ids_logprob_out_of_vocabulary(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        for token_ids_logprob in ([-1], [2_000_000_000]):
+            response = requests.post(
+                f"{self.base_url}/generate",
+                headers=headers,
+                json={
+                    "text": "hi",
+                    "sampling_params": {"max_new_tokens": 1},
+                    "return_logprob": True,
+                    "token_ids_logprob": token_ids_logprob,
+                },
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("out-of-vocabulary", response.text)
+
+    def test_token_ids_logprob_rejects_nested_list(self):
+        # Nested lists are a batch-level wire format; a single request must
+        # pass a flat list of ints. A ragged nested list with in-vocab ids
+        # would otherwise crash the scheduler in the sampler gather.
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        for token_ids_logprob in ([[0]], [[0], [1, 2]]):
+            response = requests.post(
+                f"{self.base_url}/generate",
+                headers=headers,
+                json={
+                    "text": "hi",
+                    "sampling_params": {"max_new_tokens": 1},
+                    "return_logprob": True,
+                    "token_ids_logprob": token_ids_logprob,
+                },
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("flat list of integers", response.text)
+
+    def test_token_ids_logprob_batch_with_one_oov(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        response = requests.post(
+            f"{self.base_url}/generate",
+            headers=headers,
+            json={
+                "text": ["hi", "hi"],
+                "sampling_params": {"max_new_tokens": 1},
+                "return_logprob": True,
+                "token_ids_logprob": [[0], [2_000_000_000]],
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("out-of-vocabulary", response.text)
+
+    def test_token_ids_logprob_valid(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        response = requests.post(
+            f"{self.base_url}/generate",
+            headers=headers,
+            json={
+                "text": "hi",
+                "sampling_params": {"max_new_tokens": 1},
+                "return_logprob": True,
+                "token_ids_logprob": [0],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/interface/_test_request_length_validation.py
+++ b/test/registered/ascend/interface/_test_request_length_validation.py
@@ -159,6 +159,8 @@ class TestRequestLengthValidation(CustomTestCase):
         self.assertIn("out-of-vocabulary", response.text)
 
     def test_token_ids_logprob_valid(self):
+        # Verify that a valid token_ids_logprob request with in-vocabulary
+        # token IDs is accepted and returns 200.
         headers = {"Authorization": f"Bearer {self.api_key}"}
         response = requests.post(
             f"{self.base_url}/generate",

--- a/test/registered/ascend/interface/_test_request_length_validation.py
+++ b/test/registered/ascend/interface/_test_request_length_validation.py
@@ -104,56 +104,6 @@ class TestRequestLengthValidation(CustomTestCase):
             str(cm.exception),
         )
 
-    def test_token_ids_logprob_out_of_vocabulary(self):
-        headers = {"Authorization": f"Bearer {self.api_key}"}
-        for token_ids_logprob in ([-1], [2_000_000_000]):
-            response = requests.post(
-                f"{self.base_url}/generate",
-                headers=headers,
-                json={
-                    "text": "hi",
-                    "sampling_params": {"max_new_tokens": 1},
-                    "return_logprob": True,
-                    "token_ids_logprob": token_ids_logprob,
-                },
-            )
-            self.assertEqual(response.status_code, 400)
-            self.assertIn("out-of-vocabulary", response.text)
-
-    def test_token_ids_logprob_rejects_nested_list(self):
-        # Nested lists are a batch-level wire format; a single request must
-        # pass a flat list of ints. A ragged nested list with in-vocab ids
-        # would otherwise crash the scheduler in the sampler gather.
-        headers = {"Authorization": f"Bearer {self.api_key}"}
-        for token_ids_logprob in ([[0]], [[0], [1, 2]]):
-            response = requests.post(
-                f"{self.base_url}/generate",
-                headers=headers,
-                json={
-                    "text": "hi",
-                    "sampling_params": {"max_new_tokens": 1},
-                    "return_logprob": True,
-                    "token_ids_logprob": token_ids_logprob,
-                },
-            )
-            self.assertEqual(response.status_code, 400)
-            self.assertIn("flat list of integers", response.text)
-
-    def test_token_ids_logprob_batch_with_one_oov(self):
-        headers = {"Authorization": f"Bearer {self.api_key}"}
-        response = requests.post(
-            f"{self.base_url}/generate",
-            headers=headers,
-            json={
-                "text": ["hi", "hi"],
-                "sampling_params": {"max_new_tokens": 1},
-                "return_logprob": True,
-                "token_ids_logprob": [[0], [2_000_000_000]],
-            },
-        )
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("out-of-vocabulary", response.text)
-
     def test_token_ids_logprob_valid(self):
         headers = {"Authorization": f"Bearer {self.api_key}"}
         response = requests.post(

--- a/test/registered/ascend/interface/_test_request_length_validation.py
+++ b/test/registered/ascend/interface/_test_request_length_validation.py
@@ -4,7 +4,7 @@ import openai
 import requests
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ascend.test_ascend_utils import QWEN3_0_6B_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -24,7 +24,7 @@ class TestRequestLengthValidation(CustomTestCase):
 
         # Start server with auto truncate disabled
         cls.process = popen_launch_server(
-            LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+            QWEN3_0_6B_WEIGHTS_PATH,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             api_key=cls.api_key,
@@ -42,7 +42,7 @@ class TestRequestLengthValidation(CustomTestCase):
 
         with self.assertRaises(openai.BadRequestError) as cm:
             client.chat.completions.create(
-                model=LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+                model=QWEN3_0_6B_WEIGHTS_PATH,
                 messages=[
                     {"role": "user", "content": long_text},
                 ],
@@ -58,7 +58,7 @@ class TestRequestLengthValidation(CustomTestCase):
 
         with self.assertRaises(openai.BadRequestError) as cm:
             client.chat.completions.create(
-                model=LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+                model=QWEN3_0_6B_WEIGHTS_PATH,
                 messages=[
                     {"role": "user", "content": long_text},
                 ],
@@ -74,7 +74,7 @@ class TestRequestLengthValidation(CustomTestCase):
 
         with self.assertRaises(openai.BadRequestError) as cm:
             client.chat.completions.create(
-                model=LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+                model=QWEN3_0_6B_WEIGHTS_PATH,
                 messages=[
                     {"role": "user", "content": long_text},
                 ],
@@ -91,7 +91,7 @@ class TestRequestLengthValidation(CustomTestCase):
 
         with self.assertRaises(openai.BadRequestError) as cm:
             client.chat.completions.create(
-                model=LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+                model=QWEN3_0_6B_WEIGHTS_PATH,
                 messages=[
                     {"role": "user", "content": long_text},
                 ],

--- a/test/registered/ascend/interface/_test_request_length_validation.py
+++ b/test/registered/ascend/interface/_test_request_length_validation.py
@@ -105,56 +105,6 @@ class TestRequestLengthValidation(CustomTestCase):
             str(cm.exception),
         )
 
-    def test_token_ids_logprob_out_of_vocabulary(self):
-        headers = {"Authorization": f"Bearer {self.api_key}"}
-        for token_ids_logprob in ([-1], [2_000_000_000]):
-            response = requests.post(
-                f"{self.base_url}/generate",
-                headers=headers,
-                json={
-                    "text": "hi",
-                    "sampling_params": {"max_new_tokens": 1},
-                    "return_logprob": True,
-                    "token_ids_logprob": token_ids_logprob,
-                },
-            )
-            self.assertEqual(response.status_code, 400)
-            self.assertIn("out-of-vocabulary", response.text)
-
-    def test_token_ids_logprob_rejects_nested_list(self):
-        # Nested lists are a batch-level wire format; a single request must
-        # pass a flat list of ints. A ragged nested list with in-vocab ids
-        # would otherwise crash the scheduler in the sampler gather.
-        headers = {"Authorization": f"Bearer {self.api_key}"}
-        for token_ids_logprob in ([[0]], [[0], [1, 2]]):
-            response = requests.post(
-                f"{self.base_url}/generate",
-                headers=headers,
-                json={
-                    "text": "hi",
-                    "sampling_params": {"max_new_tokens": 1},
-                    "return_logprob": True,
-                    "token_ids_logprob": token_ids_logprob,
-                },
-            )
-            self.assertEqual(response.status_code, 400)
-            self.assertIn("flat list of integers", response.text)
-
-    def test_token_ids_logprob_batch_with_one_oov(self):
-        headers = {"Authorization": f"Bearer {self.api_key}"}
-        response = requests.post(
-            f"{self.base_url}/generate",
-            headers=headers,
-            json={
-                "text": ["hi", "hi"],
-                "sampling_params": {"max_new_tokens": 1},
-                "return_logprob": True,
-                "token_ids_logprob": [[0], [2_000_000_000]],
-            },
-        )
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("out-of-vocabulary", response.text)
-
     def test_token_ids_logprob_valid(self):
         headers = {"Authorization": f"Bearer {self.api_key}"}
         response = requests.post(

--- a/test/registered/ascend/interface/_test_request_length_validation.py
+++ b/test/registered/ascend/interface/_test_request_length_validation.py
@@ -4,7 +4,7 @@ import openai
 import requests
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ascend.test_ascend_utils import QWEN3_0_6B_WEIGHTS_PATH
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -24,7 +24,7 @@ class TestRequestLengthValidation(CustomTestCase):
 
         # Start server with auto truncate disabled
         cls.process = popen_launch_server(
-            QWEN3_0_6B_WEIGHTS_PATH,
+            LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             api_key=cls.api_key,
@@ -42,7 +42,7 @@ class TestRequestLengthValidation(CustomTestCase):
 
         with self.assertRaises(openai.BadRequestError) as cm:
             client.chat.completions.create(
-                model=QWEN3_0_6B_WEIGHTS_PATH,
+                model=LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
                 messages=[
                     {"role": "user", "content": long_text},
                 ],
@@ -58,7 +58,7 @@ class TestRequestLengthValidation(CustomTestCase):
 
         with self.assertRaises(openai.BadRequestError) as cm:
             client.chat.completions.create(
-                model=QWEN3_0_6B_WEIGHTS_PATH,
+                model=LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
                 messages=[
                     {"role": "user", "content": long_text},
                 ],
@@ -74,7 +74,7 @@ class TestRequestLengthValidation(CustomTestCase):
 
         with self.assertRaises(openai.BadRequestError) as cm:
             client.chat.completions.create(
-                model=QWEN3_0_6B_WEIGHTS_PATH,
+                model=LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
                 messages=[
                     {"role": "user", "content": long_text},
                 ],
@@ -91,7 +91,7 @@ class TestRequestLengthValidation(CustomTestCase):
 
         with self.assertRaises(openai.BadRequestError) as cm:
             client.chat.completions.create(
-                model=QWEN3_0_6B_WEIGHTS_PATH,
+                model=LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
                 messages=[
                     {"role": "user", "content": long_text},
                 ],
@@ -103,6 +103,56 @@ class TestRequestLengthValidation(CustomTestCase):
             "max_completion_tokens is too large",
             str(cm.exception),
         )
+
+    def test_token_ids_logprob_out_of_vocabulary(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        for token_ids_logprob in ([-1], [2_000_000_000]):
+            response = requests.post(
+                f"{self.base_url}/generate",
+                headers=headers,
+                json={
+                    "text": "hi",
+                    "sampling_params": {"max_new_tokens": 1},
+                    "return_logprob": True,
+                    "token_ids_logprob": token_ids_logprob,
+                },
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("out-of-vocabulary", response.text)
+
+    def test_token_ids_logprob_rejects_nested_list(self):
+        # Nested lists are a batch-level wire format; a single request must
+        # pass a flat list of ints. A ragged nested list with in-vocab ids
+        # would otherwise crash the scheduler in the sampler gather.
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        for token_ids_logprob in ([[0]], [[0], [1, 2]]):
+            response = requests.post(
+                f"{self.base_url}/generate",
+                headers=headers,
+                json={
+                    "text": "hi",
+                    "sampling_params": {"max_new_tokens": 1},
+                    "return_logprob": True,
+                    "token_ids_logprob": token_ids_logprob,
+                },
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("flat list of integers", response.text)
+
+    def test_token_ids_logprob_batch_with_one_oov(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        response = requests.post(
+            f"{self.base_url}/generate",
+            headers=headers,
+            json={
+                "text": ["hi", "hi"],
+                "sampling_params": {"max_new_tokens": 1},
+                "return_logprob": True,
+                "token_ids_logprob": [[0], [2_000_000_000]],
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("out-of-vocabulary", response.text)
 
     def test_token_ids_logprob_valid(self):
         headers = {"Authorization": f"Bearer {self.api_key}"}


### PR DESCRIPTION
Add request length validation test case for Ascend NPU.\n\nTests include:\n- Input length longer than context length\n- Input length longer than maximum allowed length\n- Streaming mode length validation\n- Max tokens validation\n- Token IDs logprob validation (OOV, nested list, batch)

































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->