### PR TITLE
test: add Qwen3.5-4B LoRA logprob accuracy test case

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -71,6 +71,9 @@ jobs:
           mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
           cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
 
+          # Patch ascend_backend.py to handle None input during CUDA graph capture
+          sed -i '/def run_lora_b_sgemm/,/total_seq_len, _ = x.shape/{s/        total_seq_len, _ = x.shape/        if x is None:\n            return base_output\n        total_seq_len, _ = x.shape/}' ${sglang_pkg_path}/sglang/srt/lora/backend/ascend_backend.py
+
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true
           source /usr/local/Ascend/nnal/atb/set_env.sh || true

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 4: Qwen3.5-4B LoRA logprob accuracy test
+# test round 5: Qwen3.5-4B LoRA logprob accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -72,7 +72,12 @@ jobs:
           cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
 
           # Patch ascend_backend.py to handle None input during CUDA graph capture
-          sed -i '/def run_lora_b_sgemm/,/total_seq_len, _ = x.shape/{s/        total_seq_len, _ = x.shape/        if x is None:\n            return base_output\n        total_seq_len, _ = x.shape/}' ${sglang_pkg_path}/sglang/srt/lora/backend/ascend_backend.py
+          python -c "
+f=open('${sglang_pkg_path}/sglang/srt/lora/backend/ascend_backend.py');c=f.read();f.close()
+c=c.replace('    def run_lora_b_sgemm(\n        self,\n        x: torch.Tensor,\n        weights: torch.Tensor,\n        base_output: torch.Tensor = None,\n        *args,\n        **kwargs,\n    ) -> torch.Tensor:\n        total_seq_len, _ = x.shape','    def run_lora_b_sgemm(\n        self,\n        x: torch.Tensor,\n        weights: torch.Tensor,\n        base_output: torch.Tensor = None,\n        *args,\n        **kwargs,\n    ) -> torch.Tensor:\n        if x is None:\n            return base_output\n        total_seq_len, _ = x.shape')
+f=open('${sglang_pkg_path}/sglang/srt/lora/backend/ascend_backend.py','w');f.write(c);f.close()
+print('Patched ascend_backend.py for None input handling')
+"
 
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: Qwen3.5-4B LoRA logprob accuracy test
+# test round 3: Qwen3.5-4B LoRA logprob accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: Qwen3.5-4B LoRA logprob accuracy test
+# test round 4: Qwen3.5-4B LoRA logprob accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 5: Qwen3.5-4B LoRA logprob accuracy test
+# test round 6: Qwen3.5-4B LoRA logprob accuracy test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -72,12 +72,7 @@ jobs:
           cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
 
           # Patch ascend_backend.py to handle None input during CUDA graph capture
