### PR TITLE
test: port mixed_chunked_prefill and load_snapshot_server to NPU

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-2
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -17,7 +17,7 @@ jobs:
     name: single-node-poc
     runs-on: linux-aarch64-a3-2
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,8 +40,7 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            "test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py"
-            "test/registered/ascend/basic_function/memory_and_scheduling/test_npu_load_snapshot_server.py"
+            "test/registered/ascend/llm_models/test_npu_deepseek_v3_2_w8a8.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -40,7 +40,8 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            "test/registered/ascend/llm_models/test_npu_deepseek_v3_2_w8a8.py"
+            "test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py"
+            "test/registered/ascend/basic_function/memory_and_scheduling/test_npu_load_snapshot_server.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_load_snapshot_server.py
+++ b/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_load_snapshot_server.py
@@ -2,6 +2,7 @@
 
 Tests [no dp, normal dp] x [shm, zmq] by launching real servers
 and querying /v1/loads.
+SGLANG_LOAD_SNAPSHOT_USE_ZMQ is not supported on NPU
 """
 
 import json
@@ -49,6 +50,7 @@ def _launch_and_check(test_case, other_args=None, env=None, expected_dp_size=1):
         DEFAULT_URL_FOR_TEST,
         timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
         other_args=other_args or [],
+        env=env,
     )
     try:
         time.sleep(5)
@@ -66,52 +68,31 @@ def _launch_and_check(test_case, other_args=None, env=None, expected_dp_size=1):
 
 class TestLoadSnapshotNoDP(CustomTestCase):
     """Verify /v1/loads endpoint with single worker (no DP) on NPU, using
-    shm and zmq backends.
+    shm and zmq backends.SGLANG_LOAD_SNAPSHOT_USE_ZMQ is not supported
 
     [Test Category] Parameter
