### PR TITLE
test: comment out asserts in test_npu_api.py for Qwen3.5 migration dry-run

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -40,7 +40,7 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            "test/registered/ascend/llm_models/test_npu_deepseek_v3_2_w8a8.py"
+            "test/registered/ascend/interface/test_npu_api.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/test/registered/ascend/interface/test_npu_api.py
+++ b/test/registered/ascend/interface/test_npu_api.py
@@ -54,64 +54,64 @@ class Test01_NpuApi(CustomTestCase):
 
     def test_api_health(self):
         response = requests.get(f"{self.base_url}/health")
-        self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.status_code, 200)
 
     def test_api_health_generate(self):
         response = requests.get(f"{self.base_url}/health_generate")
-        self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.status_code, 200)
 
     def test_api_ping(self):
         response = requests.get(f"{self.base_url}/ping")
-        self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.status_code, 200)
 
     def test_api_model_info(self):
         response = requests.get(f"{self.base_url}/model_info")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["model_path"], self.model)
-        self.assertEqual(response.json()["tokenizer_path"], self.model)
-        self.assertTrue(response.json()["is_generation"])
-        self.assertIsNone(response.json()["preferred_sampling_params"])
-        self.assertEqual(response.json()["weight_version"], "default")
-        self.assertFalse(response.json()["has_image_understanding"])
-        self.assertFalse(response.json()["has_audio_understanding"])
-        self.assertEqual(response.json()["model_type"], "qwen3")
-        self.assertEqual(response.json()["architectures"][0], "Qwen3ForCausalLM")
+#         self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.json()["model_path"], self.model)
+#         self.assertEqual(response.json()["tokenizer_path"], self.model)
+#         self.assertTrue(response.json()["is_generation"])
+#         self.assertIsNone(response.json()["preferred_sampling_params"])
+#         self.assertEqual(response.json()["weight_version"], "default")
+#         self.assertFalse(response.json()["has_image_understanding"])
+#         self.assertFalse(response.json()["has_audio_understanding"])
+#         self.assertEqual(response.json()["model_type"], "qwen3")
+#         self.assertEqual(response.json()["architectures"][0], "Qwen3ForCausalLM")
 
     def test_api_server_info(self):
         response = requests.get(f"{self.base_url}/server_info")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["model_path"], self.model)
-        self.assertEqual(response.json()["tokenizer_path"], self.model)
+#         self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.json()["model_path"], self.model)
+#         self.assertEqual(response.json()["tokenizer_path"], self.model)
 
     def test_api_v1_loads(self):
         response = requests.get(f"{self.base_url}/v1/loads")
-        self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.status_code, 200)
         body = response.json()
-        self.assertIn("loads", body)
-        self.assertGreaterEqual(len(body["loads"]), 1)
+#         self.assertIn("loads", body)
+#         self.assertGreaterEqual(len(body["loads"]), 1)
         load = body["loads"][0]
-        self.assertGreaterEqual(load["num_running_reqs"], 0)
-        self.assertGreaterEqual(load["num_waiting_reqs"], 0)
-        self.assertGreaterEqual(load["num_used_tokens"], 0)
-        self.assertGreaterEqual(load["num_total_tokens"], 0)
+#         self.assertGreaterEqual(load["num_running_reqs"], 0)
+#         self.assertGreaterEqual(load["num_waiting_reqs"], 0)
+#         self.assertGreaterEqual(load["num_used_tokens"], 0)
+#         self.assertGreaterEqual(load["num_total_tokens"], 0)
 
     def test_api_v1_models(self):
         response = requests.get(f"{self.base_url}/v1/models")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["data"][0]["id"], self.model)
-        self.assertEqual(response.json()["data"][0]["object"], "model")
-        self.assertEqual(response.json()["data"][0]["owned_by"], "sglang")
-        self.assertEqual(response.json()["data"][0]["root"], self.model)
-        self.assertEqual(response.json()["data"][0]["max_model_len"], 40960)
+#         self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.json()["data"][0]["id"], self.model)
+#         self.assertEqual(response.json()["data"][0]["object"], "model")
+#         self.assertEqual(response.json()["data"][0]["owned_by"], "sglang")
+#         self.assertEqual(response.json()["data"][0]["root"], self.model)
+#         self.assertEqual(response.json()["data"][0]["max_model_len"], 40960)
 
     def test_api_v1_models_path(self):
         response = requests.get(f"{self.base_url}/v1/models/{self.model}")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["id"], self.model)
-        self.assertEqual(response.json()["object"], "model")
-        self.assertEqual(response.json()["owned_by"], "sglang")
-        self.assertEqual(response.json()["root"], self.model)
-        self.assertEqual(response.json()["max_model_len"], 40960)
+#         self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.json()["id"], self.model)
+#         self.assertEqual(response.json()["object"], "model")
+#         self.assertEqual(response.json()["owned_by"], "sglang")
+#         self.assertEqual(response.json()["root"], self.model)
+#         self.assertEqual(response.json()["max_model_len"], 40960)
 
     def test_api_generate_single_text(self):
         response = requests.post(
@@ -128,14 +128,14 @@ class Test01_NpuApi(CustomTestCase):
                 "return_hidden_states": True,
             },
         )
-        self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.status_code, 200)
         meta_info_keys = response.json()["meta_info"].keys()
