### PR TITLE
Add prefix MM cache E2E test

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: <测试用例描述>
+# test round 1: Prefix MM Cache E2E Test
 
 on:
   pull_request:
@@ -15,9 +15,9 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-1
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,9 +38,9 @@ jobs:
           echo "Source code path: ${sglang_source_path}"
           ln -sf ${sglang_source_path} /root/sglang
 
-          # Test cases - 使用时替换为实际的测试用例路径
+          # Test cases
           test_cases=(
-            "test/registered/ascend/llm_models/test_npu_deepseek_v3_2_w8a8.py"
+            "test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-1
+    runs-on: linux-aarch64-a3-4
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090
     steps:

--- a/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
+++ b/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
@@ -155,8 +155,8 @@ class TestPrefixMMCacheE2E(CustomTestCase):
         print("ufhgsfduioffbnc;oaihfninfioooooooojhffffffffffffffffffffhh")
         print(response1.json())
         self.assertEqual(response2.status_code, 200)
-        self.assertEqual(response1.json()["meta_info"]["cached_tokens"], 0)
-        self.assertGreater(response2.json()["meta_info"]["cached_tokens"], 0)
+        self.assertEqual(response1.json()["prompt_tokens_details"]["cached_tokens"], 0)
+        self.assertGreater(response2.json()["prompt_tokens_details"]["cached_tokens"], 0)
 
     def test_text_generation(self):
         """Test that text-only generation works."""

--- a/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
+++ b/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
@@ -18,7 +18,6 @@ from sglang.test.test_utils import (
 )
 
 os.environ["TRANSFORMERS_VERBOSITY"] = "error"
-os.environ["SGLANG_MM_SKIP_COMPUTE_HASH"] = "True"
 
 register_npu_ci(est_time=400, suite="full-2-npu-a3", nightly=True)
 

--- a/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
+++ b/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
@@ -30,7 +30,7 @@ _INLINE_IMAGE_URL = (
     "cua9HOR7Y6w6swBwMy0qLTpkeI77qdEBpBFAHBBDAGH8WrwJKI4AAegUCfAKgEgpQDvh3CR"
     "3oQCuav58qlAw73kKCSgAAAABJRU5ErkJggg=="
 )
-image_url = "https://raw.githubusercontent.com/sgl-project/sglang/main/test/images/cat.jpg"
+image_url = "/root/.cache/modelscope/hub/datasets/images/invoice_with_barcode_logo.jpeg"
 
 
 class TestPrefixMMCacheE2E(CustomTestCase):

--- a/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
+++ b/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
@@ -152,6 +152,8 @@ class TestPrefixMMCacheE2E(CustomTestCase):
             json=payload,
             timeout=120,
         )
+        print("ufhgsfduioffbnc;oaihfninfioooooooojhffffffffffffffffffffhh")
+        print(response1.json())
         self.assertEqual(response2.status_code, 200)
         self.assertEqual(response1.json()["meta_info"]["cached_tokens"], 0)
         self.assertGreater(response2.json()["meta_info"]["cached_tokens"], 0)

--- a/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
+++ b/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
@@ -1,8 +1,9 @@
 """
 End-to-end test for --enable-prefix-mm-cache parameter.
-Tests the prefix multimodal cache functionality in encoder-only mode.
+Tests the prefix multimodal cache functionality with encoder + language servers.
 """
 
+import os
 import unittest
 
 import requests
@@ -16,156 +17,166 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_npu_ci(est_time=200, suite="full-1-npu-a3", nightly=True)
+os.environ["TRANSFORMERS_VERBOSITY"] = "error"
+os.environ["SGLANG_MM_SKIP_COMPUTE_HASH"] = "True"
+
+register_npu_ci(est_time=400, suite="full-2-npu-a3", nightly=True)
+
+
+_INLINE_IMAGE_URL = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAA7EAAAOxAGVKw4b"
+    "AAAAbUlEQVRYhe3VsQ2AMAxE0Y/lIgNQULD/OqyCMgCihCKSG4yRuKuiNH6JLsoEbMACOGB"
+    "cua9HOR7Y6w6swBwMy0qLTpkeI77qdEBpBFAHBBDAGH8WrwJKI4AAegUCfAKgEgpQDvh3CR"
+    "3oQCuav58qlAw73kKCSgAAAABJRU5ErkJggg=="
+)
 
 
 class TestPrefixMMCacheE2E(CustomTestCase):
