### PR TITLE
test: add Qwen3-8B LoRA logprob diff test for NPU

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 5: Qwen3-8B LoRA logprob diff test - use ascend backend (torch.ops.npu.sgmv)
+# test round 6: Qwen3-8B LoRA logprob diff test - fix lint import order
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 4: Qwen3-8B LoRA logprob diff test - use csgmv backend to avoid Triton grid limit
+# test round 5: Qwen3-8B LoRA logprob diff test - use ascend backend (torch.ops.npu.sgmv)
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: Qwen3-8B LoRA logprob diff test - set ASCEND_GRID_DIM_SPLIT_ENABLE in CI env
+# test round 4: Qwen3-8B LoRA logprob diff test - use csgmv backend to avoid Triton grid limit
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: Qwen3-8B LoRA logprob diff test - fix ASCEND_GRID_DIM_SPLIT_ENABLE
+# test round 3: Qwen3-8B LoRA logprob diff test - set ASCEND_GRID_DIM_SPLIT_ENABLE in CI env
 
 on:
   pull_request:
@@ -32,6 +32,7 @@ jobs:
           SGLANG_USE_MODELSCOPE: true
           HF_ENDPOINT: https://hf-mirror.com
           SGLANG_IS_IN_CI: true
+          ASCEND_GRID_DIM_SPLIT_ENABLE: "1"
         shell: bash
         run: |
           sglang_source_path=$(pwd)

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,99 @@
+name: Single Test (NPU)
+# test round 1: Qwen3-8B LoRA logprob diff test
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-8
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B080
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases
+          test_cases=(
+            "test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: Qwen3-8B LoRA logprob diff test
+# test round 2: Qwen3-8B LoRA logprob diff test - fix ASCEND_GRID_DIM_SPLIT_ENABLE
 
 on:
   pull_request:

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py
@@ -43,7 +43,7 @@ register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
 # LORA_HF_REPO = "/home/weights/lora-diff-Qwen3-8B"
 BASE_MODEL = QWEN3_8B_WEIGHTS_PATH
 LORA_HF_REPO = "/root/.cache/huggingface/hub/lora-diff-Qwen3-8B"
-LORA_BACKEND = "csgmv"
+LORA_BACKEND = "ascend"
 MAX_LORA_RANK = 32
 TP_SIZE = 1
 PREFILL_ATTENTION_BACKEND = "ascend"

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py
@@ -1,0 +1,203 @@
+# Copyright 2023-2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Regression test for Qwen3-8B LoRA logprob accuracy.
+
+Compares SGLang LoRA logprobs against reference training logprobs from a
+pre-computed dataset. The LoRA adapter and reference data are downloaded from:
+https://huggingface.co/datasets/yushengsu/lora-diff-Qwen3-8B
+
+Usage:
+    python -m unittest test_lora_qwen3_8b_logprob_diff
+"""
+
+import multiprocessing as mp
+import os
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.nn as nn
+# export ASCEND_GRID_DIM_SPLIT_ENABLE=1
+import sglang as sgl
+from sglang.srt.lora.utils import auto_detect_lora_target_modules
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
+
+# BASE_MODEL = "/home/weights/Qwen/Qwen3-8B"
+# LORA_HF_REPO = "/home/weights/lora-diff-Qwen3-8B"
+BASE_MODEL = QWEN3_8B_WEIGHTS_PATH
+LORA_HF_REPO = "/root/.cache/huggingface/hub/lora-diff-Qwen3-8B"
+LORA_BACKEND = "triton"
+MAX_LORA_RANK = 32
+TP_SIZE = 1
+PREFILL_ATTENTION_BACKEND = "ascend"
+DECODE_ATTENTION_BACKEND = "ascend"
+
+KL_THRESHOLD = 5e-3
+
+
+def kl_v2(a, b):
+    a = torch.tensor(a) if not torch.is_tensor(a) else a
+    b = torch.tensor(b) if not torch.is_tensor(b) else b
+    return (((a - b) ** 2) * 0.5).mean().item()
+
+
+def get_prompt_logprobs(engine, input_ids, lora_path):
+    out = engine.generate(
+        input_ids=input_ids,
+        sampling_params={"max_new_tokens": 0, "temperature": 0.0},
+        return_logprob=True,
+        logprob_start_len=0,
+        lora_path=lora_path,
+    )
+    return [logprob for logprob, _, _ in out["meta_info"]["input_token_logprobs"]][1:]
+
+
+class _MockLinearBase(nn.Module):
+    pass
+
+
+class _MockFusedMoE(nn.Module):
+    pass
+
+
+class _MockParallelLMHead(nn.Module):
+    pass
+
+
+def _build_qwen3_mock():
+    """Build a lightweight nn.Module tree that mirrors Qwen3-8B's named modules."""
+    model = nn.Module()
+    inner = nn.Module()
+    layer = nn.Module()
+
+    attn = nn.Module()
+    attn.qkv_proj = _MockLinearBase()
+    attn.o_proj = _MockLinearBase()
+    layer.self_attn = attn
+
+    mlp = nn.Module()
+    mlp.gate_up_proj = _MockLinearBase()
+    mlp.down_proj = _MockLinearBase()
+    layer.mlp = mlp
+
+    inner.layers = nn.ModuleList([layer])
+    inner.embed_tokens = nn.Embedding(10, 8)  # not a LinearBase — should be excluded
+    model.model = inner
+    model.lm_head = _MockParallelLMHead()
+    return model
+
+
+class TestLoRAQwen3_8BLogprobDiff(CustomTestCase):
+
+    def test_auto_detect_lora_target_modules(self):
+        """Verify auto_detect_lora_target_modules returns the expected module
+        set for a Qwen3-8B-like (dense) architecture.  Catches silent renames
+        of internal param names that would break LoRA auto-detection."""
+        model = _build_qwen3_mock()
+
+        with (
+            patch("sglang.srt.layers.linear.LinearBase", _MockLinearBase),
+            patch(
+                "sglang.srt.layers.moe.fused_moe_triton.layer.FusedMoE", _MockFusedMoE
+            ),
+            patch(
+                "sglang.srt.layers.vocab_parallel_embedding.ParallelLMHead",
+                _MockParallelLMHead,
+            ),
+        ):
+            detected = auto_detect_lora_target_modules(model)
+
+        expected = {"qkv_proj", "o_proj", "gate_up_proj", "down_proj", "lm_head"}
+        self.assertEqual(detected, expected)
+
+    def test_lora_qwen3_8b_logprob_accuracy(self):
+        # adapter_path = snapshot_download(
+        #     LORA_HF_REPO,
+        #     repo_type="dataset",
+        # )
+
+        engine = sgl.Engine(
+            model_path=BASE_MODEL,
+            tp_size=TP_SIZE,
+            enable_lora=True,
+            max_lora_rank=MAX_LORA_RANK,
+            lora_paths={"my_lora": LORA_HF_REPO},
+            lora_backend=LORA_BACKEND,
+            attention_backend="ascend",
+            prefill_attention_backend=PREFILL_ATTENTION_BACKEND,
+            decode_attention_backend=DECODE_ATTENTION_BACKEND,
+        )
+
+        try:
+            cdata = torch.load(
+                os.path.join(LORA_HF_REPO, "compare_sample_train_data.pt"),
+                weights_only=False,
+            )
+
+            base_logprobs = get_prompt_logprobs(engine, cdata["tokens"], lora_path=None)
+            logprobs = get_prompt_logprobs(engine, cdata["tokens"], lora_path="my_lora")
+
+            base_t = torch.tensor(base_logprobs)
+            lora_t = torch.tensor(logprobs)
+            diff = (base_t - lora_t).abs()
+            print(
+                f"[VERIFY] base vs lora: mean_diff={diff.mean().item():.6f}, "
+                f"max_diff={diff.max().item():.6f}, "
+                f"identical={torch.equal(base_t, lora_t)}"
+            )
+
+            self.assertFalse(
+                torch.equal(base_t, lora_t),
+                "LoRA logprobs should differ from base model logprobs",
+            )
+
+            kl_sglang_trainer = kl_v2(cdata["training_logprobs"], logprobs)
+            kl_orig_trainer = kl_v2(
+                cdata["training_logprobs"], cdata["sampling_logprobs"]
+            )
+            kl_sglang_orig = kl_v2(logprobs, cdata["sampling_logprobs"])
+
+            print(f"KL(orig_sampler, trainer) = {kl_orig_trainer:.6e}")
+            print(f"KL(sglang, trainer)       = {kl_sglang_trainer:.6e}")
+            print(f"KL(sglang, orig_sampler)  = {kl_sglang_orig:.6e}")
+
+            self.assertLessEqual(
+                kl_sglang_trainer,
+                KL_THRESHOLD,
+                f"KL(sglang, trainer) = {kl_sglang_trainer:.6e} exceeds "
+                f"threshold {KL_THRESHOLD}",
+            )
+
+        finally:
+            engine.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        mp.set_start_method("spawn")
+    except RuntimeError:
+        pass
+
+    try:
+        unittest.main(warnings="ignore", verbosity=2)
+    finally:
+        if torch.npu.is_available():
+            torch.npu.empty_cache()
+            torch.npu.synchronize()
+

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py
@@ -32,11 +32,13 @@ os.environ["ASCEND_GRID_DIM_SPLIT_ENABLE"] = "1"
 
 import torch
 import torch.nn as nn
+
 import sglang as sgl
 from sglang.srt.lora.utils import auto_detect_lora_target_modules
+from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import CustomTestCase
-from sglang.test.ascend.test_ascend_utils import QWEN3_8B_WEIGHTS_PATH
+
 register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
 
 # BASE_MODEL = "/home/weights/Qwen/Qwen3-8B"
@@ -201,4 +203,5 @@ if __name__ == "__main__":
         if torch.npu.is_available():
             torch.npu.empty_cache()
             torch.npu.synchronize()
+
 

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py
@@ -28,9 +28,10 @@ import os
 import unittest
 from unittest.mock import patch
 
+os.environ["ASCEND_GRID_DIM_SPLIT_ENABLE"] = "1"
+
 import torch
 import torch.nn as nn
-# export ASCEND_GRID_DIM_SPLIT_ENABLE=1
 import sglang as sgl
 from sglang.srt.lora.utils import auto_detect_lora_target_modules
 from sglang.test.ci.ci_register import register_npu_ci

--- a/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py
+++ b/test/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py
@@ -43,7 +43,7 @@ register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
 # LORA_HF_REPO = "/home/weights/lora-diff-Qwen3-8B"
 BASE_MODEL = QWEN3_8B_WEIGHTS_PATH
 LORA_HF_REPO = "/root/.cache/huggingface/hub/lora-diff-Qwen3-8B"
-LORA_BACKEND = "triton"
+LORA_BACKEND = "csgmv"
 MAX_LORA_RANK = 32
 TP_SIZE = 1
 PREFILL_ATTENTION_BACKEND = "ascend"


### PR DESCRIPTION
## Description

Add regression test for Qwen3-8B LoRA logprob accuracy on NPU.

### Test Case
- 	est/registered/ascend/basic_function/lora/test_npu_lora_qwen3_8b_logprob_diff.py

### Test Details
- Compares SGLang LoRA logprobs against reference training logprobs
- Uses KL divergence to measure accuracy (threshold: 5e-3)
- Tests auto_detect_lora_target_modules for Qwen3-8B architecture

### CI Configuration
- Docker image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B080
- Timeout: 120 minutes















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->