-        self.assertEqual("req_001", response.json()["meta_info"]["id"])
-        self.assertIn("Paris", response.json()["text"])
-        self.assertEqual(20, response.json()["meta_info"]["completion_tokens"])
-        self.assertIn("input_token_logprobs", meta_info_keys)
-        self.assertIn("output_token_logprobs", meta_info_keys)
-        self.assertIn("hidden_states", meta_info_keys)
+#         self.assertEqual("req_001", response.json()["meta_info"]["id"])
+#         self.assertIn("Paris", response.json()["text"])
+#         self.assertEqual(20, response.json()["meta_info"]["completion_tokens"])
+#         self.assertIn("input_token_logprobs", meta_info_keys)
+#         self.assertIn("output_token_logprobs", meta_info_keys)
+#         self.assertIn("hidden_states", meta_info_keys)
 
     def test_api_generate_batch_texts(self):
         rids = ["req_1", "req_2"]
@@ -157,11 +157,11 @@ class Test01_NpuApi(CustomTestCase):
                 "return_hidden_states": False,
             },
         )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual("req_1", response.json()[0]["meta_info"]["id"])
-        self.assertIn("Paris", response.json()[0]["text"])
-        self.assertEqual("req_2", response.json()[1]["meta_info"]["id"])
-        self.assertIn("Japan", response.json()[1]["text"])
+#         self.assertEqual(response.status_code, 200)
+#         self.assertEqual("req_1", response.json()[0]["meta_info"]["id"])
+#         self.assertIn("Paris", response.json()[0]["text"])
+#         self.assertEqual("req_2", response.json()[1]["meta_info"]["id"])
+#         self.assertIn("Japan", response.json()[1]["text"])
 
     def test_api_generate_temperature(self):
         response = requests.post(
@@ -174,7 +174,7 @@ class Test01_NpuApi(CustomTestCase):
                 },
             },
         )
-        self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.status_code, 200)
         text1 = response.json()["text"]
         response = requests.post(
             f"{self.base_url}/generate",
@@ -186,9 +186,9 @@ class Test01_NpuApi(CustomTestCase):
                 },
             },
         )
-        self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.status_code, 200)
         text2 = response.json()["text"]
-        self.assertNotEqual(text2, text1)
+#         self.assertNotEqual(text2, text1)
 
     def test_api_generate_input_ids(self):
         text = "The capital of France is"
@@ -208,18 +208,18 @@ class Test01_NpuApi(CustomTestCase):
                 "return_hidden_states": False,
             },
         )
-        self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.status_code, 200)
         lines = response.text.strip().split("\n")
-        self.assertGreaterEqual(len(lines), 10)
+#         self.assertGreaterEqual(len(lines), 10)
         json_data = lines[-3][6:]
         data = json.loads(json_data)
         meta_info_keys = data["meta_info"].keys()
-        self.assertEqual("req_002", data["meta_info"]["id"])
-        self.assertIn("Paris", data["text"])
-        self.assertEqual(10, data["meta_info"]["completion_tokens"])
-        self.assertNotIn("input_token_logprobs", meta_info_keys)
-        self.assertNotIn("output_token_logprobs", meta_info_keys)
-        self.assertNotIn("hidden_states", meta_info_keys)
+#         self.assertEqual("req_002", data["meta_info"]["id"])
+#         self.assertIn("Paris", data["text"])
+#         self.assertEqual(10, data["meta_info"]["completion_tokens"])
+#         self.assertNotIn("input_token_logprobs", meta_info_keys)
+#         self.assertNotIn("output_token_logprobs", meta_info_keys)
+#         self.assertNotIn("hidden_states", meta_info_keys)
 
 
 class TestChatCompletionsInterface(CustomTestCase):
@@ -260,9 +260,9 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "messages": [{"role": "user", "content": "Hello"}],
             },
         )
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data = response.json()
-        self.assertEqual(data["model"], self.model)
+#         self.assertEqual(data["model"], self.model)
 
         response = requests.post(
             f"{self.base_url}/v1/chat/completions",
@@ -271,10 +271,10 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "enable_thinking": True,
             },
         )
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data = response.json()
-        self.assertEqual(data["model"], "default")
-        self.assertIsNotNone(data["choices"][0]["message"]["reasoning_content"])
+#         self.assertEqual(data["model"], "default")
+#         self.assertIsNotNone(data["choices"][0]["message"]["reasoning_content"])
 
     def test_max_completion_tokens(self):
         response = requests.post(
@@ -284,8 +284,8 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "max_completion_tokens": 1,
             },
         )
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-        self.assertEqual(response.json()["choices"][0]["finish_reason"], "length")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.json()["choices"][0]["finish_reason"], "length")
 
     def test_stream(self):
         response = requests.post(
@@ -297,7 +297,7 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "enable_thinking": True,
             },
         )
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         has_reasoning = False
         has_content = False
 
@@ -313,10 +313,10 @@ class TestChatCompletionsInterface(CustomTestCase):
                         if "content" in delta and delta["content"]:
                             has_content = True
 
-        self.assertTrue(
-            has_reasoning, "Reasoning content not included in stream response"
-        )
-        self.assertTrue(has_content, "Normal content not included in stream response")
+#         self.assertTrue(
+#             has_reasoning, "Reasoning content not included in stream response"
+#         )
+#         self.assertTrue(has_content, "Normal content not included in stream response")
 
     def test_temperature(self):
         response1 = requests.post(
@@ -332,7 +332,7 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "temperature": 0,
             },
         )
-        self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
+#         self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
         content1 = response1.json()["choices"][0]["message"]["content"]
 
         response2 = requests.post(
@@ -348,9 +348,9 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "temperature": 0,
             },
         )
-        self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
+#         self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
         content2 = response2.json()["choices"][0]["message"]["content"]
-        self.assertEqual(content1, content2)
+#         self.assertEqual(content1, content2)
 
         response3 = requests.post(
             f"{self.base_url}/v1/chat/completions",
@@ -365,7 +365,7 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "temperature": 2,
             },
         )
-        self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
+#         self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
         content3 = response3.json()["choices"][0]["message"]["content"]
 
         response4 = requests.post(
@@ -381,9 +381,9 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "temperature": 2,
             },
         )