-          python -c "
-f=open('${sglang_pkg_path}/sglang/srt/lora/backend/ascend_backend.py');c=f.read();f.close()
-c=c.replace('    def run_lora_b_sgemm(\n        self,\n        x: torch.Tensor,\n        weights: torch.Tensor,\n        base_output: torch.Tensor = None,\n        *args,\n        **kwargs,\n    ) -> torch.Tensor:\n        total_seq_len, _ = x.shape','    def run_lora_b_sgemm(\n        self,\n        x: torch.Tensor,\n        weights: torch.Tensor,\n        base_output: torch.Tensor = None,\n        *args,\n        **kwargs,\n    ) -> torch.Tensor:\n        if x is None:\n            return base_output\n        total_seq_len, _ = x.shape')
-f=open('${sglang_pkg_path}/sglang/srt/lora/backend/ascend_backend.py','w');f.write(c);f.close()
-print('Patched ascend_backend.py for None input handling')
-"
+          python -c "f=open('${sglang_pkg_path}/sglang/srt/lora/backend/ascend_backend.py');c=f.read();f.close();c=c.replace('    def run_lora_b_sgemm(\n        self,\n        x: torch.Tensor,\n        weights: torch.Tensor,\n        base_output: torch.Tensor = None,\n        *args,\n        **kwargs,\n    ) -> torch.Tensor:\n        total_seq_len, _ = x.shape','    def run_lora_b_sgemm(\n        self,\n        x: torch.Tensor,\n        weights: torch.Tensor,\n        base_output: torch.Tensor = None,\n        *args,\n        **kwargs,\n    ) -> torch.Tensor:\n        if x is None:\n            return base_output\n        total_seq_len, _ = x.shape');f=open('${sglang_pkg_path}/sglang/srt/lora/backend/ascend_backend.py','w');f.write(c);f.close();print('Patched ascend_backend.py for None input handling')"
 
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,99 @@
+name: Single Test (NPU)
+# test round 1: Qwen3.5-4B LoRA logprob accuracy test
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-8
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases
+          test_cases=(
+            "test/registered/ascend/basic_function/lora/test_lora_npu_qwen3_5_4b_logprob_diff.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: Qwen3.5-4B LoRA logprob accuracy test
+# test round 2: Qwen3.5-4B LoRA logprob accuracy test
 
 on:
   pull_request:

--- a/test/registered/ascend/basic_function/lora/test_lora_npu_qwen3_5_4b_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_lora_npu_qwen3_5_4b_logprob_diff.py
@@ -37,7 +37,7 @@ BASE_MODEL = "/root/.cache/modelscope/hub/models/Qwen/Qwen3.5-4B"
 LORA_HF_REPO = "/root/.cache/huggingface/hub/lora-test-case-Qwen3.5-4B"
 
 
-LORA_BACKEND = "triton"
+LORA_BACKEND = "ascend"
 MAX_LORA_RANK = 64
 TP_SIZE = 1
 

--- a/test/registered/ascend/basic_function/lora/test_lora_npu_qwen3_5_4b_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_lora_npu_qwen3_5_4b_logprob_diff.py
@@ -37,7 +37,7 @@ BASE_MODEL = "/root/.cache/modelscope/hub/models/Qwen/Qwen3.5-4B"
 LORA_HF_REPO = "/root/.cache/huggingface/hub/lora-test-case-Qwen3.5-4B"
 
 
-LORA_BACKEND = "ascend"
+LORA_BACKEND = "torch_native"
 MAX_LORA_RANK = 64
 TP_SIZE = 1
 

--- a/test/registered/ascend/basic_function/lora/test_lora_npu_qwen3_5_4b_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_lora_npu_qwen3_5_4b_logprob_diff.py
@@ -1,0 +1,138 @@
+# Copyright 2023-2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Regression test for Qwen3.5-4B LoRA logprob accuracy.
+
+Compares SGLang LoRA logprobs against reference training logprobs from a
+pre-computed dataset. The LoRA adapter and reference data are downloaded from:
+https://huggingface.co/datasets/opherlie/lora-test-case-Qwen3.5-4B
+
+"""
+
+import multiprocessing as mp
+import os
+import unittest
+
+import torch
+
+import sglang as sgl
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
+
+BASE_MODEL = "/root/.cache/modelscope/hub/models/Qwen/Qwen3.5-4B"
+LORA_HF_REPO = "/root/.cache/huggingface/hub/lora-test-case-Qwen3.5-4B"
+
+
+LORA_BACKEND = "triton"
+MAX_LORA_RANK = 64
+TP_SIZE = 1
+
+KL_THRESHOLD = 4e-3
+
+
+def kl_v2(a, b):
+    a = torch.tensor(a) if not torch.is_tensor(a) else a
+    b = torch.tensor(b) if not torch.is_tensor(b) else b
+    return (((a - b) ** 2) * 0.5).mean().item()
+
+
+def get_prompt_logprobs(engine, input_ids, lora_path):
+    if isinstance(input_ids, torch.Tensor):
+        input_ids = [input_ids.tolist()]
+    elif not isinstance(input_ids[0], list):
+        input_ids = [input_ids]
+    out = engine.generate(
+        input_ids=input_ids,
+        sampling_params={"max_new_tokens": 0, "temperature": 0.0},
+        return_logprob=True,
+        logprob_start_len=0,
+        lora_path=lora_path,
+    )
+    if isinstance(out, list):
+        out = out[0]
+    return [logprob for logprob, _, _ in out["meta_info"]["input_token_logprobs"]][1:]
+
+
+class TestLoRAQwen3_5_4BLogprobDiff(CustomTestCase):
+
+    def test_lora_qwen3_5_4b_logprob_accuracy(self):
+        engine = sgl.Engine(
+            model_path=BASE_MODEL,
+            tp_size=TP_SIZE,
+            enable_lora=True,
+            max_lora_rank=MAX_LORA_RANK,
+            lora_paths={"my_lora": LORA_HF_REPO},
+            lora_backend=LORA_BACKEND,
+            attention_backend="ascend",
+        )
+
+        try:
+            cdata = torch.load(
+                os.path.join(LORA_HF_REPO, "compare_sample_train_data.pt"),
+                weights_only=False,
+            )
+
+            base_logprobs = get_prompt_logprobs(engine, cdata["tokens"], lora_path=None)
+            logprobs = get_prompt_logprobs(engine, cdata["tokens"], lora_path="my_lora")
+
+            base_t = torch.tensor(base_logprobs)
+            lora_t = torch.tensor(logprobs)
+            diff = (base_t - lora_t).abs()
+            print(
+                f"[VERIFY] base vs lora: mean_diff={diff.mean().item():.6f}, "
+                f"max_diff={diff.max().item():.6f}, "
+                f"identical={torch.equal(base_t, lora_t)}"
+            )
+
+            self.assertFalse(
+                torch.equal(base_t, lora_t),
+                "LoRA logprobs should differ from base model logprobs",
+            )
+
+            kl_sglang_trainer = kl_v2(cdata["training_logprobs"], logprobs)
+            kl_orig_trainer = kl_v2(
+                cdata["training_logprobs"], cdata["sampling_logprobs"]
+            )
+            kl_sglang_orig = kl_v2(logprobs, cdata["sampling_logprobs"])
+
+            print(f"KL(orig_sampler, trainer) = {kl_orig_trainer:.6e}")
+            print(f"KL(sglang, trainer)       = {kl_sglang_trainer:.6e}")
+            print(f"KL(sglang, orig_sampler)  = {kl_sglang_orig:.6e}")
+
+            self.assertLessEqual(
+                kl_sglang_trainer,
+                KL_THRESHOLD,
+                f"KL(sglang, trainer) = {kl_sglang_trainer:.6e} exceeds "
+                f"threshold {KL_THRESHOLD}",
+            )
+
+        finally:
+            engine.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        mp.set_start_method("spawn")
+    except RuntimeError:
+        pass
+
+    try:
+        unittest.main(warnings="ignore", verbosity=2)
+    finally:
+        if torch.npu.is_available():
+            torch.npu.empty_cache()
+            torch.npu.synchronize()


### PR DESCRIPTION
## Description

Add regression test for Qwen3.5-4B LoRA logprob accuracy.

- Compares SGLang LoRA logprobs against reference training logprobs
- Uses KL divergence v2 metric with threshold 4e-3
- Tests LoRA adapter from lora-test-case-Qwen3.5-4B dataset

## Test Case

- `test/registered/ascend/basic_function/lora/test_lora_npu_qwen3_5_4b_logprob_diff.py`





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->