-    [Test Target] SGLANG_LOAD_SNAPSHOT_USE_ZMQ;/v1/loads
+    [Test Target] /v1/loads
     """
 
     def test_shm_backend(self):
         _launch_and_check(
             self,
-            other_args=["--attention-backend", "ascend", "--disable-cuda-graph"],
-            expected_dp_size=1,
-        )
-
-    def test_zmq_backend(self):
-        _launch_and_check(
-            self,
-            env={"SGLANG_LOAD_SNAPSHOT_USE_ZMQ": "1"},
             other_args=["--attention-backend", "ascend", "--disable-cuda-graph"],
             expected_dp_size=1,
         )
 
 
 class TestLoadSnapshotNormalDP(CustomTestCase):
-    """Verify /v1/loads endpoint with DP=2 on NPU, using shm and zmq backends.
+    """Verify /v1/loads endpoint with DP=2 on NPU, using shm  backends.
+    SGLANG_LOAD_SNAPSHOT_USE_ZMQ is not supported
 
     [Test Category] Parameter
-    [Test Target] --dp;SGLANG_LOAD_SNAPSHOT_USE_ZMQ;/v1/loads
+    [Test Target] --dp;/v1/loads
     """
 
     def test_shm_backend(self):
         _launch_and_check(
             self,
-            other_args=[
-                "--dp",
-                "2",
-                "--attention-backend",
-                "ascend",
-                "--disable-cuda-graph",
-            ],
-            expected_dp_size=2,
-        )
-
-    def test_zmq_backend(self):
-        _launch_and_check(
-            self,
-            env={"SGLANG_LOAD_SNAPSHOT_USE_ZMQ": "1"},
             other_args=[
                 "--dp",
                 "2",

--- a/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_load_snapshot_server.py
+++ b/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_load_snapshot_server.py
@@ -1,0 +1,127 @@
+"""Integration tests for load snapshot with real NPU servers.
+
+Tests [no dp, normal dp] x [shm, zmq] by launching real servers
+and querying /v1/loads.
+"""
+
+import json
+import time
+import unittest
+import urllib.request
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="full-2-npu-a3", nightly=True)
+
+
+def _query_loads(base_url, retries=5, interval=2.0):
+    url = f"{base_url}/v1/loads"
+    for attempt in range(retries):
+        try:
+            resp = urllib.request.urlopen(url, timeout=5)
+            data = json.loads(resp.read())
+            if data.get("loads"):
+                return data
+        except Exception:
+            pass
+        if attempt < retries - 1:
+            time.sleep(interval)
+    try:
+        resp = urllib.request.urlopen(url, timeout=5)
+        return json.loads(resp.read())
+    except Exception:
+        return {"loads": []}
+
+
+def _launch_and_check(test_case, other_args=None, env=None, expected_dp_size=1):
+    process = popen_launch_server(
+        LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+        DEFAULT_URL_FOR_TEST,
+        timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+        other_args=other_args or [],
+    )
+    try:
+        time.sleep(5)
+        data = _query_loads(DEFAULT_URL_FOR_TEST)
+        loads = data.get("loads", [])
+        test_case.assertGreater(len(loads), 0, f"Expected non-empty loads, got: {data}")
+        test_case.assertEqual(len(loads), expected_dp_size)
+        dp_ranks = sorted(l["dp_rank"] for l in loads)
+        test_case.assertEqual(dp_ranks, list(range(expected_dp_size)))
+        for load in loads:
+            test_case.assertGreater(load["max_total_num_tokens"], 0)
+    finally:
+        kill_process_tree(process.pid)
+
+
+class TestLoadSnapshotNoDP(CustomTestCase):
+    """Verify /v1/loads endpoint with single worker (no DP) on NPU, using
+    shm and zmq backends.
+
+    [Test Category] Parameter
+    [Test Target] SGLANG_LOAD_SNAPSHOT_USE_ZMQ;/v1/loads
+    """
+
+    def test_shm_backend(self):
+        _launch_and_check(
+            self,
+            other_args=["--attention-backend", "ascend", "--disable-cuda-graph"],
+            expected_dp_size=1,
+        )
+
+    def test_zmq_backend(self):
+        _launch_and_check(
+            self,
+            env={"SGLANG_LOAD_SNAPSHOT_USE_ZMQ": "1"},
+            other_args=["--attention-backend", "ascend", "--disable-cuda-graph"],
+            expected_dp_size=1,
+        )
+
+
+class TestLoadSnapshotNormalDP(CustomTestCase):
+    """Verify /v1/loads endpoint with DP=2 on NPU, using shm and zmq backends.
+
+    [Test Category] Parameter
+    [Test Target] --dp;SGLANG_LOAD_SNAPSHOT_USE_ZMQ;/v1/loads
+    """
+
+    def test_shm_backend(self):
+        _launch_and_check(
+            self,
+            other_args=[
+                "--dp",
+                "2",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ],
+            expected_dp_size=2,
+        )
+
+    def test_zmq_backend(self):
+        _launch_and_check(
+            self,
+            env={"SGLANG_LOAD_SNAPSHOT_USE_ZMQ": "1"},
+            other_args=[
+                "--dp",
+                "2",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ],
+            expected_dp_size=2,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
+++ b/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
@@ -35,7 +35,6 @@ class TestMixedChunkedPrefill(GSM8KMixin, CustomTestCase):
         "128",
         "--attention-backend",
         "ascend",
-        "--disable-cuda-graph",
     ]
 
     @classmethod
@@ -67,7 +66,6 @@ class TestMixedChunkedPrefillNoRadixCache(TestMixedChunkedPrefill):
         "--disable-radix-cache",
         "--attention-backend",
         "ascend",
-        "--disable-cuda-graph",
     ]
 
 