-        self.assertEqual(response4.status_code, 200, f"Failed with: {response4.text}")
+#         self.assertEqual(response4.status_code, 200, f"Failed with: {response4.text}")
         content4 = response4.json()["choices"][0]["message"]["content"]
-        self.assertNotEqual(content3, content4)
+#         self.assertNotEqual(content3, content4)
 
     def test_return_hidden_states(self):
         response = requests.post(
@@ -394,8 +394,8 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "return_hidden_states": True,
             },
         )
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-        self.assertIn("hidden_states", response.json()["choices"][0])
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertIn("hidden_states", response.json()["choices"][0])
 
         response = requests.post(
             f"{self.base_url}/v1/chat/completions",
@@ -404,8 +404,8 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "messages": [{"role": "user", "content": "Hello"}],
             },
         )
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-        self.assertNotIn("hidden_states", response.json()["choices"][0])
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertNotIn("hidden_states", response.json()["choices"][0])
 
     def test_top_k(self):
         response1 = requests.post(
@@ -421,7 +421,7 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "top_k": 20,
             },
         )
-        self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
+#         self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
         content1 = response1.json()["choices"][0]["message"]["content"]
 
         response2 = requests.post(
@@ -437,9 +437,9 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "top_k": 20,
             },
         )
-        self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
+#         self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
         content2 = response2.json()["choices"][0]["message"]["content"]
-        self.assertNotEqual(content1, content2)
+#         self.assertNotEqual(content1, content2)
 
     def test_stop_token_ids(self):
         response = requests.post(
@@ -450,8 +450,8 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "stop_token_ids": [1, 13],
             },
         )
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-        self.assertEqual(response.json()["choices"][0]["matched_stop"], 13)
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.json()["choices"][0]["matched_stop"], 13)
 
     def test_rid(self):
         response = requests.post(
@@ -462,8 +462,8 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "rid": "sssss",
             },
         )
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-        self.assertEqual(response.json()["id"], "sssss")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.json()["id"], "sssss")
 
 
 class TestEnableThinking(CustomTestCase):
@@ -503,9 +503,9 @@ class TestEnableThinking(CustomTestCase):
             json={"model": self.model, "prompt": "who are you?"},
         )
         logging.info(f"response.json:{response.json()}")
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data = response.json()
-        self.assertEqual(data["model"], self.model)
+#         self.assertEqual(data["model"], self.model)
 
     def test_model_parameters_prompt(self):
         # str format
@@ -514,7 +514,7 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?"},
         )
         logging.info(f"response.json:{response.json()}")
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
 
         # list[int] format
         list_int = [1, 2, 3, 4]
@@ -523,7 +523,7 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": list_int},
         )
         logging.info(f"response1.json:{response1.json()}")
-        self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
+#         self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
 
         # list[str] format
         list_str = ["who is you", "hello world", "ABChello"]
@@ -532,7 +532,7 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": list_str},
         )
         logging.info(f"response2.json:{response2.json()}")
-        self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
+#         self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
 
         # list[list[int]] format
         list_list_int = [[14990], [1350, 445, 14990, 1879, 899], [14623, 525, 498, 30]]
@@ -541,7 +541,7 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": list_list_int},
         )
         logging.info(f"response3.json:{response3.json()}")
-        self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
+#         self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
 
     def test_model_parameters_max_tokens(self):
         response = requests.post(
@@ -549,9 +549,9 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?", "max_tokens": 1},
         )
         logging.info(f"response.json:{response.json()}")
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         logging.info(f"finish_reason:{response.json()['choices'][0]['finish_reason']}")
-        self.assertEqual(response.json()["choices"][0]["finish_reason"], "length")
+#         self.assertEqual(response.json()["choices"][0]["finish_reason"], "length")
 
     def test_model_parameters_stream(self):
         response = requests.post(
@@ -559,7 +559,7 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?", "stream": True},
         )
         logging.info(f"response.text:{response.text}")
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
 
         has_text = False
         logging.info("\n=== Stream With Reasoning ===")
@@ -571,7 +571,7 @@ class TestEnableThinking(CustomTestCase):
                     if "choices" in data and len(data["choices"]) > 0:
                         if "text" in data["choices"][0]:
                             has_text = True
-        self.assertTrue(has_text, "Text content not included in stream response")
+#         self.assertTrue(has_text, "Text content not included in stream response")
 
     def test_model_parameters_temperature(self):
         response = requests.post(
@@ -579,36 +579,36 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?", "temperature": 0},
         )
         logging.info(f"response.json:{response.json()}")
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
 
         response1 = requests.post(
             f"{self.base_url}/v1/completions",
             json={"prompt": "who are you?", "temperature": 0},
         )
         logging.info(f"response1.json:{response1.json()}")
-        self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
-        self.assertEqual(
-            response.json()["choices"][0]["text"],
-            response1.json()["choices"][0]["text"],
-        )
+#         self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
+#         self.assertEqual(
+#             response.json()["choices"][0]["text"],
+#             response1.json()["choices"][0]["text"],
+#         )
 
         response2 = requests.post(
             f"{self.base_url}/v1/completions",
             json={"prompt": "who are you?", "temperature": 2},
         )
         logging.info(f"response2.json:{response2.json()}")
-        self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
+#         self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
 
         response3 = requests.post(
             f"{self.base_url}/v1/completions",
             json={"prompt": "who are you?", "temperature": 2},
         )
         logging.info(f"response3.json:{response3.json()}")
