### PR TITLE
test(ascend): add DSV4-Flash W8A8 single-node PD-mix accuracy & performance cases

### DIFF
--- a/.github/workflows/dsv4-flash-test-npu.yml
+++ b/.github/workflows/dsv4-flash-test-npu.yml
@@ -75,9 +75,12 @@ jobs:
           mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
           cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
 
-          # Set environment of cann
-          source /usr/local/Ascend/cann/set_env.sh || true
+          # Set environment of cann (must include custom vendors so that
+          # DSV4 HCA custom ops such as aclnnHcPre can be loaded from libopapi.so)
+          source /usr/local/Ascend/ascend-toolkit/set_env.sh || true
           source /usr/local/Ascend/nnal/atb/set_env.sh || true
+          source /usr/local/Ascend/ascend-toolkit/latest/opp/vendors/customize/bin/set_env.bash || true
+          source /usr/local/Ascend/ascend-toolkit/latest/opp/vendors/custom_transformer/bin/set_env.bash || true
 
           current_date=$(date +%Y%m%d)
           log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"

--- a/.github/workflows/dsv4-flash-test-npu.yml
+++ b/.github/workflows/dsv4-flash-test-npu.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: linux-aarch64-a3-16
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090
+      options: --pull always
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/dsv4-flash-test-npu.yml
+++ b/.github/workflows/dsv4-flash-test-npu.yml
@@ -20,7 +20,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-16
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090
+      image: swr.cn-south-west-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090-20260703
       options: --pull always
     steps:
       - name: Checkout code

--- a/.github/workflows/dsv4-flash-test-npu.yml
+++ b/.github/workflows/dsv4-flash-test-npu.yml
@@ -21,7 +21,6 @@ jobs:
     runs-on: linux-aarch64-a3-16
     container:
       image: swr.cn-south-west-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090-20260703
-      options: --pull always
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/dsv4-flash-test-npu.yml
+++ b/.github/workflows/dsv4-flash-test-npu.yml
@@ -1,23 +1,26 @@
-name: Single Test (NPU)
-# test round 1: <测试用例描述>
+name: DSV4-Flash Single Test (NPU)
+# DSV4-Flash W8A8 single-node PD-mix accuracy & performance test cases.
 
 on:
   pull_request:
     branches:
       - testcases
     paths:
-      - ".github/workflows/single-test-npu.yml"
+      - ".github/workflows/dsv4-flash-test-npu.yml"
+      - "test/registered/ascend/accuracy/deepseek_v4_flash/**"
+      - "test/registered/ascend/performance/deepseek_v4_flash/**"
+      - "python/sglang/test/ascend/e2e/test_npu_performance_utils.py"
 
 concurrency:
-  group: single-test-npu-${{ github.ref }}
+  group: dsv4-flash-test-npu-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-16
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,7 +30,7 @@ jobs:
           npu-smi info
 
       - name: Run test
-        timeout-minutes: 120
+        timeout-minutes: 240
         env:
           SGLANG_USE_MODELSCOPE: true
           HF_ENDPOINT: https://hf-mirror.com
@@ -38,9 +41,10 @@ jobs:
           echo "Source code path: ${sglang_source_path}"
           ln -sf ${sglang_source_path} /root/sglang
 