-    """End-to-end test for --enable-prefix-mm-cache with multimodal encoding."""
+    """End-to-end test for --enable-prefix-mm-cache with encoder + language servers."""
 
     model = QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH
-    base_host = "127.0.0.1"
-    encode_port = "30000"
-    encode_url = f"http://{base_host}:{encode_port}"
-    image_url = (
-        "https://raw.githubusercontent.com/sgl-project/sglang/main/test/images/cat.jpg"
-    )
-    video_url = "https://raw.githubusercontent.com/sgl-project/sglang/main/test/videos/sample_video.mp4"
-    audio_url = "https://raw.githubusercontent.com/sgl-project/sglang/main/test/audio/sample_audio.mp3"
+    encoder_host = "127.0.0.1"
+    encoder_port = "30000"
+    encoder_url = f"http://{encoder_host}:{encoder_port}"
+    language_host = "127.0.0.1"
+    language_port = "30001"
+    language_url = f"http://{language_host}:{language_port}"
 
     @classmethod
     def setUpClass(cls):
-        """Start encoder server with --enable-prefix-mm-cache."""
+        """Start encoder server with --enable-prefix-mm-cache and language server."""
+        # Start encoder server
         encode_args = [
             "--trust-remote-code",
             "--encoder-only",
             "--encoder-transfer-backend",
             "zmq_to_scheduler",
-            "--tp",
+            "--tp-size",
             "1",
             "--port",
-            cls.encode_port,
+            cls.encoder_port,
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.8",
             "--enable-prefix-mm-cache",
         ]
         cls.process_encode = popen_launch_server(
             cls.model,
-            base_url=cls.encode_url,
+            base_url=cls.encoder_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=encode_args,
+        )
+
+        # Start language server
+        language_args = [
+            "--trust-remote-code",
+            "--language-only",
+            "--encoder-urls",
+            cls.encoder_url,
+            "--encoder-transfer-backend",
+            "zmq_to_scheduler",
+            "--tp-size",
+            "1",
+            "--port",
+            cls.language_port,
+            "--base-gpu-id",
+            "1",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.8",
+        ]
+        cls.process_language = popen_launch_server(
+            cls.model,
+            base_url=cls.language_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=language_args,
         )
 
     @classmethod
     def tearDownClass(cls):
         """Clean up processes."""
-        if cls.process_encode:
-            try:
-                kill_process_tree(cls.process_encode.pid)
-            except Exception as e:
-                print(f"Error killing process: {e}")
+        for process in [cls.process_encode, cls.process_language]:
+            if process:
+                try:
+                    kill_process_tree(process.pid)
+                except Exception as e:
+                    print(f"Error killing process: {e}")
+        os.environ.pop("SGLANG_MM_SKIP_COMPUTE_HASH", None)
 
-    def _parse_cache_log(self):
-        """Parse encode server logs and return cache hit/miss information."""
-        # This is a placeholder - actual implementation would parse server logs
-        return []
-
-    def test_health_check(self):
+    def test_encoder_health_check(self):
         """Test that encoder server is healthy."""
-        response = requests.get(f"{self.encode_url}/health", timeout=10)
+        response = requests.get(f"{self.encoder_url}/health", timeout=10)
+        self.assertEqual(response.status_code, 200)
+
+    def test_language_server_health(self):
+        """Test that language server is healthy."""
+        response = requests.get(f"{self.language_url}/health", timeout=10)
         self.assertEqual(response.status_code, 200)
 
     def test_image_encoding_with_cache(self):
         """Test that image encoding works with prefix mm cache enabled."""