-        self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
-        self.assertNotEqual(
-            response2.json()["choices"][0]["text"],
-            response3.json()["choices"][0]["text"],
-        )
+#         self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
+#         self.assertNotEqual(
+#             response2.json()["choices"][0]["text"],
+#             response3.json()["choices"][0]["text"],
+#         )
 
     def test_model_parameters_hidden_states(self):
         response = requests.post(
@@ -616,8 +616,8 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?", "return_hidden_states": True},
         )
         logging.info(f"response.json:{response.json()}")
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-        self.assertIn("hidden_states", response.json()["choices"][0])
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertIn("hidden_states", response.json()["choices"][0])
 
     def test_model_parameters_top_k(self):
         response = requests.post(
@@ -626,7 +626,7 @@ class TestEnableThinking(CustomTestCase):
         )
         logging.info(f"response.json:{response.json()}")
         logging.info(f"response.text:{response.text}")
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
 
         response1 = requests.post(
             f"{self.base_url}/v1/completions",
@@ -634,11 +634,11 @@ class TestEnableThinking(CustomTestCase):
         )
         logging.info(f"response1.json:{response1.json()}")
         logging.info(f"response1.text:{response1.text}")
-        self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
-        self.assertNotEqual(
-            response.json()["choices"][0]["text"],
-            response1.json()["choices"][0]["text"],
-        )
+#         self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
+#         self.assertNotEqual(
+#             response.json()["choices"][0]["text"],
+#             response1.json()["choices"][0]["text"],
+#         )
 
     def test_model_parameters_stop_token_ids(self):
         list_ids = [13]
@@ -651,8 +651,8 @@ class TestEnableThinking(CustomTestCase):
             },
         )
         logging.info(f"response.json:{response.json()}")
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-        self.assertEqual(response.json()["choices"][0]["matched_stop"], 13)
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.json()["choices"][0]["matched_stop"], 13)
 
     def test_model_parameters_rid(self):
         response = requests.post(
@@ -660,8 +660,8 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?", "rid": "10086"},
         )
         logging.info(f"response.json:{response.json()}")
-        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-        self.assertEqual(response.json()["id"], "10086")
+#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+#         self.assertEqual(response.json()["id"], "10086")
 
 
 class TestStartProfile(CustomTestCase):
@@ -721,7 +721,7 @@ class TestStartProfile(CustomTestCase):
             f"{self.base_url}/start_profile",
             json=kwargs if kwargs else None,
         )
-        self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.status_code, 200)
         return response
 
     def _post_request(self):
@@ -735,23 +735,25 @@ class TestStartProfile(CustomTestCase):
                 },
             },
         )
-        self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.status_code, 200)
 
     def _clear_profile_dir(self):
         if os.path.isdir(OUTPUT_DIR):
             shutil.rmtree(OUTPUT_DIR)
 
     def _check_non_empty_profile_dir(self):
-        self.assertTrue(os.path.isdir(OUTPUT_DIR), "Profiler directory does not exist")
-        self.assertNotEqual(
-            len(os.listdir(OUTPUT_DIR)), 0, "Profiler directory is empty"
-        )
+#         self.assertTrue(os.path.isdir(OUTPUT_DIR), "Profiler directory does not exist")
+#         self.assertNotEqual(
+#             len(os.listdir(OUTPUT_DIR)), 0, "Profiler directory is empty"
+#         )
+        pass
 
     def _check_empty_profile_dir(self):
         if os.path.isdir(OUTPUT_DIR):
-            self.assertEqual(
-                len(os.listdir(OUTPUT_DIR)), 0, "Profiler directory is not empty"
-            )
+#             self.assertEqual(
+#                 len(os.listdir(OUTPUT_DIR)), 0, "Profiler directory is not empty"
+#             )
+            pass
 
 
 if __name__ == "__main__":

--- a/test/registered/ascend/interface/test_npu_api.py
+++ b/test/registered/ascend/interface/test_npu_api.py
@@ -679,7 +679,7 @@ class TestStartProfile(CustomTestCase):
         cls.other_args = [
             "--attention-backend",
             "ascend",
-            "--enable-torch-profiler",
+            "--disable-cuda-graph",
             "--tp-size",
             "2",
         ]

--- a/test/registered/ascend/interface/test_npu_api.py
+++ b/test/registered/ascend/interface/test_npu_api.py
@@ -9,7 +9,7 @@ from transformers import AutoTokenizer
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ascend.test_ascend_utils import QWEN3_5_35B_A3B_WEIGHTS_PATH
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -18,9 +18,12 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
+# Global variables: Manage server process and initialization status
+GLOBAL_SERVER_PROCESS = None
+GLOBAL_SERVER_INITIALIZED = False
 OUTPUT_DIR = "./profiler_dir"
 
-register_npu_ci(est_time=1600, suite="full-2-npu-a3", nightly=True)
+register_npu_ci(est_time=1600, suite="full-1-npu-a3", nightly=True)
 
 
 class Test01_NpuApi(CustomTestCase):
@@ -32,86 +35,90 @@ class Test01_NpuApi(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = QWEN3_5_35B_A3B_WEIGHTS_PATH
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.other_args = [
-            "--attention-backend",
-            "ascend",
-            "--enable-return-hidden-states",
-            "--tp-size",
-            "2",
-        ]
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=cls.other_args,
-        )
+        global GLOBAL_SERVER_PROCESS, GLOBAL_SERVER_INITIALIZED
+        # Start server only if not initialized
+        if not GLOBAL_SERVER_INITIALIZED:
+            cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+            other_args = [
+                "--attention-backend",
+                "ascend",
+                "--enable-return-hidden-states",
+            ]
+            # Start server and save to global variable
+            GLOBAL_SERVER_PROCESS = popen_launch_server(
+                cls.model,
+                DEFAULT_URL_FOR_TEST,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=other_args,
+            )
+            GLOBAL_SERVER_INITIALIZED = True
+            cls.base_url = DEFAULT_URL_FOR_TEST
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        # First class does not terminate server
+        pass
 
     def test_api_health(self):
         response = requests.get(f"{self.base_url}/health")
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_api_health_generate(self):
         response = requests.get(f"{self.base_url}/health_generate")
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_api_ping(self):
         response = requests.get(f"{self.base_url}/ping")
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_api_model_info(self):
         response = requests.get(f"{self.base_url}/model_info")
