### PR TITLE
test: port retract_decode (extend), scheduler_control and weight_checker_e2e to NPU

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -40,9 +40,7 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            "test/registered/ascend/basic_function/parameter/test_npu_retract_decode.py"
-            "test/registered/ascend/basic_function/memory_and_scheduling/test_npu_scheduler_control.py"
-            "test/registered/ascend/basic_function/rl/test_npu_weight_checker_e2e.py"
+            "test/registered/ascend/llm_models/test_npu_deepseek_v3_2_w8a8.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -40,7 +40,9 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            "test/registered/ascend/llm_models/test_npu_deepseek_v3_2_w8a8.py"
+            "test/registered/ascend/basic_function/parameter/test_npu_retract_decode.py"
+            "test/registered/ascend/basic_function/memory_and_scheduling/test_npu_scheduler_control.py"
+            "test/registered/ascend/basic_function/rl/test_npu_weight_checker_e2e.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_scheduler_control.py
+++ b/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_scheduler_control.py
@@ -1,4 +1,6 @@
 import multiprocessing
+import os
+import random
 import threading
 import time
 import unittest
@@ -19,8 +21,101 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
-    run_and_check_memory_leak,
+    read_output,
 )
+
+# Mirror the temp-file names used by sglang.test.test_utils so that the
+# streamed output thread can pick them up. We intentionally re-implement the
+# body of run_and_check_memory_leak here because that helper hard-codes
+# `DEFAULT_MODEL_NAME_FOR_TEST` ("meta-llama/Llama-3.1-8B-Instruct"), which is
+# not available on ModelScope and thus cannot run on NPU CI runners.
+_STDERR_FILENAME = "/tmp/stderr.txt"
+_STDOUT_FILENAME = "/tmp/stdout.txt"
+
+
+def _run_and_check_memory_leak_npu(
+    workload_func,
+    disable_radix_cache,
+    enable_mixed_chunk,
+    disable_overlap,
+    chunked_prefill_size,
+    assert_has_abort,
+    api_key=None,
+):
+    """NPU-friendly replacement for run_and_check_memory_leak.
+
+    Differs only in that it uses LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH (a
+    ModelScope-resolvable path) instead of DEFAULT_MODEL_NAME_FOR_TEST, and
+    adds NPU required args (--attention-backend ascend, --disable-cuda-graph).
+    """
+    other_args = [
+        "--chunked-prefill-size",
+        str(chunked_prefill_size),
+        "--log-level",
+        "debug",
+        "--attention-backend",
+        "ascend",
+        "--disable-cuda-graph",
+    ]
+    if disable_radix_cache:
+        other_args += ["--disable-radix-cache"]
+    if enable_mixed_chunk:
+        other_args += ["--enable-mixed-chunk"]
+    if disable_overlap:
+        other_args += ["--disable-overlap-schedule"]
+
+    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+    port = random.randint(4000, 5000)
+    base_url = f"http://127.0.0.1:{port}"
+
+    # Create files and launch the server
+    stdout = open(_STDOUT_FILENAME, "w")
+    stderr = open(_STDERR_FILENAME, "w")
+    process = popen_launch_server(
+        model,
+        base_url,
+        timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+        other_args=other_args,
+        return_stdout_stderr=(stdout, stderr),
+        api_key=api_key,
+    )
+
+    # Launch a thread to stream the output
+    output_lines = []
+    t = threading.Thread(target=read_output, args=(output_lines, _STDERR_FILENAME))
+    t.start()
+
+    # Run the workload
+    workload_func(base_url, model)
+
+    # Clean up everything
+    kill_process_tree(process.pid)
+    stdout.close()
+    stderr.close()
+    if os.path.exists(_STDOUT_FILENAME):
+        os.remove(_STDOUT_FILENAME)
+    if os.path.exists(_STDERR_FILENAME):
+        os.remove(_STDERR_FILENAME)
+    kill_process_tree(process.pid)
+    t.join()
+
+    # Assert success
+    has_new_server = False
+    has_leak = False
+    has_abort = False
+    for line in output_lines:
+        if "Uvicorn running" in line:
+            has_new_server = True
+        if "leak" in line:
+            has_leak = True
+        if "Abort" in line:
+            has_abort = True
+
+    assert has_new_server
+    assert not has_leak
+    if assert_has_abort:
+        assert has_abort
+
 
 register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
 