+        payload = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": _INLINE_IMAGE_URL},
+                        },
+                        {"type": "text", "text": "Describe the image briefly."},
+                    ],
+                }
+            ],
+            "temperature": 0,
+            "max_tokens": 32,
+        }
 
         # First request (cache miss)
         response1 = requests.post(
-            f"{self.encode_url}/encode",
-            json={
-                "modality": "image",
-                "data": [self.image_url],
-            },
-            timeout=60,
-        )
-        self.assertEqual(response1.status_code, 200)
-
-        # Second request (should use cache)
-        response2 = requests.post(
-            f"{self.encode_url}/encode",
-            json={
-                "modality": "image",
-                "data": [self.image_url],
-            },
-            timeout=60,
-        )
-        self.assertEqual(response2.status_code, 200)
-        self.assertEqual(response1.json()["meta_info"]["cached_tokens"], 0)
-        self.assertGreater(response2.json()["meta_info"]["cached_tokens"], 0)
-
-    def test_video_encoding_with_cache(self):
-        """Test that video encoding works with prefix mm cache enabled."""
-
-        # First request (cache miss)
-        response1 = requests.post(
-            f"{self.encode_url}/encode",
-            json={
-                "modality": "video",
-                "data": [self.video_url],
-            },
+            f"{self.language_url}/v1/chat/completions",
+            json=payload,
             timeout=120,
         )
         self.assertEqual(response1.status_code, 200)
 
         # Second request (should use cache)
         response2 = requests.post(
-            f"{self.encode_url}/encode",
-            json={
-                "modality": "video",
-                "data": [self.video_url],
-            },
+            f"{self.language_url}/v1/chat/completions",
+            json=payload,
             timeout=120,
         )
         self.assertEqual(response2.status_code, 200)
-        self.assertEqual(response1.json()["meta_info"]["cached_tokens"], 0)
-        self.assertGreater(response2.json()["meta_info"]["cached_tokens"], 0)
 
-    def test_audio_encoding_with_cache(self):
-        """Test that audio encoding works with prefix mm cache enabled."""
-
-        # First request (cache miss)
-        response1 = requests.post(
-            f"{self.encode_url}/encode",
-            json={
-                "modality": "audio",
-                "data": [self.audio_url],
-            },
-            timeout=60,
+        # Both responses should have content
+        content1 = (
+            response1.json().get("choices", [{}])[0].get("message", {}).get("content", "")
         )
-        self.assertEqual(response1.status_code, 200)
-
-        # Second request (should use cache)
-        response2 = requests.post(
-            f"{self.encode_url}/encode",
-            json={
-                "modality": "audio",
-                "data": [self.audio_url],
-            },
-            timeout=60,
+        content2 = (
+            response2.json().get("choices", [{}])[0].get("message", {}).get("content", "")
         )
-        self.assertEqual(response2.status_code, 200)
-        self.assertEqual(response1.json()["meta_info"]["cached_tokens"], 0)
-        self.assertGreater(response2.json()["meta_info"]["cached_tokens"], 0)
+        self.assertGreater(len(content1), 0)
+        self.assertGreater(len(content2), 0)
 
-    def test_mixed_modality_encoding(self):
-        """Test that mixed modality encoding works with prefix mm cache enabled."""
-
-        # Request with image, video, and audio
+    def test_text_generation(self):
+        """Test that text-only generation works."""
         response = requests.post(
-            f"{self.encode_url}/encode",
+            f"{self.language_url}/generate",
             json={
-                "modality": "mixed",
-                "data": [self.image_url, self.video_url, self.audio_url],
+                "text": "The capital of France is",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 16},
             },
-            timeout=180,
+            timeout=60,
         )
         self.assertEqual(response.status_code, 200)
+        generated_text = response.json().get("text", "")
+        self.assertIn("Paris", generated_text)
 
 
 if __name__ == "__main__":

--- a/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
+++ b/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
@@ -154,6 +154,8 @@ class TestPrefixMMCacheE2E(CustomTestCase):
         )
         print("ufhgsfduioffbnc;oaihfninfioooooooojhffffffffffffffffffffhh")
         print(response1.json())
+        print("ufhgsfduioffbnc;oaihfninfioooooooojhffffffffffffffffffffhh")
+        print(response2.json())
         self.assertEqual(response2.status_code, 200)
         self.assertEqual(response1.json()["usage"]["prompt_tokens_details"]["cached_tokens"], 0)
         self.assertGreater(response2.json()["usage"]["prompt_tokens_details"]["cached_tokens"], 0)