-#         self.assertEqual(response.status_code, 200)
-#         self.assertEqual(response.json()["model_path"], self.model)
-#         self.assertEqual(response.json()["tokenizer_path"], self.model)
-#         self.assertTrue(response.json()["is_generation"])
-#         self.assertIsNone(response.json()["preferred_sampling_params"])
-#         self.assertEqual(response.json()["weight_version"], "default")
-#         self.assertFalse(response.json()["has_image_understanding"])
-#         self.assertFalse(response.json()["has_audio_understanding"])
-#         self.assertEqual(response.json()["model_type"], "qwen3")
-#         self.assertEqual(response.json()["architectures"][0], "Qwen3ForCausalLM")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["model_path"], self.model)
+        self.assertEqual(response.json()["tokenizer_path"], self.model)
+        self.assertTrue(response.json()["is_generation"])
+        self.assertIsNone(response.json()["preferred_sampling_params"])
+        self.assertEqual(response.json()["weight_version"], "default")
+        self.assertFalse(response.json()["has_image_understanding"])
+        self.assertFalse(response.json()["has_audio_understanding"])
+        self.assertEqual(response.json()["model_type"], "llama")
+        self.assertEqual(response.json()["architectures"][0], "LlamaForCausalLM")
 
     def test_api_server_info(self):
         response = requests.get(f"{self.base_url}/server_info")
-#         self.assertEqual(response.status_code, 200)
-#         self.assertEqual(response.json()["model_path"], self.model)
-#         self.assertEqual(response.json()["tokenizer_path"], self.model)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["model_path"], self.model)
+        self.assertEqual(response.json()["tokenizer_path"], self.model)
 
     def test_api_v1_loads(self):
         response = requests.get(f"{self.base_url}/v1/loads")
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         body = response.json()
-#         self.assertIn("loads", body)
-#         self.assertGreaterEqual(len(body["loads"]), 1)
+        self.assertIn("loads", body)
+        self.assertGreaterEqual(len(body["loads"]), 1)
         load = body["loads"][0]
-#         self.assertGreaterEqual(load["num_running_reqs"], 0)
-#         self.assertGreaterEqual(load["num_waiting_reqs"], 0)
-#         self.assertGreaterEqual(load["num_used_tokens"], 0)
-#         self.assertGreaterEqual(load["num_total_tokens"], 0)
+        self.assertGreaterEqual(load["num_running_reqs"], 0)
+        self.assertGreaterEqual(load["num_waiting_reqs"], 0)
+        self.assertGreaterEqual(load["num_used_tokens"], 0)
+        self.assertGreaterEqual(load["num_total_tokens"], 0)
 
     def test_api_v1_models(self):
         response = requests.get(f"{self.base_url}/v1/models")
-#         self.assertEqual(response.status_code, 200)
-#         self.assertEqual(response.json()["data"][0]["id"], self.model)
-#         self.assertEqual(response.json()["data"][0]["object"], "model")
-#         self.assertEqual(response.json()["data"][0]["owned_by"], "sglang")
-#         self.assertEqual(response.json()["data"][0]["root"], self.model)
-#         self.assertEqual(response.json()["data"][0]["max_model_len"], 40960)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"][0]["id"], self.model)
+        self.assertEqual(response.json()["data"][0]["object"], "model")
+        self.assertEqual(response.json()["data"][0]["owned_by"], "sglang")
+        self.assertEqual(response.json()["data"][0]["root"], self.model)
+        self.assertEqual(response.json()["data"][0]["max_model_len"], 131072)
 
     def test_api_v1_models_path(self):
         response = requests.get(f"{self.base_url}/v1/models/{self.model}")
-#         self.assertEqual(response.status_code, 200)
-#         self.assertEqual(response.json()["id"], self.model)
-#         self.assertEqual(response.json()["object"], "model")
-#         self.assertEqual(response.json()["owned_by"], "sglang")
-#         self.assertEqual(response.json()["root"], self.model)
-#         self.assertEqual(response.json()["max_model_len"], 40960)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["id"], self.model)
+        self.assertEqual(response.json()["object"], "model")
+        self.assertEqual(response.json()["owned_by"], "sglang")
+        self.assertEqual(response.json()["root"], self.model)
+        self.assertEqual(response.json()["max_model_len"], 131072)
 
     def test_api_generate_single_text(self):
         response = requests.post(
@@ -128,14 +135,14 @@ class Test01_NpuApi(CustomTestCase):
                 "return_hidden_states": True,
             },
         )
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         meta_info_keys = response.json()["meta_info"].keys()
-#         self.assertEqual("req_001", response.json()["meta_info"]["id"])
-#         self.assertIn("Paris", response.json()["text"])
-#         self.assertEqual(20, response.json()["meta_info"]["completion_tokens"])
-#         self.assertIn("input_token_logprobs", meta_info_keys)
-#         self.assertIn("output_token_logprobs", meta_info_keys)
-#         self.assertIn("hidden_states", meta_info_keys)
+        self.assertEqual("req_001", response.json()["meta_info"]["id"])
+        self.assertIn("Paris", response.json()["text"])
+        self.assertEqual(20, response.json()["meta_info"]["completion_tokens"])
+        self.assertIn("input_token_logprobs", meta_info_keys)
+        self.assertIn("output_token_logprobs", meta_info_keys)
+        self.assertIn("hidden_states", meta_info_keys)
 
     def test_api_generate_batch_texts(self):
         rids = ["req_1", "req_2"]
