### PR TITLE
Add Qwen3Next MambaCache test with cann9.0.0-a3-B080

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: Qwen3Next MambaCache test with cann9.0.0-a3-B080
+# test round 2: Qwen3Next MambaCache - fix model path and add register_npu_ci
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 8: Qwen3Next MambaCache - add disable-radix-cache, mem-fraction-static, suite full-16-npu-a3
+# test round 1: Qwen3 Next Mamba Cache Test
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-16
+    runs-on: linux-aarch64-a3-2
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B080
     steps:
@@ -70,10 +70,6 @@ jobs:
           mkdir -p ${ascend_test_util_path}
           mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
           cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
-
-          # Copy fixed NPU backend to override image version
-          cp ${sglang_source_path}/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py \
-             ${sglang_pkg_path}/sglang/srt/hardware_backend/npu/attention/
 
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 4: Qwen3Next MambaCache - suite full-16-npu-a3, restore tp-size 4
+# test round 5: Qwen3Next MambaCache - runner linux-aarch64-a3-16 for 80B model
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-16
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B080
     steps:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 5: Qwen3Next MambaCache - runner linux-aarch64-a3-16 for 80B model
+# test round 6: Qwen3Next MambaCache - fix _replay_metadata in_capture arg
 
 on:
   pull_request:
@@ -70,6 +70,10 @@ jobs:
           mkdir -p ${ascend_test_util_path}
           mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
           cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Copy fixed NPU backend to override image version
+          cp ${sglang_source_path}/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py \
+             ${sglang_pkg_path}/sglang/srt/hardware_backend/npu/attention/
 
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: Qwen3Next MambaCache - fix isort order, tp-size 4->2
+# test round 4: Qwen3Next MambaCache - suite full-16-npu-a3, restore tp-size 4
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,0 +1,99 @@
+name: Single Test (NPU)
+# test round 1: Qwen3Next MambaCache test with cann9.0.0-a3-B080
+
+on:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/single-test-npu.yml"
+
+concurrency:
+  group: single-test-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B080
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases
+          test_cases=(
+            "test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 7: Qwen3Next MambaCache - fix seq_lens_cpu type handling
+# test round 8: Qwen3Next MambaCache - add disable-radix-cache, mem-fraction-static, suite full-16-npu-a3
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: Qwen3Next MambaCache - fix model path and add register_npu_ci
+# test round 3: Qwen3Next MambaCache - fix isort order, tp-size 4->2
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 6: Qwen3Next MambaCache - fix _replay_metadata in_capture arg
+# test round 7: Qwen3Next MambaCache - fix seq_lens_cpu type handling
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -15,9 +15,9 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-4
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B080
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
@@ -129,12 +129,19 @@ class AscendMambaAttnBackendBase(MambaAttnBackendBase):
         req_pool_indices: torch.Tensor,
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
+        seq_lens_cpu: Optional[torch.Tensor] = None,
         **kwargs,
     ):
-        num_padding = torch.count_nonzero(
-            seq_lens_cpu == self.get_cuda_graph_seq_len_fill_value()
-        )
+        # Handle case where seq_lens_cpu might be a bool (in_capture) due to API mismatch
+        if not isinstance(seq_lens_cpu, torch.Tensor):
+            seq_lens_cpu = None
+
+        if seq_lens_cpu is not None:
+            num_padding = torch.count_nonzero(
+                seq_lens_cpu == self.get_cuda_graph_seq_len_fill_value()
+            )
+        else:
+            num_padding = 0
         # Make sure forward metadata is correctly handled for padding reqs
         req_pool_indices[bs - num_padding :] = 0
         mamba_indices = self.req_to_token_pool.get_mamba_indices(req_pool_indices)

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
@@ -130,6 +130,7 @@ class AscendMambaAttnBackendBase(MambaAttnBackendBase):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
         seq_lens_cpu: Optional[torch.Tensor],