--- a/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
+++ b/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
@@ -156,10 +156,16 @@ class TestPrefixMMCacheE2E(CustomTestCase):
 
         # Both responses should have content
         content1 = (
-            response1.json().get("choices", [{}])[0].get("message", {}).get("content", "")
+            response1.json()
+            .get("choices", [{}])[0]
+            .get("message", {})
+            .get("content", "")
         )
         content2 = (
-            response2.json().get("choices", [{}])[0].get("message", {}).get("content", "")
+            response2.json()
+            .get("choices", [{}])[0]
+            .get("message", {})
+            .get("content", "")
         )
         self.assertGreater(len(content1), 0)
         self.assertGreater(len(content2), 0)

--- a/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
+++ b/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
@@ -1,0 +1,172 @@
+"""
+End-to-end test for --enable-prefix-mm-cache parameter.
+Tests the prefix multimodal cache functionality in encoder-only mode.
+"""
+
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=200, suite="full-1-npu-a3", nightly=True)
+
+
+class TestPrefixMMCacheE2E(CustomTestCase):
+    """End-to-end test for --enable-prefix-mm-cache with multimodal encoding."""
+
+    model = QWEN3_VL_8B_INSTRUCT_WEIGHTS_PATH
+    base_host = "127.0.0.1"
+    encode_port = "30000"
+    encode_url = f"http://{base_host}:{encode_port}"
+    image_url = (
+        "https://raw.githubusercontent.com/sgl-project/sglang/main/test/images/cat.jpg"
+    )
+    video_url = "https://raw.githubusercontent.com/sgl-project/sglang/main/test/videos/sample_video.mp4"
+    audio_url = "https://raw.githubusercontent.com/sgl-project/sglang/main/test/audio/sample_audio.mp3"
+
+    @classmethod
+    def setUpClass(cls):
+        """Start encoder server with --enable-prefix-mm-cache."""
+        encode_args = [
+            "--trust-remote-code",
+            "--encoder-only",
+            "--encoder-transfer-backend",
+            "zmq_to_scheduler",
+            "--tp",
+            "1",
+            "--port",
+            cls.encode_port,
+            "--enable-prefix-mm-cache",
+        ]
+        cls.process_encode = popen_launch_server(
+            cls.model,
+            base_url=cls.encode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=encode_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up processes."""
+        if cls.process_encode:
+            try:
+                kill_process_tree(cls.process_encode.pid)
+            except Exception as e:
+                print(f"Error killing process: {e}")
+
+    def _parse_cache_log(self):
+        """Parse encode server logs and return cache hit/miss information."""
+        # This is a placeholder - actual implementation would parse server logs
+        return []
+
+    def test_health_check(self):
+        """Test that encoder server is healthy."""
+        response = requests.get(f"{self.encode_url}/health", timeout=10)
+        self.assertEqual(response.status_code, 200)
+
+    def test_image_encoding_with_cache(self):
+        """Test that image encoding works with prefix mm cache enabled."""
+
+        # First request (cache miss)
+        response1 = requests.post(
+            f"{self.encode_url}/encode",
+            json={
+                "modality": "image",
+                "data": [self.image_url],
+            },
+            timeout=60,
+        )
+        self.assertEqual(response1.status_code, 200)
+
+        # Second request (should use cache)
+        response2 = requests.post(
+            f"{self.encode_url}/encode",
+            json={
+                "modality": "image",
+                "data": [self.image_url],
+            },
+            timeout=60,
+        )
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(response1.json()["meta_info"]["cached_tokens"], 0)
+        self.assertGreater(response2.json()["meta_info"]["cached_tokens"], 0)
+
+    def test_video_encoding_with_cache(self):
+        """Test that video encoding works with prefix mm cache enabled."""
+
+        # First request (cache miss)
+        response1 = requests.post(
+            f"{self.encode_url}/encode",
+            json={
+                "modality": "video",
+                "data": [self.video_url],
+            },
+            timeout=120,
+        )
+        self.assertEqual(response1.status_code, 200)
+
+        # Second request (should use cache)
+        response2 = requests.post(
+            f"{self.encode_url}/encode",
+            json={
+                "modality": "video",
+                "data": [self.video_url],
+            },
+            timeout=120,
+        )
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(response1.json()["meta_info"]["cached_tokens"], 0)
+        self.assertGreater(response2.json()["meta_info"]["cached_tokens"], 0)
+
+    def test_audio_encoding_with_cache(self):
+        """Test that audio encoding works with prefix mm cache enabled."""
+
+        # First request (cache miss)
+        response1 = requests.post(
+            f"{self.encode_url}/encode",
+            json={
+                "modality": "audio",
+                "data": [self.audio_url],
+            },
+            timeout=60,
+        )
+        self.assertEqual(response1.status_code, 200)
+
+        # Second request (should use cache)
+        response2 = requests.post(
+            f"{self.encode_url}/encode",
+            json={
+                "modality": "audio",
+                "data": [self.audio_url],
+            },
+            timeout=60,
+        )
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(response1.json()["meta_info"]["cached_tokens"], 0)
+        self.assertGreater(response2.json()["meta_info"]["cached_tokens"], 0)
+
+    def test_mixed_modality_encoding(self):
+        """Test that mixed modality encoding works with prefix mm cache enabled."""
+
+        # Request with image, video, and audio
+        response = requests.post(
+            f"{self.encode_url}/encode",
+            json={
+                "modality": "mixed",
+                "data": [self.image_url, self.video_url, self.audio_url],
+            },
+            timeout=180,
+        )
+        self.assertEqual(response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
+++ b/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
@@ -155,8 +155,8 @@ class TestPrefixMMCacheE2E(CustomTestCase):
         print("ufhgsfduioffbnc;oaihfninfioooooooojhffffffffffffffffffffhh")
         print(response1.json())
         self.assertEqual(response2.status_code, 200)
-        self.assertEqual(response1.json()["prompt_tokens_details"]["cached_tokens"], 0)
-        self.assertGreater(response2.json()["prompt_tokens_details"]["cached_tokens"], 0)
+        self.assertEqual(response1.json()["usage"]["prompt_tokens_details"]["cached_tokens"], 0)
+        self.assertGreater(response2.json()["usage"]["prompt_tokens_details"]["cached_tokens"], 0)
 
     def test_text_generation(self):
         """Test that text-only generation works."""

--- a/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
+++ b/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
@@ -30,6 +30,7 @@ _INLINE_IMAGE_URL = (
     "cua9HOR7Y6w6swBwMy0qLTpkeI77qdEBpBFAHBBDAGH8WrwJKI4AAegUCfAKgEgpQDvh3CR"
     "3oQCuav58qlAw73kKCSgAAAABJRU5ErkJggg=="
 )
+image_url = "https://raw.githubusercontent.com/sgl-project/sglang/main/test/images/cat.jpg"
 
 
 class TestPrefixMMCacheE2E(CustomTestCase):
@@ -128,7 +129,7 @@ class TestPrefixMMCacheE2E(CustomTestCase):
                     "content": [
                         {
                             "type": "image_url",
-                            "image_url": {"url": _INLINE_IMAGE_URL},
+                            "image_url": {"url": image_url},
                         },
                         {"type": "text", "text": "Describe the image briefly."},
                     ],

--- a/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
+++ b/test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
@@ -153,22 +153,8 @@ class TestPrefixMMCacheE2E(CustomTestCase):
             timeout=120,
         )
         self.assertEqual(response2.status_code, 200)
-
-        # Both responses should have content
-        content1 = (
-            response1.json()
-            .get("choices", [{}])[0]
-            .get("message", {})
-            .get("content", "")
-        )
-        content2 = (
-            response2.json()
-            .get("choices", [{}])[0]
-            .get("message", {})
-            .get("content", "")
-        )
-        self.assertGreater(len(content1), 0)
-        self.assertGreater(len(content2), 0)
+        self.assertEqual(response1.json()["meta_info"]["cached_tokens"], 0)
+        self.assertGreater(response2.json()["meta_info"]["cached_tokens"], 0)
 
     def test_text_generation(self):
         """Test that text-only generation works."""


### PR DESCRIPTION
Add test for --enable-prefix-mm-cache parameter with encoder-only mode

Test file: test/registered/ascend/basic_function/EPD/test_npu_prefix_mm_cache.py
Image: cann9.0.0-a3-B090
Runner: linux-aarch64-a3-1

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->