-          # Test cases - 使用时替换为实际的测试用例路径
+          # DSV4-Flash W8A8 single-node PD-mix test cases
           test_cases=(
-            "test/registered/ascend/llm_models/test_npu_deepseek_v3_2_w8a8.py"
+            "test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py"
+            "test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/dsv4-flash-test-npu.yml
+++ b/.github/workflows/dsv4-flash-test-npu.yml
@@ -43,9 +43,11 @@ jobs:
           ln -sf ${sglang_source_path} /root/sglang
 
           # DSV4-Flash W8A8 single-node PD-mix test cases
+          # Order: performance first (faster, isolates service-launch issues),
+          # then accuracy (AIME26 + GPQA-Diamond).
           test_cases=(
-            "test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py"
             "test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py"
+            "test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,6 @@
 name: Single Test (NPU)
-# test round 1: <测试用例描述>
+# test round 1: DSV4-Flash W8A8 single-node PD-mix accuracy (AIME26 + GPQA-Diamond)
+#                and performance (in8k/out1k, TPOT<=50ms, throughput>=1708) cases.
 
 on:
   pull_request:
@@ -15,9 +16,9 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-16
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,7 +28,7 @@ jobs:
           npu-smi info
 
       - name: Run test
-        timeout-minutes: 120
+        timeout-minutes: 240
         env:
           SGLANG_USE_MODELSCOPE: true
           HF_ENDPOINT: https://hf-mirror.com
@@ -38,9 +39,12 @@ jobs:
           echo "Source code path: ${sglang_source_path}"
           ln -sf ${sglang_source_path} /root/sglang
 
-          # Test cases - 使用时替换为实际的测试用例路径
+          # Test cases - DSV4-Flash W8A8 single-node 16-card PD-mix:
+          #   1. Accuracy on AIME26 + GPQA-Diamond
+          #   2. Performance in8k/out1k (TPOT<=50ms, throughput>=1708)
           test_cases=(
-            "test/registered/ascend/llm_models/test_npu_deepseek_v3_2_w8a8.py"
+            "test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py"
+            "test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -164,6 +164,9 @@ MINIMAX_M2_5_EAGLE3_MODEL_PATH = (
 QWEN3_5_397B_W8A8_MODEL_PATH = (
     "/root/.cache/modelscope/hub/models/Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
 )
+DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH = (
+    "/root/.cache/modelscope/hub/models/Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp"
+)
 QWEN3_5_397B_W4A8_MODEL_PATH = (
     "/root/.cache/modelscope/hub/models/Eco-Tech/Qwen3.5-397B-A17B-w4a8-mtp"
 )

--- a/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
+++ b/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
@@ -82,7 +82,7 @@ DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "--deepep-mode",
     "auto",
     "--quantization",
-    "compressed-tensors",
+    "modelslim",
     "--enable-dp-lm-head",
     "--kv-cache-dtype",
     "auto",

--- a/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
+++ b/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
@@ -65,7 +65,7 @@ DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "--watchdog-timeout",
     9000,
     "--mem-fraction-static",
-    0.85,
+    0.7,
     "--prefill-max-requests",
     2,
     "--disable-radix-cache",

--- a/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
+++ b/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
@@ -65,7 +65,7 @@ DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "--watchdog-timeout",
     9000,
     "--mem-fraction-static",
-    0.7,
+    0.75,
     "--prefill-max-requests",
     2,
     "--disable-radix-cache",

--- a/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
+++ b/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
@@ -17,21 +17,23 @@ register_npu_ci(
 )
 
 # Environment variables for DSV4-Flash single-node PD-mix deployment.
-# Derived from run_dsv4_flash_hisi.sh (deployment script) plus MTP related
-# envs referenced from PR #882.
+# Derived from run_dsv4_flash.sh (latest deployment script from dev).
 DEEPSEEK_V4_FLASH_W8A8_16P_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "INF_NAN_MODE_FORCE_DISABLE": "1",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
     # deepep
     "HCCL_BUFFSIZE": "1000",
     "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
-    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "64",
-    # dsv4
-    "IS_DEEPSEEK_V4": "1",
-    "USE_FUSED_HC_PRE_ASCENDC": "1",
-    "SGLANG_DSV4_NPU_FUSED_COMPRESSOR": "1",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "16",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "2048",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
     # skip gpu branch
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
     "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
     "FORCE_DRAFT_MODEL_NON_QUANT": "1",
     "SGLANG_DSV4_FP4_EXPERTS": "False",
@@ -44,36 +46,33 @@ DEEPSEEK_V4_FLASH_W8A8_16P_ENVS = {
     # MTP (EAGLE) related envs
     "SGLANG_ENABLE_SPEC_V2": "1",
     "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
-    # network
-    "HCCL_SOCKET_IFNAME": "lo",
-    "GLOO_SOCKET_IFNAME": "lo",
-    "HCCL_OP_EXPANSION_MODE": "AIV",
-    "SGLANG_SET_CPU_AFFINITY": "1",
 }
 
 # Server launch arguments for DSV4-Flash W8A8 single-node 16-card PD-mix.
-# Derived from run_dsv4_flash_hisi.sh and the test case design (Excel) which
-# requires max-running-requests=160 and MTP (EAGLE) enabled.
+# Derived from run_dsv4_flash.sh (latest deployment script from dev) and the
+# test case design (Excel) which requires max-running-requests=160 and MTP
+# (EAGLE) enabled.
 DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "--page-size",
     128,
     "--tp-size",
     16,
     "--trust-remote-code",
-    "--attention-backend",
-    "ascend",
     "--device",
     "npu",
+    "--attention-backend",
+    "dsv4",
     "--watchdog-timeout",
     9000,
     "--mem-fraction-static",
-    0.65,
+    0.85,
+    "--prefill-max-requests",
+    2,
     "--disable-radix-cache",
     "--chunked-prefill-size",
     -1,
     "--max-running-requests",
     160,
-    "--disable-overlap-schedule",
     "--dp-size",
     16,
     "--enable-dp-attention",
@@ -85,13 +84,13 @@ DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "modelslim",
     "--enable-dp-lm-head",
     "--kv-cache-dtype",
-    "auto",
-    "--skip-server-warmup",
+    "bfloat16",
     "--cuda-graph-bs",
     1,
     2,
-    3,
     4,
+    8,
+    10,
     # MTP (EAGLE) configuration, required by the test case design (Excel S2).
     "--speculative-algorithm",
     "EAGLE",

--- a/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
+++ b/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
@@ -65,7 +65,7 @@ DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "--watchdog-timeout",
     9000,
     "--mem-fraction-static",
-    0.75,
+    0.7,
     "--prefill-max-requests",
     2,
     "--disable-radix-cache",

--- a/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
+++ b/test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py
@@ -1,0 +1,169 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_accuracy_utils import (
+    BENCHMARK_TOOL_DEFAULT,
+    TestAscendAccuracyTestCaseBase,
+)
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=3600,
+    suite="",
+    nightly=True,
+    disabled="accuracy testcase",
+)
+
+# Environment variables for DSV4-Flash single-node PD-mix deployment.
+# Derived from run_dsv4_flash_hisi.sh (deployment script) plus MTP related
+# envs referenced from PR #882.
+DEEPSEEK_V4_FLASH_W8A8_16P_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "INF_NAN_MODE_FORCE_DISABLE": "1",
+    # deepep
+    "HCCL_BUFFSIZE": "1000",
+    "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "64",
+    # dsv4
+    "IS_DEEPSEEK_V4": "1",
+    "USE_FUSED_HC_PRE_ASCENDC": "1",
+    "SGLANG_DSV4_NPU_FUSED_COMPRESSOR": "1",
+    # skip gpu branch
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "FORCE_DRAFT_MODEL_NON_QUANT": "1",
+    "SGLANG_DSV4_FP4_EXPERTS": "False",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    # MTP (EAGLE) related envs
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # network
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+}
+
+# Server launch arguments for DSV4-Flash W8A8 single-node 16-card PD-mix.
+# Derived from run_dsv4_flash_hisi.sh and the test case design (Excel) which
+# requires max-running-requests=160 and MTP (EAGLE) enabled.
+DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--attention-backend",
+    "ascend",
+    "--device",
+    "npu",
+    "--watchdog-timeout",
+    9000,
+    "--mem-fraction-static",
+    0.65,
+    "--disable-radix-cache",
+    "--chunked-prefill-size",
+    -1,
+    "--max-running-requests",
+    160,
+    "--disable-overlap-schedule",
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--quantization",
+    "compressed-tensors",
+    "--enable-dp-lm-head",
+    "--kv-cache-dtype",
+    "auto",
+    "--skip-server-warmup",
+    "--cuda-graph-bs",
+    1,
+    2,
+    3,
+    4,
+    # MTP (EAGLE) configuration, required by the test case design (Excel S2).
+    "--speculative-algorithm",
+    "EAGLE",
+    "--speculative-num-steps",
+    2,
+    "--speculative-eagle-topk",
+    1,
+    "--speculative-num-draft-tokens",
+    3,
+]
+
+# Generation config shared by AIME26 and GPQA-Diamond, required by the test
+# case design (Excel S4): max_tokens=125000, top_p=1, temperature=1, thinking=true.
+DEEPSEEK_V4_FLASH_W8A8_GENERATION_CONFIG = {
+    "max_tokens": 125000,
+    "top_p": 1,
+    "temperature": 1,
+    "n": 1,
+    "extra_body": {"chat_template_kwargs": {"thinking": True}},
+}
+
+
+class TestNPUDeepSeekV4FlashW8A816PAIME26(TestAscendAccuracyTestCaseBase):
+    """Test NPU accuracy for DeepSeek-V4-Flash W8A8 16p PD-mix on AIME26.
+
+    Single-node 16-card PD mixed deployment with TP=16, DP=16, EP=16 and MTP
+    (EAGLE) enabled. Baseline accuracy 0.933 (gap < 1% compared with paper).
+    """
+
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    model = DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH
+    other_args = DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS
+    envs = DEEPSEEK_V4_FLASH_W8A8_16P_ENVS
+    accuracy = 0.933
+    datasets = ["aime26"]
+    few_shot_num = 0
+    generation_config = DEEPSEEK_V4_FLASH_W8A8_GENERATION_CONFIG
+    eval_batch_size = 30
+    limit = 30
+    stream = True
+    timeout = 6000
+    seed = 1
+
+    def test_npu_deepseek_v4_flash_w8a8_16p_aime26(self):
+        """Run NPU accuracy test for DeepSeek-V4-Flash W8A8 16p on AIME26."""
+        self.run_accuracy()
+
+
+class TestNPUDeepSeekV4FlashW8A816PGPQA(TestAscendAccuracyTestCaseBase):
+    """Test NPU accuracy for DeepSeek-V4-Flash W8A8 16p PD-mix on GPQA-Diamond.
+
+    Single-node 16-card PD mixed deployment with TP=16, DP=16, EP=16 and MTP
+    (EAGLE) enabled. Baseline accuracy 0.712 (gap < 1% compared with paper).
+    """
+
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    model = DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH
+    other_args = DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS
+    envs = DEEPSEEK_V4_FLASH_W8A8_16P_ENVS
+    accuracy = 0.712
+    datasets = ["gpqa_diamond"]
+    few_shot_num = 0
+    generation_config = DEEPSEEK_V4_FLASH_W8A8_GENERATION_CONFIG
+    eval_batch_size = 128
+    stream = True
+    timeout = 6000
+    seed = 1
+
+    def test_npu_deepseek_v4_flash_w8a8_16p_gpqa(self):
+        """Run NPU accuracy test for DeepSeek-V4-Flash W8A8 16p on GPQA-Diamond."""
+        self.run_accuracy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
+++ b/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
@@ -81,7 +81,7 @@ DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "--deepep-mode",
     "auto",
     "--quantization",
