### PR TITLE
Test DeepEP dispatcher output dtype

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: DeepEP dispatcher output dtype test
+# test round 2: DeepEP dispatcher output dtype test
 
 on:
   pull_request:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 2: DeepEP dispatcher output dtype test
+# test round 3: DeepEP dispatcher output dtype test - extended timeout
 
 on:
   pull_request:
@@ -27,7 +27,7 @@ jobs:
           npu-smi info
 
       - name: Run test
-        timeout-minutes: 120
+        timeout-minutes: 300
         env:
           SGLANG_USE_MODELSCOPE: true
           HF_ENDPOINT: https://hf-mirror.com

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 3: DeepEP dispatcher output dtype test - extended timeout
+# test round 4: DeepEP dispatcher output dtype test - extended timeout to 600min
 
 on:
   pull_request:
@@ -27,7 +27,7 @@ jobs:
           npu-smi info
 
       - name: Run test
-        timeout-minutes: 300
+        timeout-minutes: 600
         env:
           SGLANG_USE_MODELSCOPE: true
           HF_ENDPOINT: https://hf-mirror.com

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-4
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090-20260703
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: <测试用例描述>
+# test round 1: DeepEP dispatcher output dtype test
 
 on:
   pull_request:
@@ -15,9 +15,9 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-4
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-B090-20260703
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,9 +38,8 @@ jobs:
           echo "Source code path: ${sglang_source_path}"
           ln -sf ${sglang_source_path} /root/sglang
 
-          # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            "test/registered/ascend/llm_models/test_npu_deepseek_v3_2_w8a8.py"
+            "test/registered/ascend/basic_function/parameter/test_npu_deepep_dispatcher_output_dtype.py"
           )
 
           for test_case in "${test_cases[@]}"; do
@@ -50,7 +49,6 @@ jobs:
             fi
           done
 
-          # copy required file from our daily cache
           cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
           cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
 
@@ -71,7 +69,6 @@ jobs:
           mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
           cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
 
-          # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true
           source /usr/local/Ascend/nnal/atb/set_env.sh || true
 

--- a/test/registered/ascend/basic_function/parameter/test_npu_deepep_dispatcher_output_dtype.py
+++ b/test/registered/ascend/basic_function/parameter/test_npu_deepep_dispatcher_output_dtype.py
@@ -34,7 +34,7 @@ class TestDtypeAuto(CustomTestCase):
                 "--mem-fraction-static",
                 "0.8",
                 "--moe-a2a-backend",
-                "deepep"
+                "deepep",
                 "--deepep-dispatcher-output-dtype",
                 cls.dtype,
                 "--attention-backend",

--- a/test/registered/ascend/basic_function/parameter/test_npu_deepep_dispatcher_output_dtype.py
+++ b/test/registered/ascend/basic_function/parameter/test_npu_deepep_dispatcher_output_dtype.py
@@ -1,0 +1,71 @@
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+# from sglang.test.ascend.test_ascend_utils import
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+model = "/root/.cache/modelscope/hub/models/Eco-Tech/Qwen3.5-35B-A3B-w8a8-mtp"
+register_npu_ci(est_time=200, suite="full-4-npu-a3", nightly=True)
+
+
+class TestDtypeAuto(CustomTestCase):
+    dtype="auto"
+    @classmethod
+    def setUpClass(cls):
+        cls.model = model
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--mem-fraction-static",
+                "0.8",
+                "--deepep-dispatcher-output-dtype",
+                cls.dtype,
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(f"Eval accuracy of GSM8K: {metrics=}")
+
+        self.assertGreater(metrics["score"], 0.83)
+
+class TestDtypeBf16(TestDtypeAuto):
+    dtype = "bf16"
+
+class TestDtypeInt8(TestDtypeAuto):
+    dtype = "int8"
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/parameter/test_npu_deepep_dispatcher_output_dtype.py
+++ b/test/registered/ascend/basic_function/parameter/test_npu_deepep_dispatcher_output_dtype.py
@@ -33,6 +33,8 @@ class TestDtypeAuto(CustomTestCase):
                 "4",
                 "--mem-fraction-static",
                 "0.8",
+                "--moe-a2a-backend",
+                "deepep"
                 "--deepep-dispatcher-output-dtype",
                 cls.dtype,
                 "--attention-backend",

--- a/test/registered/ascend/basic_function/parameter/test_npu_deepep_dispatcher_output_dtype.py
+++ b/test/registered/ascend/basic_function/parameter/test_npu_deepep_dispatcher_output_dtype.py
@@ -1,8 +1,6 @@
 import unittest
 from types import SimpleNamespace
 
-import requests
-
 # from sglang.test.ascend.test_ascend_utils import
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_npu_ci
@@ -19,7 +17,8 @@ register_npu_ci(est_time=200, suite="full-4-npu-a3", nightly=True)
 
 
 class TestDtypeAuto(CustomTestCase):
-    dtype="auto"
+    dtype = "auto"
+
     @classmethod
     def setUpClass(cls):
         cls.model = model
@@ -61,11 +60,14 @@ class TestDtypeAuto(CustomTestCase):
 
         self.assertGreater(metrics["score"], 0.83)
 
+
 class TestDtypeBf16(TestDtypeAuto):
     dtype = "bf16"
 
+
 class TestDtypeInt8(TestDtypeAuto):
     dtype = "int8"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add test case for DeepEP dispatcher output dtype with auto/bf16/int8 modes

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->