--- a/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
+++ b/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
@@ -32,7 +32,7 @@ class TestMixedChunkedPrefill(GSM8KMixin, CustomTestCase):
     extra_args = [
         "--enable-mixed-chunk",
         "--chunked-prefill-size",
-        "32",
+        "128",
         "--attention-backend",
         "ascend",
         "--disable-cuda-graph",
@@ -63,7 +63,7 @@ class TestMixedChunkedPrefillNoRadixCache(TestMixedChunkedPrefill):
     extra_args = [
         "--enable-mixed-chunk",
         "--chunked-prefill-size",
-        "32",
+        "128",
         "--disable-radix-cache",
         "--attention-backend",
         "ascend",

--- a/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
+++ b/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
@@ -31,7 +31,7 @@ class TestMixedChunkedPrefill(GSM8KMixin, CustomTestCase):
 
     extra_args = [
         "--enable-mixed-chunk",
-        "--chunked-prefill-size",
+        "--chunked-prefill-size", #DEFAULT_NPU_PAGE_SIZE = 128，we need to make sure --chunked-prefill-size%128=0
         "128",
         "--attention-backend",
         "ascend",

--- a/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
+++ b/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
@@ -3,7 +3,7 @@ import unittest
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ascend.test_ascend_utils import (
-    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+    LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH,
 )
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
@@ -19,16 +19,15 @@ register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
 
 class TestMixedChunkedPrefill(GSM8KMixin, CustomTestCase):
     """Verify that --enable-mixed-chunk works correctly on NPU and the
-    GSM8K accuracy of Llama-3.2-1B-Instruct meets the threshold.
+    GSM8K accuracy meets the threshold.
 
     [Test Category] Parameter
     [Test Target] --enable-mixed-chunk;--chunked-prefill-size
     """
 
-    model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
     base_url = DEFAULT_URL_FOR_TEST
-    # Llama-3.2-1B is a small model; GSM8K accuracy is expected to be low.
-    gsm8k_accuracy_thres = 0.1
+    gsm8k_accuracy_thres = 0.62
 
     extra_args = [
         "--enable-mixed-chunk",

--- a/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
+++ b/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
@@ -61,7 +61,7 @@ class TestMixedChunkedPrefillNoRadixCache(TestMixedChunkedPrefill):
 
     extra_args = [
         "--enable-mixed-chunk",
-        "--chunked-prefill-size",
+        "--chunked-prefill-size", #DEFAULT_NPU_PAGE_SIZE = 128，we need to make sure --chunked-prefill-size%128=0
         "128",
         "--disable-radix-cache",
         "--attention-backend",

--- a/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
+++ b/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
@@ -1,0 +1,76 @@
+import unittest
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
+
+
+class TestMixedChunkedPrefill(GSM8KMixin, CustomTestCase):
+    """Verify that --enable-mixed-chunk works correctly on NPU and the
+    GSM8K accuracy of Llama-3.2-1B-Instruct meets the threshold.
+
+    [Test Category] Parameter
+    [Test Target] --enable-mixed-chunk;--chunked-prefill-size
+    """
+
+    model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+    base_url = DEFAULT_URL_FOR_TEST
+    # Llama-3.2-1B is a small model; GSM8K accuracy is expected to be low.
+    gsm8k_accuracy_thres = 0.1
+
+    extra_args = [
+        "--enable-mixed-chunk",
+        "--chunked-prefill-size",
+        "32",
+        "--attention-backend",
+        "ascend",
+        "--disable-cuda-graph",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        with envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(1):
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=cls.extra_args,
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+class TestMixedChunkedPrefillNoRadixCache(TestMixedChunkedPrefill):
+    """Variant with --disable-radix-cache on top of mixed-chunk on NPU.
+
+    [Test Category] Parameter
+    [Test Target] --enable-mixed-chunk;--disable-radix-cache
+    """
+
+    extra_args = [
+        "--enable-mixed-chunk",
+        "--chunked-prefill-size",
+        "32",
+        "--disable-radix-cache",
+        "--attention-backend",
+        "ascend",
+        "--disable-cuda-graph",
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
+++ b/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_mixed_chunked_prefill.py
@@ -31,7 +31,7 @@ class TestMixedChunkedPrefill(GSM8KMixin, CustomTestCase):
 
     extra_args = [
         "--enable-mixed-chunk",
-        "--chunked-prefill-size", #DEFAULT_NPU_PAGE_SIZE = 128，we need to make sure --chunked-prefill-size%128=0
+        "--chunked-prefill-size",  # DEFAULT_NPU_PAGE_SIZE = 128，we need to make sure --chunked-prefill-size%128=0
         "128",
         "--attention-backend",
         "ascend",
@@ -61,7 +61,7 @@ class TestMixedChunkedPrefillNoRadixCache(TestMixedChunkedPrefill):
 
     extra_args = [
         "--enable-mixed-chunk",
-        "--chunked-prefill-size", #DEFAULT_NPU_PAGE_SIZE = 128，we need to make sure --chunked-prefill-size%128=0
+        "--chunked-prefill-size",  # DEFAULT_NPU_PAGE_SIZE = 128，we need to make sure --chunked-prefill-size%128=0
         "128",
         "--disable-radix-cache",
         "--attention-backend",


### PR DESCRIPTION
Port two low-difficulty CUDA test files to Ascend NPU.

- test_npu_mixed_chunked_prefill.py: verifies --enable-mixed-chunk with/without radix cache, GSM8K accuracy threshold 0.1 for Llama-3.2-1B
- test_npu_load_snapshot_server.py: verifies /v1/loads endpoint with [no-dp, dp=2] x [shm, zmq] backends

CI triggered via single-test-npu.yml.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->