-    "compressed-tensors",
+    "modelslim",
     "--enable-dp-lm-head",
     "--kv-cache-dtype",
     "auto",

--- a/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
+++ b/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
@@ -64,7 +64,7 @@ DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "--watchdog-timeout",
     9000,
     "--mem-fraction-static",
-    0.85,
+    0.7,
     "--prefill-max-requests",
     2,
     "--disable-radix-cache",

--- a/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
+++ b/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
@@ -64,7 +64,7 @@ DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "--watchdog-timeout",
     9000,
     "--mem-fraction-static",
-    0.75,
+    0.7,
     "--prefill-max-requests",
     2,
     "--disable-radix-cache",

--- a/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
+++ b/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
@@ -64,7 +64,7 @@ DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "--watchdog-timeout",
     9000,
     "--mem-fraction-static",
-    0.7,
+    0.75,
     "--prefill-max-requests",
     2,
     "--disable-radix-cache",

--- a/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
+++ b/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
@@ -1,0 +1,139 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    AISBENCHMARK_DATASET_DEFAULT,
+    BENCHMARK_TOOL_DEFAULT,
+    DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH,
+    TestAscendPerformanceTestCaseBase,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=3600,
+    suite="",
+    nightly=True,
+    disabled="performance testcase",
+)
+
+# Environment variables for DSV4-Flash single-node PD-mix deployment.
+# Derived from run_dsv4_flash_hisi.sh (deployment script) plus MTP related
+# envs referenced from PR #882.
+DEEPSEEK_V4_FLASH_W8A8_16P_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "INF_NAN_MODE_FORCE_DISABLE": "1",
+    # deepep
+    "HCCL_BUFFSIZE": "1000",
+    "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "64",
+    # dsv4
+    "IS_DEEPSEEK_V4": "1",
+    "USE_FUSED_HC_PRE_ASCENDC": "1",
+    "SGLANG_DSV4_NPU_FUSED_COMPRESSOR": "1",
+    # skip gpu branch
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "FORCE_DRAFT_MODEL_NON_QUANT": "1",
+    "SGLANG_DSV4_FP4_EXPERTS": "False",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    # MTP (EAGLE) related envs
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # network
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+}
+
+# Server launch arguments for DSV4-Flash W8A8 single-node 16-card PD-mix.
+# Derived from run_dsv4_flash_hisi.sh and the test case design (Excel) which
+# requires max-running-requests=160 and MTP (EAGLE) enabled.
+DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--attention-backend",
+    "ascend",
+    "--device",
+    "npu",
+    "--watchdog-timeout",
+    9000,
+    "--mem-fraction-static",
+    0.65,
+    "--disable-radix-cache",
+    "--chunked-prefill-size",
+    -1,
+    "--max-running-requests",
+    160,
+    "--disable-overlap-schedule",
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--quantization",
+    "compressed-tensors",
+    "--enable-dp-lm-head",
+    "--kv-cache-dtype",
+    "auto",
+    "--skip-server-warmup",
+    "--cuda-graph-bs",
+    1,
+    2,
+    3,
+    4,
+    # MTP (EAGLE) configuration, required by the test case design (Excel S2).
+    "--speculative-algorithm",
+    "EAGLE",
+    "--speculative-num-steps",
+    2,
+    "--speculative-eagle-topk",
+    1,
+    "--speculative-num-draft-tokens",
+    3,
+]
+
+
+class TestNPUDeepSeekV4FlashW8A816PIn8kOut1k50ms(TestAscendPerformanceTestCaseBase):
+    """Test NPU performance for DeepSeek-V4-Flash W8A8 16p PD-mix in8k out1k.
+
+    Single-node 16-card PD mixed deployment with TP=16, DP=16, EP=16 and MTP
+    (EAGLE) enabled. Random short-sequence benchmark from benchmark.sh:
+    input_len=8000, output_len=1000, num_prompts=160, max_concurrency=160.
+    Expected: TPOT <= 50ms and output token throughput >= 1708 tokens/s
+    (1.6x H20 baseline) on A3-560T.
+    """
+
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    dataset_type = AISBENCHMARK_DATASET_DEFAULT
+    model = DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH
+    other_args = DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS
+    envs = DEEPSEEK_V4_FLASH_W8A8_16P_ENVS
+    dataset_name = "random"
+    input_len = 8000
+    output_len = 1000
+    num_prompts = 160
+    max_concurrency = 160
+    random_range_ratio = 1
+    warmup_requests = 0
+    request_rate = float("inf")
+    seed = 1
+    tpot = 50
+    output_token_throughput = 1708
+
+    def test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms(self):
+        """Run NPU performance test for DeepSeek-V4-Flash W8A8 16p in8k out1k."""
+        self.run_throughput()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
+++ b/test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py
@@ -16,21 +16,23 @@ register_npu_ci(
 )
 
 # Environment variables for DSV4-Flash single-node PD-mix deployment.