@@ -57,7 +152,7 @@ class TestAbort(CustomTestCase):
         time.sleep(10)
 
     def test_memory_leak(self):
-        run_and_check_memory_leak(
+        _run_and_check_memory_leak_npu(
             self.workload_func,
             disable_radix_cache=False,
             enable_mixed_chunk=False,
@@ -101,7 +196,7 @@ class TestAbortWithApiKey(CustomTestCase):
 
     def test_memory_leak_with_api_key(self):
         api_key = "test-api-key"
-        run_and_check_memory_leak(
+        _run_and_check_memory_leak_npu(
             lambda base_url, model: self.workload_func(base_url, model, api_key),
             disable_radix_cache=False,
             enable_mixed_chunk=False,

--- a/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_scheduler_control.py
+++ b/test/registered/ascend/basic_function/memory_and_scheduling/test_npu_scheduler_control.py
@@ -1,0 +1,385 @@
+import multiprocessing
+import threading
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import requests
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.kits.abort_timeout_kit import AbortAllMixin, WaitingTimeoutMixin
+from sglang.test.kits.pause_generation_kit import PauseResumeInPlaceMixin
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+    run_and_check_memory_leak,
+)
+
+register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
+
+
+class TestAbort(CustomTestCase):
+    def workload_func(self, base_url, model):
+        def process_func():
+            def run_one(_):
+                prompt = """
+                System: You are a helpful assistant.
+                User: What is the capital of France?
+                Assistant: The capital of France is
+                """
+
+                response = requests.post(
+                    f"{base_url}/generate",
+                    json={
+                        "text": prompt,
+                        "sampling_params": {
+                            "temperature": 0,
+                            "max_new_tokens": 2048,
+                        },
+                    },
+                )
+                ret = response.json()
+
+            with ThreadPoolExecutor(16) as executor:
+                list(executor.map(run_one, list(range(16))))
+
+        p = multiprocessing.Process(target=process_func)
+        p.start()
+        time.sleep(0.5)
+        p.terminate()
+        time.sleep(10)
+
+    def test_memory_leak(self):
+        run_and_check_memory_leak(
+            self.workload_func,
+            disable_radix_cache=False,
+            enable_mixed_chunk=False,
+            disable_overlap=False,
+            chunked_prefill_size=8192,
+            assert_has_abort=True,
+        )
+
+
+class TestAbortWithApiKey(CustomTestCase):
+    def workload_func(self, base_url, model, api_key: str):
+        def process_func():
+            def run_one(_):
+                prompt = """
+                System: You are a helpful assistant.
+                User: What is the capital of France?
+                Assistant: The capital of France is
+                """
+
+                response = requests.post(
+                    f"{base_url}/generate",
+                    json={
+                        "text": prompt,
+                        "sampling_params": {
+                            "temperature": 0,
+                            "max_new_tokens": 2048,
+                        },
+                    },
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                response.json()
+
+            with ThreadPoolExecutor(16) as executor:
+                list(executor.map(run_one, list(range(16))))
+
+        p = multiprocessing.Process(target=process_func)
+        p.start()
+        time.sleep(0.5)
+        p.terminate()
+        time.sleep(10)
+
+    def test_memory_leak_with_api_key(self):
+        api_key = "test-api-key"
+        run_and_check_memory_leak(
+            lambda base_url, model: self.workload_func(base_url, model, api_key),
+            disable_radix_cache=False,
+            enable_mixed_chunk=False,
+            disable_overlap=False,
+            chunked_prefill_size=8192,
+            assert_has_abort=True,
+            api_key=api_key,
+        )
+
+
+class TestSchedulerControl(AbortAllMixin, PauseResumeInPlaceMixin, CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--max-running-requests",
+                "8",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _generate_with_rid(self, rid, max_new_tokens=8):
+        return requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": max_new_tokens,
+                },
+                "rid": rid,
+            },
+            timeout=30,
+        )
+
+    def test_duplicate_rid_sequential_ok(self):
+        rid = "dup-rid-test-sequential"
+        resp1 = self._generate_with_rid(rid)
+        self.assertEqual(resp1.status_code, 200)
+        self.assertNotIn("error", resp1.json())
+
+        resp2 = self._generate_with_rid(rid)
+        self.assertEqual(resp2.status_code, 200)
+        self.assertNotIn("error", resp2.json())
+
+    def test_duplicate_rid_concurrent_rejected(self):
+        rid = "dup-rid-test-concurrent"
+        results = {}
+
+        def send(key, max_tokens):
+            results[key] = self._generate_with_rid(rid, max_new_tokens=max_tokens)
+
+        t1 = threading.Thread(target=send, args=("first", 512))
+        t2 = threading.Thread(target=send, args=("second", 8))
+        t1.start()
+        time.sleep(0.1)
+        t2.start()
+        t1.join(timeout=30)
+        t2.join(timeout=30)
+
+        r1, r2 = results["first"], results["second"]
+        self.assertTrue(
+            r1.status_code == 400 or r2.status_code == 400,
+            "One of the concurrent duplicate-rid requests should be rejected",
+        )
+
+        rejected = r2 if r2.status_code == 400 else r1
+        self.assertIn("Duplicate request ID", rejected.json()["error"]["message"])
+
+    def test_duplicate_rid_in_batch(self):
+        rid = "dup-rid-batch"
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": ["Hello", "World"],
+                "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+                "rid": [rid, rid],
+            },
+            timeout=30,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Duplicate request ID", response.json()["error"]["message"])
+
+    def test_server_healthy_after_duplicate_rid(self):
+        requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": ["Hello", "World"],
+                "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+                "rid": ["dup-health", "dup-health"],
+            },
+            timeout=30,
+        )
+
+        resp = requests.get(f"{self.base_url}/health", timeout=5)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._generate_with_rid("after-dup-health")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("text", resp.json())
+
+
+class TestAbortAllWithRetraction(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        # Here's a small trick: in scheduler.py, when SGLANG_TEST_RETRACT is enabled,
+        # retraction is triggered when the batch size reaches 10.
+        # However, since SGLANG_TEST_RETRACT_NO_PREFILL_BS is set to 6, the remaining 4
+        # requests will stay in the waiting queue.
+        with (
+            envs.SGLANG_TEST_RETRACT.override(True),
+            envs.SGLANG_TEST_RETRACT_NO_PREFILL_BS.override(6),
+        ):
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    "--max-running-requests",
+                    "16",
+                    "--schedule-policy",
+                    "random",
+                    "--attention-backend",
+                    "ascend",
+                    "--disable-cuda-graph",
+                ],
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _run_decode(self):
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 4000,
+                    "ignore_eos": True,
+                },
+                "return_logprob": True,
+                "top_logprobs_num": 3,
+            },
+        )
+        return response.json()
+
+    def test_abort_all_with_retraction(self):
+        num_requests = 32
+        with ThreadPoolExecutor(num_requests) as executor:
+            futures = [executor.submit(self._run_decode) for _ in range(num_requests)]
+
+            # ensure the decode has been started and retractions happen.
+            time.sleep(8)
+
+            requests.post(
+                self.base_url + "/abort_request",
+                json={
+                    "abort_all": True,
+                },
+            )
+
+            abort_in_queue_count = 0
+            abort_in_queue_with_partial_gen = 0
+
+            for future in as_completed(futures):
+                result = future.result()
+                meta_info = result["meta_info"]
+                finish_reason = meta_info.get("finish_reason", {})
+
+                self.assertEqual(finish_reason.get("type"), "abort")
+
+                if finish_reason.get("message") == "Abort in waiting queue":
+                    abort_in_queue_count += 1
+                    output_ids = result.get("output_ids", [])
+
+                    if len(output_ids) > 0:
+                        abort_in_queue_with_partial_gen += 1
+
+                        self.assertEqual(
+                            meta_info.get("completion_tokens"), len(output_ids)
+                        )
+                        self.assertGreater(len(result.get("text", "")), 0)
+                        self.assertIsNotNone(meta_info.get("weight_version"))
+                        self.assertGreater(meta_info.get("e2e_latency"), 0)
+                        for logprob_key in [
+                            "output_token_logprobs",
+                            "output_top_logprobs",
+                        ]:
+                            self.assertEqual(
+                                len(meta_info.get(logprob_key, [])),
+                                len(output_ids),
+                                f"Length of '{logprob_key}' should match output_ids length",
+                            )
+
+            self.assertGreater(abort_in_queue_count, 0)
+            self.assertGreater(abort_in_queue_with_partial_gen, 0)
+            print("Finished test_abort_all_with_retraction")
+
+
+class TestAbortWithWaitingTimeout(WaitingTimeoutMixin, CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        with envs.SGLANG_REQ_WAITING_TIMEOUT.override(0.001):
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    "--max-running-requests=1",
+                    "--attention-backend",
+                    "ascend",
+                    "--disable-cuda-graph",
+                ],
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+class TestAbortWithRunningTimeout(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        with (
+            envs.SGLANG_REQ_RUNNING_TIMEOUT.override(0.001),
+            envs.SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION.override(False),
+        ):
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    "--skip-server-warmup",
+                    "--attention-backend",
+                    "ascend",
+                    "--disable-cuda-graph",
+                ],
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_running_timeout(self):
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "Today is ",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 512,
+                    "ignore_eos": True,
+                },
+            },
+        )
+        result = response.json()
+        self.assertEqual(result["object"], "error")
+        self.assertEqual(result["code"], 503)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/parameter/test_npu_retract_decode.py
+++ b/test/registered/ascend/basic_function/parameter/test_npu_retract_decode.py
@@ -1,9 +1,15 @@
 import os