+        **kwargs,
     ):
         num_padding = torch.count_nonzero(
             seq_lens_cpu == self.get_cuda_graph_seq_len_fill_value()

--- a/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
+++ b/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
@@ -20,6 +20,9 @@ class TestQwen3Next(
     gsm8k_accuracy_thres = 0.93
     kl_div_thres = 0.0025
     other_args = [
+        "--trust-remote-code",
+        "--mem-fraction-static",
+        "0.5",
         "--tp-size",
         "4",
         "--chunked-prefill-size",
@@ -32,6 +35,8 @@ class TestQwen3Next(
         "1",
         "--attention-backend",
         "ascend",
+        "--disable-cuda-graph",
+        "--disable-radix-cache",
     ]
 
 

--- a/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
+++ b/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
@@ -1,13 +1,13 @@
 import unittest
 
+from sglang.test.ascend.test_ascend_utils import (
+    QWEN3_NEXT_80B_A3B_INSTRUCT_WEIGHTS_PATH,
+)
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.kl_divergence_kit import KLDivergenceMixin
 from sglang.test.kits.prefix_cache_branching_kit import PrefixCacheBranchingMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
-from sglang.test.ascend.test_ascend_utils import (
-    QWEN3_NEXT_80B_A3B_INSTRUCT_WEIGHTS_PATH,
-)
 
 register_npu_ci(est_time=600, suite="full-4-npu-a3", nightly=True)
 
@@ -21,7 +21,7 @@ class TestQwen3Next(
     kl_div_thres = 0.0025
     other_args = [
         "--tp-size",
-        "4",
+        "2",
         "--chunked-prefill-size",
         "1024",
         "--mamba-scheduler-strategy",

--- a/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
+++ b/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
@@ -9,7 +9,7 @@ from sglang.test.kits.kl_divergence_kit import KLDivergenceMixin
 from sglang.test.kits.prefix_cache_branching_kit import PrefixCacheBranchingMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
-register_npu_ci(est_time=600, suite="full-4-npu-a3", nightly=True)
+register_npu_ci(est_time=600, suite="full-16-npu-a3", nightly=True)
 
 
 class TestQwen3Next(
@@ -21,7 +21,7 @@ class TestQwen3Next(
     kl_div_thres = 0.0025
     other_args = [
         "--tp-size",
-        "2",
+        "4",
         "--chunked-prefill-size",
         "1024",
         "--mamba-scheduler-strategy",

--- a/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
+++ b/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
@@ -9,7 +9,7 @@ from sglang.test.kits.kl_divergence_kit import KLDivergenceMixin
 from sglang.test.kits.prefix_cache_branching_kit import PrefixCacheBranchingMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
-register_npu_ci(est_time=600, suite="full-16-npu-a3", nightly=True)
+register_npu_ci(est_time=600, suite="full-4-npu-a3", nightly=True)
 
 
 class TestQwen3Next(
@@ -20,9 +20,6 @@ class TestQwen3Next(
     gsm8k_accuracy_thres = 0.93
     kl_div_thres = 0.0025
     other_args = [
-        "--trust-remote-code",
-        "--mem-fraction-static",
-        "0.5",
         "--tp-size",
         "4",
         "--chunked-prefill-size",
@@ -36,7 +33,8 @@ class TestQwen3Next(
         "--attention-backend",
         "ascend",
         "--disable-cuda-graph",
-        "--disable-radix-cache",
+        "--max-running-requests",
+        "4",
     ]
 
 

--- a/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
+++ b/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
@@ -1,18 +1,21 @@
 import unittest
 
-from sglang.test.ascend.test_ascend_utils import (
-    QWEN3_NEXT_80B_A3B_INSTRUCT_WEIGHTS_FOR_TEST,
-)
+from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.kl_divergence_kit import KLDivergenceMixin
 from sglang.test.kits.prefix_cache_branching_kit import PrefixCacheBranchingMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
+from sglang.test.ascend.test_ascend_utils import (
+    QWEN3_NEXT_80B_A3B_INSTRUCT_WEIGHTS_PATH,
+)
+
+register_npu_ci(est_time=600, suite="full-4-npu-a3", nightly=True)
 
 
 class TestQwen3Next(
     GSM8KMixin, KLDivergenceMixin, PrefixCacheBranchingMixin, DefaultServerBase
 ):
-    model = QWEN3_NEXT_80B_A3B_INSTRUCT_WEIGHTS_FOR_TEST
+    model = QWEN3_NEXT_80B_A3B_INSTRUCT_WEIGHTS_PATH
     cache_chunk_size = 64
     gsm8k_accuracy_thres = 0.93
     kl_div_thres = 0.0025

--- a/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
+++ b/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
@@ -1,0 +1,36 @@
+import unittest
+
+from sglang.test.ascend.test_ascend_utils import (
+    QWEN3_NEXT_80B_A3B_INSTRUCT_WEIGHTS_FOR_TEST,
+)
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.kits.kl_divergence_kit import KLDivergenceMixin
+from sglang.test.kits.prefix_cache_branching_kit import PrefixCacheBranchingMixin
+from sglang.test.server_fixtures.default_fixture import DefaultServerBase
+
+
+class TestQwen3Next(
+    GSM8KMixin, KLDivergenceMixin, PrefixCacheBranchingMixin, DefaultServerBase
+):
+    model = QWEN3_NEXT_80B_A3B_INSTRUCT_WEIGHTS_FOR_TEST
+    cache_chunk_size = 64
+    gsm8k_accuracy_thres = 0.93
+    kl_div_thres = 0.0025
+    other_args = [
+        "--tp-size",
+        "4",
+        "--chunked-prefill-size",
+        "1024",
+        "--mamba-scheduler-strategy",
+        "extra_buffer",
+        "--mamba-track-interval",
+        "2",
+        "--page-size",
+        "1",
+        "--attention-backend",
+        "ascend",
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
+++ b/test/registered/ascend/basic_function/mambacache/test_npu_qwen3_next_models.py
@@ -32,7 +32,7 @@ class TestQwen3Next(
         "1",
         "--attention-backend",
         "ascend",
-        "--disable-cuda-graph",
+        #"--disable-cuda-graph",
         "--max-running-requests",
         "4",
     ]


### PR DESCRIPTION
## Description

Add test case for Qwen3Next 80B A3B model with MambaCache support.

### Changes
- Add test_npu_qwen3_next_models.py for Qwen3Next model testing
- Update single-test-npu.yml to use cann9.0.0-a3-B080 docker image
- Configure MambaCache specific args: extra_buffer scheduler, page_size=1, ascend backend

### Test Configuration
- Model: QWEN3_NEXT_80B_A3B_INSTRUCT
- TP size: 4
- Attention backend: ascend
- Mamba scheduler: extra_buffer

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->