-# Derived from run_dsv4_flash_hisi.sh (deployment script) plus MTP related
-# envs referenced from PR #882.
+# Derived from run_dsv4_flash.sh (latest deployment script from dev).
 DEEPSEEK_V4_FLASH_W8A8_16P_ENVS = {
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
     "STREAMS_PER_DEVICE": "32",
     "INF_NAN_MODE_FORCE_DISABLE": "1",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
     # deepep
     "HCCL_BUFFSIZE": "1000",
     "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
-    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "64",
-    # dsv4
-    "IS_DEEPSEEK_V4": "1",
-    "USE_FUSED_HC_PRE_ASCENDC": "1",
-    "SGLANG_DSV4_NPU_FUSED_COMPRESSOR": "1",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "16",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "2048",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
     # skip gpu branch
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
     "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
     "FORCE_DRAFT_MODEL_NON_QUANT": "1",
     "SGLANG_DSV4_FP4_EXPERTS": "False",
@@ -43,36 +45,33 @@ DEEPSEEK_V4_FLASH_W8A8_16P_ENVS = {
     # MTP (EAGLE) related envs
     "SGLANG_ENABLE_SPEC_V2": "1",
     "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
-    # network
-    "HCCL_SOCKET_IFNAME": "lo",
-    "GLOO_SOCKET_IFNAME": "lo",
-    "HCCL_OP_EXPANSION_MODE": "AIV",
-    "SGLANG_SET_CPU_AFFINITY": "1",
 }
 
 # Server launch arguments for DSV4-Flash W8A8 single-node 16-card PD-mix.
-# Derived from run_dsv4_flash_hisi.sh and the test case design (Excel) which
-# requires max-running-requests=160 and MTP (EAGLE) enabled.
+# Derived from run_dsv4_flash.sh (latest deployment script from dev) and the
+# test case design (Excel) which requires max-running-requests=160 and MTP
+# (EAGLE) enabled.
 DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "--page-size",
     128,
     "--tp-size",
     16,
     "--trust-remote-code",
-    "--attention-backend",
-    "ascend",
     "--device",
     "npu",
+    "--attention-backend",
+    "dsv4",
     "--watchdog-timeout",
     9000,
     "--mem-fraction-static",
-    0.65,
+    0.85,
+    "--prefill-max-requests",
+    2,
     "--disable-radix-cache",
     "--chunked-prefill-size",
     -1,
     "--max-running-requests",
     160,
-    "--disable-overlap-schedule",
     "--dp-size",
     16,
     "--enable-dp-attention",
@@ -84,13 +83,13 @@ DEEPSEEK_V4_FLASH_W8A8_16P_OTHER_ARGS = [
     "modelslim",
     "--enable-dp-lm-head",
     "--kv-cache-dtype",
-    "auto",
-    "--skip-server-warmup",
+    "bfloat16",
     "--cuda-graph-bs",
     1,
     2,
-    3,
     4,
+    8,
+    10,
     # MTP (EAGLE) configuration, required by the test case design (Excel S2).
     "--speculative-algorithm",
     "EAGLE",


### PR DESCRIPTION
## Summary

Add two CI test cases for **DeepSeek-V4-Flash W8A8** on a **single-node 16-card PD-mixed deployment** (TP=16, DP=16, EP=16, `enable-dp-attention`, MTP/EAGLE enabled).

### Test Cases

#### 1. Accuracy Case
File: `test/registered/ascend/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_aime26_gpqa.py`

Two test classes:
- **AIME26**: baseline accuracy `0.933` (gap < 1% vs paper)
  - `eval_batch_size=30`, `limit=30`
- **GPQA-Diamond**: baseline accuracy `0.712` (gap < 1% vs paper)
  - `eval_batch_size=128`

Both use `generation_config = {max_tokens: 125000, top_p: 1, temperature: 1, n: 1, extra_body: {chat_template_kwargs: {thinking: true}}}` per the test case design.

#### 2. Performance Case
File: `test/registered/ascend/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_16p_in8k_out1k_50ms.py`

Random short-sequence benchmark (`benchmark.sh`):
- `input_len=8000`, `output_len=1000`
- `num_prompts=160`, `max_concurrency=160`
- `random_range_ratio=1`, `warmup_requests=0`
- Expected: **TPOT <= 50ms**, **output throughput >= 1708 tokens/s** (1.6x H20 baseline on A3-560T)

### Server Launch Configuration

Derived from the deployment script `run_dsv4_flash_hisi.sh`, with MTP (EAGLE) enabled per the test case design (Excel S2) and `max-running-requests=160`.

Key server args:
```
--page-size 128 --tp-size 16 --dp-size 16 --enable-dp-attention
--attention-backend ascend --device npu --trust-remote-code
--quantization compressed-tensors --enable-dp-lm-head
--moe-a2a-backend deepep --deepep-mode auto
--disable-radix-cache --chunked-prefill-size -1
--kv-cache-dtype auto --mem-fraction-static 0.65
--max-running-requests 160 --disable-overlap-schedule
--watchdog-timeout 9000 --skip-server-warmup
--cuda-graph-bs 1 2 3 4
--speculative-algorithm EAGLE --speculative-num-steps 2
--speculative-eagle-topk 1 --speculative-num-draft-tokens 3
```

Key environment variables:
```
IS_DEEPSEEK_V4=1
USE_FUSED_HC_PRE_ASCENDC=1
SGLANG_DSV4_NPU_FUSED_COMPRESSOR=1
PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
STREAMS_PER_DEVICE=32
INF_NAN_MODE_FORCE_DISABLE=1
HCCL_BUFFSIZE=1000
DEEP_NORMAL_MODE_USE_INT8_QUANT=1
SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
SGLANG_ENABLE_SPEC_V2=1
SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1
HCCL_OP_EXPANSION_MODE=AIV
HCCL_SOCKET_IFNAME=lo
GLOO_SOCKET_IFNAME=lo
SGLANG_SET_CPU_AFFINITY=1
```

### CI Pipeline

`.github/workflows/single-test-npu.yml` is updated to:
- Use the `linux-aarch64-a3-16` runner (16-card)
- Use the `swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090` image
- Execute the two new test cases with a 240-minute timeout
- Trigger on PR to `testcases` when the workflow file changes

### Other Changes

- Added `DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH` constant to `python/sglang/test/ascend/e2e/test_npu_performance_utils.py` (model path: `/root/.cache/modelscope/hub/models/Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp`)

### References

- PR #882: DSV4 MTP test case (model path constant, MTP envs)
- PR #872 / #885: `single-test-npu.yml` structure
- Deployment script: `run_dsv4_flash_hisi.sh`
- Test case design: `sglang支持DSV4测试用例.xlsx`
- Reference test cases: `test_npu_deepseek_v3_2_w8a8_1p1d_32p_in128k_out1k_26ms.py`, `test_npu_qwen3_5_397b_8p_gpqa.py`, `test_npu_qwen3_5_397b_8p_aime26.py`

### Notes

- If `compressed-tensors` quantization fails to load, switch to `modelslim` (per user instruction).
- If `attention-backend ascend` is not supported for DSV4, switch to `dsv4` (per PR #882).



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->