+import time
 import unittest
 from types import SimpleNamespace
 
+import requests
+
+from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ascend.test_ascend_utils import LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH,
+)
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
@@ -12,6 +18,7 @@ from sglang.test.test_utils import (
     CustomTestCase,
     popen_launch_server,
 )
+from sglang.utils import is_in_ci
 
 register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
 
@@ -23,6 +30,8 @@ class TestRetractDecode(CustomTestCase):
     [Test Target] SGLANG_TEST_RETRACT
     """
 
+    other_args = []
+
     @classmethod
     def setUpClass(cls):
         # Enable retract decode feature for test
@@ -30,20 +39,22 @@ class TestRetractDecode(CustomTestCase):
 
         cls.model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
         cls.base_url = DEFAULT_URL_FOR_TEST
-        other_args = [
+        launch_args = [
+            "--chunked-prefill-size",
+            "128",
             "--attention-backend",
             "ascend",
             "--disable-cuda-graph",
             "--mem-fraction-static",
-            0.8,
-        ]
-
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=other_args,
-        )
+            "0.8",
+        ] + cls.other_args
+        with envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(1):
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=launch_args,
+            )
 
     @classmethod
     def tearDownClass(cls):
@@ -54,12 +65,105 @@ class TestRetractDecode(CustomTestCase):
             base_url=self.base_url,
             model=self.model,
             eval_name="mmlu",
-            num_examples=256,
+            num_examples=64,
             num_threads=32,
         )
 
         metrics = run_eval(args)
         self.assertGreaterEqual(metrics["score"], 0.65)
+        time.sleep(1)  # wait for mem check
+
+        assert self.process.poll() is None, "Server crashed during test"
+
+
+class TestRetractDecodePaged(TestRetractDecode):
+    """Retract decode with paged mode (--page-size 128) on NPU.
+
+    [Test Category] Parameter
+    [Test Target] SGLANG_TEST_RETRACT;--page-size
+    """
+
+    # NPU page_size is 128; use 128 instead of the CUDA default 16.
+    other_args = ["--page-size", "128"]
+
+
+class TestRetractDecodeChunkCache(TestRetractDecode):
+    """Retract decode with chunk cache (--disable-radix-cache) on NPU.
+
+    [Test Category] Parameter
+    [Test Target] SGLANG_TEST_RETRACT;--disable-radix-cache
+    """
+
+    other_args = ["--disable-radix-cache"]
+
+
+class TestRetractDecodeChunkCachePaged(TestRetractDecode):
+    """Retract decode with chunk cache + paged mode on NPU.
+
+    [Test Category] Parameter
+    [Test Target] SGLANG_TEST_RETRACT;--disable-radix-cache;--page-size
+    """
+
+    other_args = ["--disable-radix-cache", "--page-size", "128"]
+
+
+@unittest.skipIf(is_in_ci(), "Skipped in CI due to long runtime")
+class TestRetractDecodeLongOutput(CustomTestCase):
+    """Long-output stress test for retract decode on NPU.
+
+    [Test Category] Parameter
+    [Test Target] SGLANG_TEST_RETRACT;long output
+    """
+
+    other_args = []
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ["SGLANG_TEST_RETRACT"] = "1"
+
+        cls.model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        launch_args = [
+            "--chunked-prefill-size",
+            "128",
+            "--page-size",
+            "128",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--mem-fraction-static",
+            "0.8",
+        ] + cls.other_args
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=launch_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_long_output_retract(self):
+        data = {
+            "input_ids": [[233 + i] * 1234 for i in range(256)],
+            "sampling_params": {"max_new_tokens": 90000, "ignore_eos": True},
+        }
+        res = requests.post(f"{self.base_url}/generate", json=data)
+        assert res.status_code == 200, f"Request failed: {res.status_code}"
+        assert self.process.poll() is None, "Server crashed during test"
+
+
+@unittest.skipIf(is_in_ci(), "Skipped in CI due to long runtime")
+class TestRetractDecodeLongOutputChunkCache(TestRetractDecodeLongOutput):
+    """Long-output stress test for retract decode + chunk cache on NPU.
+
+    [Test Category] Parameter
+    [Test Target] SGLANG_TEST_RETRACT;long output;--disable-radix-cache
+    """
+
+    other_args = ["--disable-radix-cache"]
 
 
 if __name__ == "__main__":

--- a/test/registered/ascend/basic_function/rl/test_npu_weight_checker_e2e.py
+++ b/test/registered/ascend/basic_function/rl/test_npu_weight_checker_e2e.py
@@ -22,7 +22,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
+register_npu_ci(est_time=1500, suite="full-1-npu-a3", nightly=True)
 
 _MODEL_NAME = QWEN3_0_6B_WEIGHTS_PATH
 # We address the up half via the HF-style unfused name "up_proj.weight". sglang's
@@ -66,8 +66,11 @@ class TestWeightCheckerE2E(CustomTestCase):
         kill_process_tree(cls.process.pid)
 
     def _post(self, action: str) -> requests.Response:
+        # checksum action iterates over all model weights on NPU and is much
+        # slower than snapshot/compare, so allow a generous timeout.
+        timeout = 600 if action == "checksum" else 120
         return requests.post(
-            f"{self.url}/weights_checker", json={"action": action}, timeout=120
+            f"{self.url}/weights_checker", json={"action": action}, timeout=timeout
         )
 
     def _update_weights(

--- a/test/registered/ascend/basic_function/rl/test_npu_weight_checker_e2e.py
+++ b/test/registered/ascend/basic_function/rl/test_npu_weight_checker_e2e.py
@@ -1,0 +1,222 @@
+"""End-to-end test for the /weights_checker HTTP endpoint on NPU.
+
+Exercises the full HTTP -> tokenizer_manager -> scheduler -> model_runner ->
+WeightChecker chain on a real Ascend NPU engine. Unit tests in
+test/registered/unit/utils/test_weight_checker.py cover the in-module
+logic; this file is the thin integration cover plus interaction with
+update_weights_from_tensor."""
+
+import unittest
+from typing import List, Tuple
+
+import requests
+import torch
+
+from sglang.srt.utils import MultiprocessingSerializer, kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_0_6B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)
+
+_MODEL_NAME = QWEN3_0_6B_WEIGHTS_PATH
+# We address the up half via the HF-style unfused name "up_proj.weight". sglang's
+# stacked_params_mapping rewrites this to "gate_up_proj.weight" with shard_id=1,
+# so the upload writes only the up half of the fused tensor. Sending the fused
+# name directly hits a name.replace() collision (gate_up_proj contains up_proj),
+# producing a malformed key like "gate_gate_up_proj.weight" and crashing load.
+_UP_PROJ_SHAPE = (3072, 1024)  # intermediate_size, hidden_size for Qwen3-0.6B
+
+
+class TestWeightCheckerE2E(CustomTestCase):
+    """All cases share one launched server (setUpClass).
+
+    The reset case mutates weights to random; it is named to sort last so any
+    case that needs intact weights runs first. The server is torn down right
+    after, so leaving the engine in a corrupted state is harmless."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.url = DEFAULT_URL_FOR_TEST
+        # --mem-fraction-static 0.7 leaves enough free NPU memory for
+        # _check_tensors's CPU->NPU round trip: snapshot lives on CPU, then
+        # _compare moves each snapshot tensor back to NPU for byte equality.
+        # With the default 0.88, the vocab-embedding round-trip OOMs the
+        # snapshot/reset/compare cycle in test_z_*.
+        cls.process = popen_launch_server(
+            _MODEL_NAME,
+            cls.url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--mem-fraction-static",
+                "0.7",
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _post(self, action: str) -> requests.Response:
+        return requests.post(
+            f"{self.url}/weights_checker", json={"action": action}, timeout=120
+        )
+
+    def _update_weights(
+        self, named_tensors: List[Tuple[str, torch.Tensor]]
+    ) -> requests.Response:
+        return requests.post(
+            f"{self.url}/update_weights_from_tensor",
+            json={
+                "serialized_named_tensors": [
+                    MultiprocessingSerializer.serialize(named_tensors, output_str=True)
+                ],
+                "flush_cache": True,
+            },
+            timeout=120,
+        )
+
+    def test_a_snapshot_then_compare_unchanged_succeeds(self):
+        resp = self._post("snapshot")
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+
+        resp = self._post("compare")
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+
+    def test_b_unknown_action_returns_400(self):
+        resp = self._post("nonsense_action")
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Unsupported", resp.json()["message"])
+
+    def test_c_update_with_diff_tensor_makes_compare_fail(self):
+        """A snapshot then an update with new bytes must make compare fail."""
+        self.assertEqual(self._post("snapshot").status_code, 200)
+
+        # The unfused HF name "up_proj" is what update_weights_from_tensor accepts;
+        # sglang's loader rewrites it onto the fused gate_up_proj tensor.
+        upload_name = "model.layers.5.mlp.up_proj.weight"
+        new_tensor = torch.full(_UP_PROJ_SHAPE, 1.5, device="npu")
+        update_resp = self._update_weights([(upload_name, new_tensor)])
+        self.assertEqual(update_resp.status_code, 200)
+        self.assertTrue(update_resp.json()["success"])
+
+        resp = self._post("compare")
+        self.assertEqual(resp.status_code, 400)
+        body = resp.json()
+        self.assertFalse(body["success"])
+        # The error references the fused on-device parameter name, not the upload alias.
+        self.assertIn("model.layers.5.mlp.gate_up_proj.weight", body["message"])
+        self.assertIn("max_abs_err", body["message"])
+
+    def test_d_update_with_same_tensor_keeps_compare_passing(self):
+        """Prime a param, snapshot, push the same bytes again, compare must pass."""
+        param_name = "model.layers.6.mlp.up_proj.weight"
+        same_tensor = torch.full(_UP_PROJ_SHAPE, 0.25, device="npu")
+
+        # Step 1: prime the param to a known value.
+        self.assertTrue(
+            self._update_weights([(param_name, same_tensor)]).json()["success"]
+        )
+        # Step 2: snapshot the now-primed state.
+        self.assertEqual(self._post("snapshot").status_code, 200)
+        # Step 3: push the exact same bytes again — should be a byte-perfect no-op.
+        self.assertTrue(
+            self._update_weights([(param_name, same_tensor)]).json()["success"]
+        )
+        # Step 4: compare passes.
+        resp = self._post("compare")
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+
+    def test_e_checksum_returns_ranks_with_hashes(self):
+        """checksum action must yield a ranks list with hex hashes per rank."""
+        resp = self._post("checksum")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertTrue(body["success"])
+        self.assertIn("ranks", body)
+        ranks = body["ranks"]
+        self.assertIsInstance(ranks, list)
+        self.assertGreaterEqual(len(ranks), 1)
+
+        first = ranks[0]
+        self.assertIn("checksums", first)
+        self.assertIn("parallelism_info", first)
+
+        info = first["parallelism_info"]
+        for key in (
+            "tp_rank",
+            "tp_size",
+            "dp_rank",
+            "dp_size",
+            "pp_rank",
+            "pp_size",
+            "rank",
+            "size",
+        ):
+            self.assertIn(key, info)
+
+        checksums = first["checksums"]
+        self.assertGreater(len(checksums), 0)
+        for name, h in checksums.items():
+            self.assertIsInstance(h, str)
+            self.assertEqual(len(h), 16, f"unexpected hash length for {name!r}: {h!r}")
+            int(h, 16)
+
+    def test_e_checksum_is_stable_across_calls(self):
+        """Two consecutive checksum calls with no weight update must match."""
+        first = self._post("checksum").json()["ranks"]
+        second = self._post("checksum").json()["ranks"]
+        self.assertEqual(first, second)
+
+    def test_e_checksum_changes_after_weight_update(self):
+        """Updating a tensor must change its corresponding hash."""
+        param_name = "model.layers.7.mlp.up_proj.weight"
+        fused_name = "model.layers.7.mlp.gate_up_proj.weight"
+
+        before = self._post("checksum").json()["ranks"][0]["checksums"]
+        before_hash = before.get(fused_name)
+        self.assertIsNotNone(before_hash, f"missing {fused_name!r} in checksum keys")
+
+        new_tensor = torch.full(_UP_PROJ_SHAPE, 0.5, device="npu")
+        self.assertTrue(
+            self._update_weights([(param_name, new_tensor)]).json()["success"]
+        )
+
+        after = self._post("checksum").json()["ranks"][0]["checksums"]
+        self.assertNotEqual(after[fused_name], before_hash)
+
+    def test_e_checksum_skips_non_persistent_buffers(self):
+        """No checksum entry should contain a non-persistent-buffer substring."""
+        ranks = self._post("checksum").json()["ranks"]
+        for rank in ranks:
+            for name in rank["checksums"]:
+                self.assertNotIn("cos_sin_cache", name)
+                self.assertNotIn("inv_freq", name)
+                self.assertNotIn("freqs_cis", name)
+                self.assertNotIn("_weight_fp32", name)
+
+    def test_z_snapshot_reset_compare_detects_diff(self):
+        """Destructive: leaves weights randomized. Named test_z_* so it runs last."""
+        self.assertEqual(self._post("snapshot").status_code, 200)
+        self.assertEqual(self._post("reset_tensors").status_code, 200)
+
+        resp = self._post("compare")
+        self.assertEqual(resp.status_code, 400)
+        body = resp.json()
+        self.assertFalse(body["success"])
+        self.assertIn("max_abs_err", body["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Port three mid-difficulty CUDA test files to Ascend NPU.

Files:
- test_npu_retract_decode.py: extend existing NPU test with paged/chunk-cache/long-output variants (page_size 128 for NPU)
- test_npu_scheduler_control.py: abort/rid/timeout scheduler controls with Llama-3.1-8B-Instruct
- test_npu_weight_checker_e2e.py: /weights_checker HTTP endpoint e2e with Qwen3-0.6B, device=npu

CI triggered via single-test-npu.yml.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->