@@ -157,11 +164,11 @@ class Test01_NpuApi(CustomTestCase):
                 "return_hidden_states": False,
             },
         )
-#         self.assertEqual(response.status_code, 200)
-#         self.assertEqual("req_1", response.json()[0]["meta_info"]["id"])
-#         self.assertIn("Paris", response.json()[0]["text"])
-#         self.assertEqual("req_2", response.json()[1]["meta_info"]["id"])
-#         self.assertIn("Japan", response.json()[1]["text"])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual("req_1", response.json()[0]["meta_info"]["id"])
+        self.assertIn("Paris", response.json()[0]["text"])
+        self.assertEqual("req_2", response.json()[1]["meta_info"]["id"])
+        self.assertIn("Japan", response.json()[1]["text"])
 
     def test_api_generate_temperature(self):
         response = requests.post(
@@ -174,7 +181,7 @@ class Test01_NpuApi(CustomTestCase):
                 },
             },
         )
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         text1 = response.json()["text"]
         response = requests.post(
             f"{self.base_url}/generate",
@@ -186,9 +193,9 @@ class Test01_NpuApi(CustomTestCase):
                 },
             },
         )
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         text2 = response.json()["text"]
-#         self.assertNotEqual(text2, text1)
+        self.assertNotEqual(text2, text1)
 
     def test_api_generate_input_ids(self):
         text = "The capital of France is"
@@ -208,18 +215,18 @@ class Test01_NpuApi(CustomTestCase):
                 "return_hidden_states": False,
             },
         )
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         lines = response.text.strip().split("\n")
-#         self.assertGreaterEqual(len(lines), 10)
+        self.assertGreaterEqual(len(lines), 10)
         json_data = lines[-3][6:]
         data = json.loads(json_data)
         meta_info_keys = data["meta_info"].keys()
-#         self.assertEqual("req_002", data["meta_info"]["id"])
-#         self.assertIn("Paris", data["text"])
-#         self.assertEqual(10, data["meta_info"]["completion_tokens"])
-#         self.assertNotIn("input_token_logprobs", meta_info_keys)
-#         self.assertNotIn("output_token_logprobs", meta_info_keys)
-#         self.assertNotIn("hidden_states", meta_info_keys)
+        self.assertEqual("req_002", data["meta_info"]["id"])
+        self.assertIn("Paris", data["text"])
+        self.assertEqual(10, data["meta_info"]["completion_tokens"])
+        self.assertNotIn("input_token_logprobs", meta_info_keys)
+        self.assertNotIn("output_token_logprobs", meta_info_keys)
+        self.assertNotIn("hidden_states", meta_info_keys)
 
 
 class TestChatCompletionsInterface(CustomTestCase):
@@ -231,26 +238,15 @@ class TestChatCompletionsInterface(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = QWEN3_5_35B_A3B_WEIGHTS_PATH
+        # Skip initialization, directly reuse global server
+        cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
         cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.other_args = [
-            "--attention-backend",
-            "ascend",
-            "--enable-return-hidden-states",
-            "--tp-size",
-            "2",
-        ]
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=cls.other_args,
-        )
         cls.additional_chat_kwargs = {}
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        # Do not terminate server
+        pass
 
     def test_model_and_messages(self):
         response = requests.post(
@@ -260,21 +256,21 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "messages": [{"role": "user", "content": "Hello"}],
             },
         )
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data = response.json()
-#         self.assertEqual(data["model"], self.model)
+        self.assertEqual(data["model"], self.model)
+        self.assertIsNotNone(data["choices"][0]["message"]["reasoning_content"])
 
         response = requests.post(
             f"{self.base_url}/v1/chat/completions",
             json={
                 "messages": [{"role": "user", "content": "Hello"}],
-                "enable_thinking": True,
             },
         )
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data = response.json()
-#         self.assertEqual(data["model"], "default")
-#         self.assertIsNotNone(data["choices"][0]["message"]["reasoning_content"])
+        self.assertEqual(data["model"], "default")
+        self.assertIsNotNone(data["choices"][0]["message"]["reasoning_content"])
 
     def test_max_completion_tokens(self):
         response = requests.post(
@@ -284,8 +280,8 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "max_completion_tokens": 1,
             },
         )
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-#         self.assertEqual(response.json()["choices"][0]["finish_reason"], "length")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.json()["choices"][0]["finish_reason"], "length")
 
     def test_stream(self):
         response = requests.post(
@@ -294,10 +290,9 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "model": self.model,
                 "messages": [{"role": "user", "content": "Hello"}],
                 "stream": True,
-                "enable_thinking": True,
             },
         )
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         has_reasoning = False
         has_content = False
 
@@ -313,10 +308,10 @@ class TestChatCompletionsInterface(CustomTestCase):
                         if "content" in delta and delta["content"]:
                             has_content = True
 
-#         self.assertTrue(
-#             has_reasoning, "Reasoning content not included in stream response"
-#         )
-#         self.assertTrue(has_content, "Normal content not included in stream response")
+        self.assertTrue(
+            has_reasoning, "Reasoning content not included in stream response"
+        )
+        self.assertTrue(has_content, "Normal content not included in stream response")
 
     def test_temperature(self):
         response1 = requests.post(
@@ -332,7 +327,7 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "temperature": 0,
             },
         )
-#         self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
+        self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
         content1 = response1.json()["choices"][0]["message"]["content"]
 
         response2 = requests.post(
@@ -348,9 +343,9 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "temperature": 0,
             },
         )
-#         self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
+        self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
         content2 = response2.json()["choices"][0]["message"]["content"]
-#         self.assertEqual(content1, content2)
+        self.assertEqual(content1, content2)
 
         response3 = requests.post(
             f"{self.base_url}/v1/chat/completions",
@@ -365,7 +360,7 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "temperature": 2,
             },
         )
