### PR TITLE
test: add Qwen3-30B-A3B-Instruct-2507 LoRA logprob accuracy test

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 6: Qwen3-30B-A3B LoRA logprob accuracy test
+# test round 1: Qwen3.5-35B-A3B LoRA logprob accuracy test
 
 on:
   pull_request:
@@ -40,7 +40,7 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            "test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py"
+            "test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_5_35b_a3b_logprob_diff.py"
           )
 
           for test_case in "${test_cases[@]}"; do
@@ -70,9 +70,6 @@ jobs:
           mkdir -p ${ascend_test_util_path}
           mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
           cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
-
-          # Copy fixed moe_align_block_size.py to image's sglang (provides pure Python fallback for NPU)
-          cp ${sglang_source_path}/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py ${sglang_pkg_path}/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
 
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,99 @@
+name: Single Test (NPU)
+# test round 1: Qwen3-30B-A3B LoRA logprob accuracy test
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-8
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases - 使用时替换为实际的测试用例路径
+          test_cases=(
+            "test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: Qwen3.5-35B-A3B LoRA logprob accuracy test
+# test round 2: Qwen3.5-35B-A3B LoRA logprob accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: Qwen3-30B-A3B LoRA logprob accuracy test
+# test round 4: Qwen3-30B-A3B LoRA logprob accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -71,6 +71,9 @@ jobs:
           mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
           cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
 
+          # Patch moe_align_block_size.py to support NPU
+          python -c "f=open('${sglang_pkg_path}/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py');c=f.read();f.close();c=c.replace('from sglang.srt.utils import is_cuda, is_hip, is_musa, is_xpu','from sglang.srt.utils import is_cuda, is_hip, is_musa, is_npu, is_xpu');c=c.replace('_is_musa = is_musa()\n','_is_musa = is_musa()\n_is_npu = is_npu()\n');c=c.replace('if _is_cuda or _is_hip or _is_xpu or _is_musa:','if _is_cuda or _is_hip or _is_xpu or _is_musa or _is_npu:');f=open('${sglang_pkg_path}/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py','w');f.write(c);f.close();print('Patched moe_align_block_size.py for NPU')"
+
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true
           source /usr/local/Ascend/nnal/atb/set_env.sh || true

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 4: Qwen3-30B-A3B LoRA logprob accuracy test
+# test round 5: Qwen3-30B-A3B LoRA logprob accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 5: Qwen3-30B-A3B LoRA logprob accuracy test
+# test round 6: Qwen3-30B-A3B LoRA logprob accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: Qwen3-30B-A3B LoRA logprob accuracy test
+# test round 2: Qwen3-30B-A3B LoRA logprob accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -71,8 +71,8 @@ jobs:
           mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
           cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
 
-          # Patch moe_align_block_size.py to support NPU
-          python -c "f=open('${sglang_pkg_path}/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py');c=f.read();f.close();c=c.replace('from sglang.srt.utils import is_cuda, is_hip, is_musa, is_xpu','from sglang.srt.utils import is_cuda, is_hip, is_musa, is_npu, is_xpu');c=c.replace('_is_musa = is_musa()\n','_is_musa = is_musa()\n_is_npu = is_npu()\n');c=c.replace('if _is_cuda or _is_hip or _is_xpu or _is_musa:','if _is_cuda or _is_hip or _is_xpu or _is_musa or _is_npu:');f=open('${sglang_pkg_path}/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py','w');f.write(c);f.close();print('Patched moe_align_block_size.py for NPU')"
+          # Copy fixed moe_align_block_size.py to image's sglang (provides pure Python fallback for NPU)
+          cp ${sglang_source_path}/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py ${sglang_pkg_path}/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
 
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: Qwen3-30B-A3B LoRA logprob accuracy test
+# test round 3: Qwen3-30B-A3B LoRA logprob accuracy test
 
 on:
   pull_request:

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
@@ -13,7 +13,7 @@ _is_xpu = is_xpu()
 _is_musa = is_musa()
 _is_npu = is_npu()
 
-if _is_cuda or _is_hip or _is_xpu or _is_musa or _is_npu:
+if _is_cuda or _is_hip or _is_xpu or _is_musa:
     from sgl_kernel import moe_align_block_size as sgl_moe_align_block_size
 
 
@@ -57,6 +57,9 @@ def moe_align_block_size(
     - The padding ensures that the total number of tokens is now divisible
         by block_size for proper block matrix operations.
     """
+    if _is_npu:
+        return _moe_align_block_size_python(topk_ids, block_size, num_experts)
+
     if topk_ids.numel() < num_experts + 1:
         max_num_tokens_padded = topk_ids.numel() * block_size
     else:
@@ -86,3 +89,56 @@ def moe_align_block_size(
         True,
     )
     return sorted_ids, expert_ids, num_tokens_post_pad
+
+
+def _moe_align_block_size_python(
+    topk_ids: torch.Tensor, block_size: int, num_experts: int
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pure Python implementation of moe_align_block_size for NPU."""
+    # topk_ids shape: [total_tokens, top_k]
+    # Flatten to get all expert assignments
+    flat_ids = topk_ids.view(-1)
+    total_tokens = flat_ids.size(0)
+
+    # Count tokens per expert
+    token_counts = torch.bincount(flat_ids, minlength=num_experts + 1)
+
+    # Calculate padded tokens per expert (round up to block_size)
+    padded_counts = ((token_counts + block_size - 1) // block_size) * block_size
+
+    # Calculate cumulative sum for positioning
+    cum_counts = torch.zeros(num_experts + 2, dtype=torch.int32, device=topk_ids.device)
+    cum_counts[1:] = torch.cumsum(padded_counts, dim=0)
+
+    total_padded = cum_counts[-1].item()
+    max_num_m_blocks = triton.cdiv(total_padded, block_size)
+
+    # Build sorted_token_ids and expert_ids
+    sorted_token_ids = torch.full(
+        (total_padded,), num_experts, dtype=torch.int32, device=topk_ids.device
+    )
+    expert_ids = torch.zeros(
+        (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
+    )
+
+    # Place tokens for each expert
+    for expert_id in range(num_experts + 1):
+        start_pos = cum_counts[expert_id].item()
+        # Find tokens belonging to this expert
+        expert_mask = flat_ids == expert_id
+        expert_token_indices = torch.nonzero(expert_mask, as_tuple=True)[0]
+        count = expert_token_indices.size(0)
+        if count > 0:
+            sorted_token_ids[start_pos : start_pos + count] = expert_token_indices.to(
+                torch.int32
+            )
+        # Fill expert_ids for each block
+        num_blocks = (padded_counts[expert_id].item()) // block_size
+        block_start = start_pos // block_size
+        expert_ids[block_start : block_start + num_blocks] = expert_id
+
+    num_tokens_post_padded = torch.tensor(
+        [total_padded], dtype=torch.int32, device=topk_ids.device
+    )
+
+    return sorted_token_ids, expert_ids, num_tokens_post_padded

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
@@ -5,14 +5,15 @@ from typing import Tuple
 import torch
 import triton
 
-from sglang.srt.utils import is_cuda, is_hip, is_musa, is_xpu
+from sglang.srt.utils import is_cuda, is_hip, is_musa, is_npu, is_xpu
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_xpu = is_xpu()
 _is_musa = is_musa()
+_is_npu = is_npu()
 
-if _is_cuda or _is_hip or _is_xpu or _is_musa:
+if _is_cuda or _is_hip or _is_xpu or _is_musa or _is_npu:
     from sgl_kernel import moe_align_block_size as sgl_moe_align_block_size
 
 

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py
@@ -41,7 +41,7 @@ register_cuda_ci(est_time=100, stage="extra-b", runner_config="4-gpu-b200")
 
 BASE_MODEL = QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH
 # LORA_HF_REPO = "yushengsu/lora-diff-Qwen3-30B-A3B-Instruct-2507"
-LORA_HF_REPO = "/root/.cache/huggingface/hub/lora-diff-Qwen3-30B-A3B-Instruct-2507"
+LORA_HF_REPO = "yushengsu/lora-diff-Qwen3-30B-A3B-Instruct-2507"
 LORA_BACKEND = "triton"
 MAX_LORA_RANK = 32
 TP_SIZE = 4

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py
@@ -1,0 +1,148 @@
+# Copyright 2023-2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Regression test for Qwen3-30B-A3B-Instruct-2507 LoRA logprob accuracy.
+
+Compares SGLang LoRA logprobs against reference training logprobs from a
+pre-computed dataset. The LoRA adapter and reference data are downloaded from:
+https://huggingface.co/datasets/yushengsu/lora-diff-Qwen3-30B-A3B-Instruct-2507
+
+Usage:
+    python -m unittest test_lora_qwen3_30b_a3b_instruct_2507_logprob_diff
+"""
+
+import multiprocessing as mp
+import os
+import unittest
+
+import torch
+from huggingface_hub import snapshot_download
+
+import sglang as sgl
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+from sglang.test.ascend.test_ascend_utils import QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH
+register_cuda_ci(est_time=100, stage="extra-b", runner_config="4-gpu-b200")
+
+BASE_MODEL = QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH
+# LORA_HF_REPO = "yushengsu/lora-diff-Qwen3-30B-A3B-Instruct-2507"
+LORA_HF_REPO = "/root/.cache/huggingface/hub/lora-diff-Qwen3-30B-A3B-Instruct-2507"
+LORA_BACKEND = "triton"
+MAX_LORA_RANK = 32
+TP_SIZE = 4
+MOE_RUNNER_BACKEND = "triton"
+EXPERTS_SHARED_OUTER_LORAS = True
+PREFILL_ATTENTION_BACKEND = "ascend"
+DECODE_ATTENTION_BACKEND = "ascend"
+
+KL_THRESHOLD = 5e-3
+
+
+def kl_v2(a, b):
+    a = torch.tensor(a) if not torch.is_tensor(a) else a
+    b = torch.tensor(b) if not torch.is_tensor(b) else b
+    return (((a - b) ** 2) * 0.5).mean().item()
+
+
+def get_prompt_logprobs(engine, input_ids, lora_path):
+    out = engine.generate(
+        input_ids=input_ids,
+        sampling_params={"max_new_tokens": 0, "temperature": 0.0},
+        return_logprob=True,
+        logprob_start_len=0,
+        lora_path=lora_path,
+    )
+    return [logprob for logprob, _, _ in out["meta_info"]["input_token_logprobs"]][1:]
+
+
+class TestLoRAQwen3_30B_A3B_Instruct_2507_LogprobDiff(CustomTestCase):
+
+    def test_lora_qwen3_30b_a3b_instruct_2507_logprob_accuracy(self):
+        adapter_path = snapshot_download(
+            LORA_HF_REPO,
+            repo_type="dataset",
+        )
+
+        engine = sgl.Engine(
+            model_path=BASE_MODEL,
+            tp_size=TP_SIZE,
+            enable_lora=True,
+            max_lora_rank=MAX_LORA_RANK,
+            lora_paths={"my_lora": adapter_path},
+            lora_backend=LORA_BACKEND,
+            attention_backend="ascend",
+            # flashinfer_allreduce_fusion_backend="trtllm",
+            moe_runner_backend=MOE_RUNNER_BACKEND,
+            experts_shared_outer_loras=EXPERTS_SHARED_OUTER_LORAS,
+            prefill_attention_backend=PREFILL_ATTENTION_BACKEND,
+            decode_attention_backend=DECODE_ATTENTION_BACKEND,
+        )
+
+        try:
+            cdata = torch.load(
+                os.path.join(adapter_path, "compare_sample_train_data.pt"),
+                weights_only=False,
+            )
+
+            base_logprobs = get_prompt_logprobs(engine, cdata["tokens"], lora_path=None)
+            logprobs = get_prompt_logprobs(engine, cdata["tokens"], lora_path="my_lora")
+
+            base_t = torch.tensor(base_logprobs)
+            lora_t = torch.tensor(logprobs)
+            diff = (base_t - lora_t).abs()
+            print(
+                f"[VERIFY] base vs lora: mean_diff={diff.mean().item():.6f}, "
+                f"max_diff={diff.max().item():.6f}, "
+                f"identical={torch.equal(base_t, lora_t)}"
+            )
+
+            self.assertFalse(
+                torch.equal(base_t, lora_t),
+                "LoRA logprobs should differ from base model logprobs",
+            )
+
+            kl_sglang_trainer = kl_v2(cdata["training_logprobs"], logprobs)
+            kl_orig_trainer = kl_v2(
+                cdata["training_logprobs"], cdata["sampling_logprobs"]
+            )
+            kl_sglang_orig = kl_v2(logprobs, cdata["sampling_logprobs"])
+
+            print(f"KL(orig_sampler, trainer) = {kl_orig_trainer:.6e}")
+            print(f"KL(sglang, trainer)       = {kl_sglang_trainer:.6e}")
+            print(f"KL(sglang, orig_sampler)  = {kl_sglang_orig:.6e}")
+
+            self.assertLessEqual(
+                kl_sglang_trainer,
+                KL_THRESHOLD,
+                f"KL(sglang, trainer) = {kl_sglang_trainer:.6e} exceeds "
+                f"threshold {KL_THRESHOLD}",
+            )
+
+        finally:
+            engine.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        mp.set_start_method("spawn")
+    except RuntimeError:
+        pass
+
+    try:
+        unittest.main(warnings="ignore", verbosity=2)
+    finally:
+        if torch.npu.is_available():
+            torch.npu.empty_cache()
+            torch.npu.synchronize()

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py
@@ -28,7 +28,7 @@ import os
 import unittest
 
 import torch
-from huggingface_hub import snapshot_download
+
 
 import sglang as sgl
 from sglang.test.ascend.test_ascend_utils import (
@@ -41,7 +41,7 @@ register_cuda_ci(est_time=100, stage="extra-b", runner_config="4-gpu-b200")
 
 BASE_MODEL = QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH
 # LORA_HF_REPO = "yushengsu/lora-diff-Qwen3-30B-A3B-Instruct-2507"
-LORA_HF_REPO = "yushengsu/lora-diff-Qwen3-30B-A3B-Instruct-2507"
+LORA_HF_REPO = "/root/.cache/huggingface/hub/lora-diff-Qwen3-30B-A3B-Instruct-2507"
 LORA_BACKEND = "triton"
 MAX_LORA_RANK = 32
 TP_SIZE = 4
@@ -73,17 +73,17 @@ def get_prompt_logprobs(engine, input_ids, lora_path):
 class TestLoRAQwen3_30B_A3B_Instruct_2507_LogprobDiff(CustomTestCase):
 
     def test_lora_qwen3_30b_a3b_instruct_2507_logprob_accuracy(self):
-        adapter_path = snapshot_download(
-            LORA_HF_REPO,
-            repo_type="dataset",
-        )
+        # adapter_path = snapshot_download(
+        #     LORA_HF_REPO,
+        #     repo_type="dataset",
+        # )
 
         engine = sgl.Engine(
             model_path=BASE_MODEL,
             tp_size=TP_SIZE,
             enable_lora=True,
             max_lora_rank=MAX_LORA_RANK,
-            lora_paths={"my_lora": adapter_path},
+            lora_paths={"my_lora": LORA_HF_REPO},
             lora_backend=LORA_BACKEND,
             attention_backend="ascend",
             # flashinfer_allreduce_fusion_backend="trtllm",
@@ -95,7 +95,7 @@ class TestLoRAQwen3_30B_A3B_Instruct_2507_LogprobDiff(CustomTestCase):
 
         try:
             cdata = torch.load(
-                os.path.join(adapter_path, "compare_sample_train_data.pt"),
+                os.path.join(LORA_HF_REPO, "compare_sample_train_data.pt"),
                 weights_only=False,
             )
 

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py
@@ -31,9 +31,12 @@ import torch
 from huggingface_hub import snapshot_download
 
 import sglang as sgl
+from sglang.test.ascend.test_ascend_utils import (
+    QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
-from sglang.test.ascend.test_ascend_utils import QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH
+
 register_cuda_ci(est_time=100, stage="extra-b", runner_config="4-gpu-b200")
 
 BASE_MODEL = QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py
@@ -29,7 +29,6 @@ import unittest
 
 import torch
 
-
 import sglang as sgl
 from sglang.test.ascend.test_ascend_utils import (
     QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH,

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_5_35b_a3b_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_5_35b_a3b_logprob_diff.py
@@ -1,0 +1,151 @@
+# Copyright 2023-2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Regression test for Qwen3.5-35B-A3B LoRA logprob accuracy.
+
+Compares SGLang LoRA logprobs against reference training logprobs from a
+pre-computed dataset. The LoRA adapter and reference data are downloaded from:
+https://huggingface.co/datasets/opherlie/lora-test-case-Qwen3.5-35B-A3B
+
+Usage:
+    python -m unittest test_lora_qwen3_5_35b_a3b_logprob_diff
+"""
+
+import multiprocessing as mp
+import os
+import unittest
+
+import torch
+
+import sglang as sgl
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(est_time=150, suite="full-4-npu-a3", nightly=True)
+
+
+BASE_MODEL = "Qwen/Qwen3.5-35B-A3B"
+LORA_HF_REPO = "opherlie/lora-test-case-Qwen3.5-35B-A3B"
+LORA_BACKEND = "triton"
+MAX_LORA_RANK = 64
+TP_SIZE = 4
+MOE_RUNNER_BACKEND = "triton"
+EXPERTS_SHARED_OUTER_LORAS = True
+LORA_USE_VIRTUAL_EXPERTS = True
+DISABLE_SHARED_EXPERTS_FUSION = True
+
+KL_THRESHOLD = 1e-3
+
+
+def kl_v2(a, b):
+    a = torch.tensor(a) if not torch.is_tensor(a) else a
+    b = torch.tensor(b) if not torch.is_tensor(b) else b
+    return (((a - b) ** 2) * 0.5).mean().item()
+
+
+def get_prompt_logprobs(engine, input_ids, lora_path):
+    if isinstance(input_ids, torch.Tensor):
+        input_ids = [input_ids.tolist()]
+    elif not isinstance(input_ids[0], list):
+        input_ids = [input_ids]
+    out = engine.generate(
+        input_ids=input_ids,
+        sampling_params={"max_new_tokens": 0, "temperature": 0.0},
+        return_logprob=True,
+        logprob_start_len=0,
+        lora_path=lora_path,
+    )
+    if isinstance(out, list):
+        out = out[0]
+    return [logprob for logprob, _, _ in out["meta_info"]["input_token_logprobs"]][1:]
+
+
+class TestLoRAQwen3_5_35B_A3B_LogprobDiff(CustomTestCase):
+
+    def test_lora_qwen3_5_35b_a3b_logprob_accuracy(self):
+
+        engine = sgl.Engine(
+            model_path=BASE_MODEL,
+            tp_size=TP_SIZE,
+            enable_lora=True,
+            max_lora_rank=MAX_LORA_RANK,
+            lora_paths={"my_lora": LORA_HF_REPO},
+            lora_backend=LORA_BACKEND,
+            moe_runner_backend=MOE_RUNNER_BACKEND,
+            experts_shared_outer_loras=EXPERTS_SHARED_OUTER_LORAS,
+            lora_use_virtual_experts=LORA_USE_VIRTUAL_EXPERTS,
+            disable_shared_experts_fusion=DISABLE_SHARED_EXPERTS_FUSION,
+            # OOM's on logits with the defaults here, as this test-case is longer context and qwen3.5 has larger vocab
+            chunked_prefill_size=8192,
+            mem_fraction_static=0.8,
+            attention_backend="ascend",
+        )
+
+        try:
+            cdata = torch.load(
+                os.path.join(LORA_HF_REPO, "compare_sample_train_data.pt"),
+                weights_only=False,
+            )
+
+            base_logprobs = get_prompt_logprobs(engine, cdata["tokens"], lora_path=None)
+            logprobs = get_prompt_logprobs(engine, cdata["tokens"], lora_path="my_lora")
+
+            base_t = torch.tensor(base_logprobs)
+            lora_t = torch.tensor(logprobs)
+            diff = (base_t - lora_t).abs()
+            print(
+                f"[VERIFY] base vs lora: mean_diff={diff.mean().item():.6f}, "
+                f"max_diff={diff.max().item():.6f}, "
+                f"identical={torch.equal(base_t, lora_t)}"
+            )
+
+            self.assertFalse(
+                torch.equal(base_t, lora_t),
+                "LoRA logprobs should differ from base model logprobs",
+            )
+
+            kl_sglang_trainer = kl_v2(cdata["training_logprobs"], logprobs)
+            kl_orig_trainer = kl_v2(
+                cdata["training_logprobs"], cdata["sampling_logprobs"]
+            )
+            kl_sglang_orig = kl_v2(logprobs, cdata["sampling_logprobs"])
+
+            print(f"KL(orig_sampler, trainer) = {kl_orig_trainer:.6e}")
+            print(f"KL(sglang, trainer)       = {kl_sglang_trainer:.6e}")
+            print(f"KL(sglang, orig_sampler)  = {kl_sglang_orig:.6e}")
+
+            self.assertLessEqual(
+                kl_sglang_trainer,
+                KL_THRESHOLD,
+                f"KL(sglang, trainer) = {kl_sglang_trainer:.6e} exceeds "
+                f"threshold {KL_THRESHOLD}",
+            )
+
+        finally:
+            engine.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        mp.set_start_method("spawn")
+    except RuntimeError:
+        pass
+
+    try:
+        unittest.main(warnings="ignore", verbosity=2)
+    finally:
+        if torch.npu.is_available():
+            torch.npu.empty_cache()
+            torch.npu.synchronize()


### PR DESCRIPTION
## Description

Add regression test for Qwen3-30B-A3B-Instruct-2507 LoRA logprob accuracy.

- Compares SGLang LoRA logprobs against reference training logprobs
- Uses KL divergence verification (threshold: 5e-3)
- Tests with TP=4, MoE runner backend=triton, experts shared outer LoRAs

## Test Case

- `test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py`





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->