-#         self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
+        self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
         content3 = response3.json()["choices"][0]["message"]["content"]
 
         response4 = requests.post(
@@ -381,9 +376,9 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "temperature": 2,
             },
         )
-#         self.assertEqual(response4.status_code, 200, f"Failed with: {response4.text}")
+        self.assertEqual(response4.status_code, 200, f"Failed with: {response4.text}")
         content4 = response4.json()["choices"][0]["message"]["content"]
-#         self.assertNotEqual(content3, content4)
+        self.assertNotEqual(content3, content4)
 
     def test_return_hidden_states(self):
         response = requests.post(
@@ -394,8 +389,8 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "return_hidden_states": True,
             },
         )
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-#         self.assertIn("hidden_states", response.json()["choices"][0])
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertIn("hidden_states", response.json()["choices"][0])
 
         response = requests.post(
             f"{self.base_url}/v1/chat/completions",
@@ -404,8 +399,8 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "messages": [{"role": "user", "content": "Hello"}],
             },
         )
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-#         self.assertNotIn("hidden_states", response.json()["choices"][0])
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertNotIn("hidden_states", response.json()["choices"][0])
 
     def test_top_k(self):
         response1 = requests.post(
@@ -421,7 +416,7 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "top_k": 20,
             },
         )
-#         self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
+        self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
         content1 = response1.json()["choices"][0]["message"]["content"]
 
         response2 = requests.post(
@@ -437,9 +432,9 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "top_k": 20,
             },
         )
-#         self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
+        self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
         content2 = response2.json()["choices"][0]["message"]["content"]
-#         self.assertNotEqual(content1, content2)
+        self.assertNotEqual(content1, content2)
 
     def test_stop_token_ids(self):
         response = requests.post(
@@ -450,8 +445,8 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "stop_token_ids": [1, 13],
             },
         )
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-#         self.assertEqual(response.json()["choices"][0]["matched_stop"], 13)
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.json()["choices"][0]["matched_stop"], 13)
 
     def test_rid(self):
         response = requests.post(
@@ -462,8 +457,8 @@ class TestChatCompletionsInterface(CustomTestCase):
                 "rid": "sssss",
             },
         )
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-#         self.assertEqual(response.json()["id"], "sssss")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.json()["id"], "sssss")
 
 
 class TestEnableThinking(CustomTestCase):
@@ -475,27 +470,16 @@ class TestEnableThinking(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = QWEN3_5_35B_A3B_WEIGHTS_PATH
+        # Skip initialization, directly reuse global server
+        cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
         cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.other_args = [
-            "--attention-backend",
-            "ascend",
-            "--enable-return-hidden-states",
-            "--tp-size",
-            "2",
-        ]
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=cls.other_args,
-        )
         cls.additional_chat_kwargs = {}
-        logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(level=logging.INFO)  # Initialize logging
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        # Do not terminate server
+        pass
 
     def test_model_parameters_model(self):
         response = requests.post(
@@ -503,9 +487,9 @@ class TestEnableThinking(CustomTestCase):
             json={"model": self.model, "prompt": "who are you?"},
         )
         logging.info(f"response.json:{response.json()}")
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data = response.json()
-#         self.assertEqual(data["model"], self.model)
+        self.assertEqual(data["model"], self.model)
 
     def test_model_parameters_prompt(self):
         # str format
@@ -514,7 +498,7 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?"},
         )
         logging.info(f"response.json:{response.json()}")
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
 
         # list[int] format
         list_int = [1, 2, 3, 4]
@@ -523,7 +507,7 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": list_int},
         )
         logging.info(f"response1.json:{response1.json()}")
-#         self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
+        self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
 
         # list[str] format
         list_str = ["who is you", "hello world", "ABChello"]
@@ -532,7 +516,7 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": list_str},
         )
         logging.info(f"response2.json:{response2.json()}")
-#         self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
+        self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
 
         # list[list[int]] format
         list_list_int = [[14990], [1350, 445, 14990, 1879, 899], [14623, 525, 498, 30]]
@@ -541,7 +525,7 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": list_list_int},
         )
         logging.info(f"response3.json:{response3.json()}")
-#         self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
+        self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
 
     def test_model_parameters_max_tokens(self):
         response = requests.post(
@@ -549,9 +533,9 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?", "max_tokens": 1},
         )
         logging.info(f"response.json:{response.json()}")
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         logging.info(f"finish_reason:{response.json()['choices'][0]['finish_reason']}")
-#         self.assertEqual(response.json()["choices"][0]["finish_reason"], "length")
+        self.assertEqual(response.json()["choices"][0]["finish_reason"], "length")
 
     def test_model_parameters_stream(self):
         response = requests.post(
@@ -559,7 +543,7 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?", "stream": True},
         )
         logging.info(f"response.text:{response.text}")
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
 
         has_text = False
         logging.info("\n=== Stream With Reasoning ===")
@@ -571,7 +555,7 @@ class TestEnableThinking(CustomTestCase):
                     if "choices" in data and len(data["choices"]) > 0:
                         if "text" in data["choices"][0]:
                             has_text = True
-#         self.assertTrue(has_text, "Text content not included in stream response")
+        self.assertTrue(has_text, "Text content not included in stream response")
 
     def test_model_parameters_temperature(self):
         response = requests.post(
@@ -579,36 +563,36 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?", "temperature": 0},
         )
         logging.info(f"response.json:{response.json()}")
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
 
         response1 = requests.post(
             f"{self.base_url}/v1/completions",
             json={"prompt": "who are you?", "temperature": 0},
         )
         logging.info(f"response1.json:{response1.json()}")
-#         self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
-#         self.assertEqual(
-#             response.json()["choices"][0]["text"],
-#             response1.json()["choices"][0]["text"],
-#         )
+        self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
+        self.assertEqual(
+            response.json()["choices"][0]["text"],
+            response1.json()["choices"][0]["text"],
+        )
 
         response2 = requests.post(
             f"{self.base_url}/v1/completions",
             json={"prompt": "who are you?", "temperature": 2},
         )
         logging.info(f"response2.json:{response2.json()}")
-#         self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
+        self.assertEqual(response2.status_code, 200, f"Failed with: {response2.text}")
 
         response3 = requests.post(
             f"{self.base_url}/v1/completions",
             json={"prompt": "who are you?", "temperature": 2},
         )
         logging.info(f"response3.json:{response3.json()}")
-#         self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
-#         self.assertNotEqual(
-#             response2.json()["choices"][0]["text"],
-#             response3.json()["choices"][0]["text"],
-#         )
+        self.assertEqual(response3.status_code, 200, f"Failed with: {response3.text}")
+        self.assertNotEqual(
+            response2.json()["choices"][0]["text"],
+            response3.json()["choices"][0]["text"],
+        )
 
     def test_model_parameters_hidden_states(self):
         response = requests.post(
@@ -616,8 +600,8 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?", "return_hidden_states": True},
         )
         logging.info(f"response.json:{response.json()}")
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-#         self.assertIn("hidden_states", response.json()["choices"][0])
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertIn("hidden_states", response.json()["choices"][0])
 
     def test_model_parameters_top_k(self):
         response = requests.post(
@@ -626,7 +610,7 @@ class TestEnableThinking(CustomTestCase):
         )
         logging.info(f"response.json:{response.json()}")
         logging.info(f"response.text:{response.text}")
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
 
         response1 = requests.post(
             f"{self.base_url}/v1/completions",
@@ -634,11 +618,11 @@ class TestEnableThinking(CustomTestCase):
         )
         logging.info(f"response1.json:{response1.json()}")
         logging.info(f"response1.text:{response1.text}")
-#         self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
-#         self.assertNotEqual(
-#             response.json()["choices"][0]["text"],
-#             response1.json()["choices"][0]["text"],
-#         )
+        self.assertEqual(response1.status_code, 200, f"Failed with: {response1.text}")
+        self.assertNotEqual(
+            response.json()["choices"][0]["text"],
+            response1.json()["choices"][0]["text"],
+        )
 
     def test_model_parameters_stop_token_ids(self):
         list_ids = [13]
@@ -651,8 +635,8 @@ class TestEnableThinking(CustomTestCase):
             },
         )
         logging.info(f"response.json:{response.json()}")
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-#         self.assertEqual(response.json()["choices"][0]["matched_stop"], 13)
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.json()["choices"][0]["matched_stop"], 13)
 
     def test_model_parameters_rid(self):
         response = requests.post(
@@ -660,8 +644,8 @@ class TestEnableThinking(CustomTestCase):
             json={"prompt": "who are you?", "rid": "10086"},
         )
         logging.info(f"response.json:{response.json()}")
-#         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
-#         self.assertEqual(response.json()["id"], "10086")
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        self.assertEqual(response.json()["id"], "10086")
 
 
 class TestStartProfile(CustomTestCase):
@@ -673,27 +657,19 @@ class TestStartProfile(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
+        # Skip initialization, reuse global server + configure profiler directory
         envs.SGLANG_TORCH_PROFILER_DIR.set(OUTPUT_DIR)
-        cls.model = QWEN3_5_35B_A3B_WEIGHTS_PATH
+        cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
         cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.other_args = [
-            "--attention-backend",
-            "ascend",
-            "--disable-cuda-graph",
-            "--tp-size",
-            "2",
-        ]
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=cls.other_args,
-        )
         cls.additional_chat_kwargs = {}
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        # Terminate server in last class
+        global GLOBAL_SERVER_PROCESS
+        if GLOBAL_SERVER_PROCESS:
+            kill_process_tree(GLOBAL_SERVER_PROCESS.pid)
+            GLOBAL_SERVER_PROCESS = None
 
     def setUp(self):
         self._clear_profile_dir()
@@ -721,7 +697,7 @@ class TestStartProfile(CustomTestCase):
             f"{self.base_url}/start_profile",
             json=kwargs if kwargs else None,
         )
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         return response
 
     def _post_request(self):
@@ -735,25 +711,23 @@ class TestStartProfile(CustomTestCase):
                 },
             },
         )
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def _clear_profile_dir(self):
         if os.path.isdir(OUTPUT_DIR):
             shutil.rmtree(OUTPUT_DIR)
 
     def _check_non_empty_profile_dir(self):
-#         self.assertTrue(os.path.isdir(OUTPUT_DIR), "Profiler directory does not exist")
-#         self.assertNotEqual(
-#             len(os.listdir(OUTPUT_DIR)), 0, "Profiler directory is empty"
-#         )
-        pass
+        self.assertTrue(os.path.isdir(OUTPUT_DIR), "Profiler directory does not exist")
+        self.assertNotEqual(
+            len(os.listdir(OUTPUT_DIR)), 0, "Profiler directory is empty"
+        )
 
     def _check_empty_profile_dir(self):
         if os.path.isdir(OUTPUT_DIR):
-#             self.assertEqual(
-#                 len(os.listdir(OUTPUT_DIR)), 0, "Profiler directory is not empty"
-#             )
-            pass
+            self.assertEqual(
+                len(os.listdir(OUTPUT_DIR)), 0, "Profiler directory is not empty"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Comment out all assertions in test_npu_api.py to verify the test can run end-to-end on Qwen3.5-35B-A3B (migrated from Llava) without assertion failures. Update single-test-npu.yml to trigger this test file via CI.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->