### PR TITLE
NPU port: streaming_session_extra + multi_instance_release_memory_occupation (cases 9, 10)

### DIFF
--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -329,6 +329,7 @@ jobs:
           pip install zss pre-commit wandb>=0.16.0 tenacity==8.3.0 loguru openpyxl latex2sympy2 zstandard transformers-stream-generator tqdm-multiprocess pycocoevalcap
           pip install yt-dlp sentencepiece==0.1.99 nltk av ftfy sqlitedict==2.1.0 sacrebleu>=1.5.0 pytablewriter black==24.1.0 isort==5.13.2 peft>=0.2.0 accelerate>=0.29.1
           pip install jsonlines httpx==0.25.0 evaluate>=0.4.0 datasets==2.16.1 numexpr xgrammar==0.1.25 numpy==1.26.4 dotenv
+          pip install /root/.cache/torch_memory_saver-0.0.8-cp311-cp311-linux_aarch64.whl
           git clone --branch v0.3.3 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git
           cd ./lmms-eval
           nohup pip install . > lmmslog.txt 2>&1 &

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -40,7 +40,7 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            "test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py"
+            #"test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py"
             "test/registered/ascend/basic_function/rl/test_npu_multi_instance_release_memory_occupation.py"
           )
 

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -75,7 +75,8 @@ jobs:
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true
           source /usr/local/Ascend/nnal/atb/set_env.sh || true
-
+          pip install torch_memory_saver
+          
           current_date=$(date +%Y%m%d)
           log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
           rm -rf ${log_path}

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -15,9 +15,9 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-4
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,7 +40,8 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            "test/registered/ascend/llm_models/test_npu_deepseek_v3_2_w8a8.py"
+            "test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py"
+            "test/registered/ascend/basic_function/rl/test_npu_multi_instance_release_memory_occupation.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -40,7 +40,7 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            #"test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py"
+            "test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py"
             "test/registered/ascend/basic_function/rl/test_npu_multi_instance_release_memory_occupation.py"
           )
 

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -27,7 +27,7 @@ jobs:
           npu-smi info
 
       - name: Run test
-        timeout-minutes: 120
+        timeout-minutes: 300
         env:
           SGLANG_USE_MODELSCOPE: true
           HF_ENDPOINT: https://hf-mirror.com

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -27,7 +27,7 @@ jobs:
           npu-smi info
 
       - name: Run test
-        timeout-minutes: 300
+        timeout-minutes: 1800
         env:
           SGLANG_USE_MODELSCOPE: true
           HF_ENDPOINT: https://hf-mirror.com

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -40,7 +40,7 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            "test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py"
+            #"test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py"
             "test/registered/ascend/basic_function/rl/test_npu_multi_instance_release_memory_occupation.py"
           )
 
@@ -75,7 +75,7 @@ jobs:
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true
           source /usr/local/Ascend/nnal/atb/set_env.sh || true
-          pip install torch_memory_saver
+          pip install /root/.cache/torch_memory_saver-0.0.8-cp311-cp311-linux_aarch64.whl
           
           current_date=$(date +%Y%m%d)
           log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -15,9 +15,9 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc
-    runs-on: linux-aarch64-a3-4
+    runs-on: linux-aarch64-a3-2
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
           npu-smi info
 
       - name: Run test
-        timeout-minutes: 1800
+        timeout-minutes: 120
         env:
           SGLANG_USE_MODELSCOPE: true
           HF_ENDPOINT: https://hf-mirror.com
@@ -40,8 +40,7 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            #"test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py"
-            "test/registered/ascend/basic_function/rl/test_npu_multi_instance_release_memory_occupation.py"
+            "test/registered/ascend/llm_models/test_npu_deepseek_v3_2_w8a8.py"
           )
 
           for test_case in "${test_cases[@]}"; do
@@ -75,8 +74,7 @@ jobs:
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true
           source /usr/local/Ascend/nnal/atb/set_env.sh || true
-          pip install /root/.cache/torch_memory_saver-0.0.8-cp311-cp311-linux_aarch64.whl
-          
+
           current_date=$(date +%Y%m%d)
           log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
           rm -rf ${log_path}

--- a/test/registered/ascend/basic_function/rl/test_npu_multi_instance_release_memory_occupation.py
+++ b/test/registered/ascend/basic_function/rl/test_npu_multi_instance_release_memory_occupation.py
@@ -99,7 +99,6 @@ class EngineWrapper:
             # to ServerArgs, so these match the CLI flag names exactly.
             attention_backend="ascend",
             disable_cuda_graph=True,
-            disable_piecewise_cuda_graph=True,
         )
         self._engine = None
         if first_rank_in_node:

--- a/test/registered/ascend/basic_function/rl/test_npu_multi_instance_release_memory_occupation.py
+++ b/test/registered/ascend/basic_function/rl/test_npu_multi_instance_release_memory_occupation.py
@@ -1,0 +1,318 @@
+"""
+NPU port of test/registered/rl/test_multi_instance_release_memory_occupation.py.
+
+Verifies multi-instance memory release/resume on Ascend NPU:
+  - Multi-process (dp_size * tp_size) spawns one EngineWrapper per rank.
+  - Each wrapper holds an SglangEngine with `enable_memory_saver=True` so
+    `release_memory_occupation` / `resume_memory_occupation` can actually
+    pause/resume KV cache and model weights via the
+    `TorchMemorySaverAdapter` pause/resume hooks.
+  - The test asserts NPU HBM drops when KV cache / weights are released,
+    rises when an HF model is loaded, drops again on HF model release,
+    and rises once more when KV cache is resumed.
+
+NPU-specific adaptations:
+  - `torch.cuda` → `torch.npu` (mem_get_info, set_device, empty_cache).
+  - `cuda:{rank}` → `npu:{rank}` for `dist.init_process_group(device_id=...)`.
+  - `dist.init_process_group` uses `backend="hccl"` (Huawei Collective
+    Communication Library) instead of the nccl default.
+  - Engine kwargs add `attention_backend="ascend"`,
+    `disable_cuda_graph=True`, `disable_piecewise_cuda_graph=True` (NPU
+    cannot use CUDA graphs).
+  - Model paths use NPU-local weights (Llama-3.2-1B-Instruct / Llama-3.2-1B
+    base) instead of the HF hub defaults.
+  - `mp.set_start_method("spawn", force=True)` is set at module import so
+    NPU multiprocessing uses spawn (required for torch_npu).
+  - CI suite is `full-4-npu-a3` because `dp_size=2 * tp_size=2` needs 4 NPUs.
+
+Note: `enable_memory_saver=True` requires `torch_memory_saver` to be
+installed in the CI image. NPU compatibility is unverified upstream; if
+the package is absent the Engine constructor raises ImportError.
+"""
+
+import gc
+import multiprocessing
+import os
+import traceback
+import unittest
+from multiprocessing import Process
+from typing import Iterable, Tuple
+
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
+from transformers import AutoModelForCausalLM
+
+from sglang.srt.entrypoints.engine import Engine as SglangEngine
+from sglang.test.ascend.test_ascend_utils import (
+    LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+    LLAMA_3_2_1B_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase, find_available_port
+
+# NPU multiprocessing must use spawn; force=True so re-imports in test
+# runners don't choke on an already-set start method.
+multiprocessing.set_start_method("spawn", force=True)
+
+register_npu_ci(est_time=600, suite="full-4-npu-a3", nightly=True)
+
+TEST_SUITE = dict(
+    model_path=LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH,
+    base_model_path=LLAMA_3_2_1B_WEIGHTS_PATH,
+    mem_fraction_static=0.83,
+    dp_size=2,
+    tp_size=2,
+)
+
+# Minimum expected memory change in MB for each operation.
+# Llama-3.2-1B bf16 is ~2GB total, ~1GB per TP rank.
+# KV cache with mem_fraction_static=0.83 is much larger.
+MIN_DELTA_MB = 200
+
+
+class EngineWrapper:
+    """
+    A wrapper around Sglang engine to mock multi instance cases such as RL training.
+    """
+
+    def __init__(
+        self, model_path, random_seed, mem_fraction_static, device_mesh_cpu, base_gpu_id
+    ):
+        self._device_mesh_cpu = device_mesh_cpu
+        self._tp_rank = device_mesh_cpu.get_local_rank()
+        self._rank = device_mesh_cpu.get_rank()
+        self._tp_size = device_mesh_cpu.size()
+        tp_size_per_node = self._tp_size
+        node_rank = self._tp_rank // tp_size_per_node
+        first_rank_in_node = self._tp_rank % tp_size_per_node == 0
+        engine_kwargs = dict(
+            model_path=model_path,
+            random_seed=random_seed,
+            mem_fraction_static=mem_fraction_static,
+            base_gpu_id=base_gpu_id,
+            enable_memory_saver=True,
+            tp_size=self._tp_size,
+            node_rank=node_rank,
+            nnodes=1,
+            # NPU-specific server args; SglangEngine forwards unknown kwargs
+            # to ServerArgs, so these match the CLI flag names exactly.
+            attention_backend="ascend",
+            disable_cuda_graph=True,
+            disable_piecewise_cuda_graph=True,
+        )
+        self._engine = None
+        if first_rank_in_node:
+            os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "0"
+            self._engine = SglangEngine(**engine_kwargs)
+
+        dist.barrier(group=self._device_mesh_cpu.get_group())
+
+    def update_weights_from_tensor(
+        self, named_tensors: Iterable[Tuple[str, torch.Tensor]]
+    ):
+        if self._tp_rank == 0:
+            self._engine.update_weights_from_tensor(list(named_tensors))
+            self._engine.flush_cache()
+        dist.barrier(group=self._device_mesh_cpu.get_group())
+
+    def release_memory_occupation(self, tags):
+        if self._tp_rank == 0:
+            self._engine.release_memory_occupation(tags)
+        dist.barrier(group=self._device_mesh_cpu.get_group())
+
+    def resume_memory_occupation(self, tags):
+        if self._tp_rank == 0:
+            self._engine.resume_memory_occupation(tags)
+        dist.barrier(group=self._device_mesh_cpu.get_group())
+
+    def shutdown(self):
+        if self._tp_rank == 0:
+            self._engine.shutdown()
+        dist.barrier(group=self._device_mesh_cpu.get_group())
+
+
+def get_npu_memory_mb(device_id: int) -> float:
+    """Return device-level NPU memory used in MB."""
+    free, total = torch.npu.mem_get_info(device_id)
+    return (total - free) / (1024**2)
+
+
+def assert_memory_decreased(before_mb, after_mb, step_name):
+    delta = before_mb - after_mb
+    assert delta > MIN_DELTA_MB, (
+        f"[{step_name}] Expected memory decrease > {MIN_DELTA_MB} MB, "
+        f"got delta={delta:.0f} MB (before={before_mb:.0f}, after={after_mb:.0f})"
+    )
+
+
+def assert_memory_increased(before_mb, after_mb, step_name):
+    delta = after_mb - before_mb
+    assert delta > MIN_DELTA_MB, (
+        f"[{step_name}] Expected memory increase > {MIN_DELTA_MB} MB, "
+        f"got delta={delta:.0f} MB (before={before_mb:.0f}, after={after_mb:.0f})"
+    )
+
+
+class TestNPUMultiInstanceReleaseMemoryOccupation(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        # `force=True` here would error because the module-level call above
+        # already set spawn; just ensure it's still spawn.
+        if multiprocessing.get_start_method(allow_none=True) != "spawn":
+            multiprocessing.set_start_method("spawn", force=True)
+
+    def test_multi_instance_release_memory_occupation(self):
+        master_port = find_available_port(23456)
+
+        dp_size = TEST_SUITE["dp_size"]
+        tp_size = TEST_SUITE["tp_size"]
+        world_size = dp_size * tp_size
+        processes = []
+        output_reader, output_writer = multiprocessing.Pipe(duplex=False)
+        for rank in range(world_size):
+            p = Process(
+                target=_run_sglang_subprocess,
+                kwargs=dict(
+                    rank=rank,
+                    dp_size=dp_size,
+                    tp_size=tp_size,
+                    model_path=TEST_SUITE["model_path"],
+                    base_model_path=TEST_SUITE["base_model_path"],
+                    master_port=master_port,
+                    output_writer=output_writer,
+                    mem_fraction_static=TEST_SUITE["mem_fraction_static"],
+                ),
+            )
+            p.start()
+            processes.append(p)
+
+        for _ in range(world_size):
+            self.assertTrue(
+                output_reader.recv(),
+                f"Subprocess fail. Check the logs above.",
+            )
+        for p in processes:
+            p.join()
+
+
+def _run_sglang_subprocess(
+    rank: int,
+    dp_size: int,
+    tp_size: int,
+    model_path: str,
+    base_model_path: str,
+    master_port: int,
+    output_writer,
+    mem_fraction_static: float,
+):
+    engine = None
+    try:
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(master_port)
+        # HCCL is the NPU collective backend (analogous to NCCL on CUDA).
+        torch.npu.set_device(rank)
+        dist.init_process_group(
+            backend="hccl",
+            rank=rank,
+            device_id=torch.device(f"npu:{rank}"),
+            world_size=dp_size * tp_size,
+        )
+        torch.npu.synchronize()
+
+        base_gpu_id = rank // tp_size * tp_size
+        mesh_kwargs = dict(
+            mesh_shape=(dp_size, tp_size, 1), mesh_dim_names=["dp", "tp", "pp"]
+        )
+        inference_device_mesh_cpu = init_device_mesh("cpu", **mesh_kwargs)
+
+        # Only TP master ranks (rank % tp_size == 0) create the Engine and
+        # measure memory. Non-master ranks share the same NPU and would see
+        # device-level memory from the master's Engine workers, causing
+        # unpredictable assertion results.
+        is_tp_master = rank % tp_size == 0
+
+        engine = EngineWrapper(
+            model_path=model_path,
+            random_seed=42,
+            mem_fraction_static=mem_fraction_static,
+            device_mesh_cpu=inference_device_mesh_cpu["tp"],
+            base_gpu_id=base_gpu_id,
+        )
+        print(f"subprocess[{rank=}] engine created, {is_tp_master=}", flush=True)
+
+        # 1 - release kv cache
+        if is_tp_master:
+            mem_before = get_npu_memory_mb(rank)
+            print(f"NPU{rank} before releasing KV cache: {mem_before:.0f} MB")
+        engine.release_memory_occupation(tags=["kv_cache"])
+        if is_tp_master:
+            mem_after = get_npu_memory_mb(rank)
+            assert_memory_decreased(mem_before, mem_after, "release KV cache")
+
+        # 2 - release sglang weights
+        if is_tp_master:
+            mem_before = get_npu_memory_mb(rank)
+            print(f"NPU{rank} before releasing weights: {mem_before:.0f} MB")
+        engine.release_memory_occupation(tags=["weights"])
+        if is_tp_master:
+            mem_after = get_npu_memory_mb(rank)
+            assert_memory_decreased(mem_before, mem_after, "release weights")
+
+        # 3 - load hf model (TP master only)
+        hf_model = None
+        if is_tp_master:
+            mem_before = get_npu_memory_mb(rank)
+            print(f"NPU{rank} before loading HF model: {mem_before:.0f} MB")
+            # Avoid device_map= which triggers accelerate dispatch hooks in
+            # transformers v5, preventing clean memory release on del.
+            hf_model = AutoModelForCausalLM.from_pretrained(
+                base_model_path,
+                torch_dtype="bfloat16",
+            ).to(f"npu:{rank}")
+            mem_after = get_npu_memory_mb(rank)
+            assert_memory_increased(mem_before, mem_after, "load HF model")
+        dist.barrier(group=inference_device_mesh_cpu["tp"].get_group())
+
+        # 4 - resume sglang weights and update from hf model
+        engine.resume_memory_occupation(tags=["weights"])
+        engine.update_weights_from_tensor(
+            named_tensors=list(hf_model.named_parameters()) if hf_model else []
+        )
+
+        # 5 - release hf model (TP master only)
+        if is_tp_master:
+            mem_before = get_npu_memory_mb(rank)
+            print(f"NPU{rank} before releasing HF model: {mem_before:.0f} MB")
+            del hf_model
+            gc.collect()
+            torch.npu.empty_cache()
+            mem_after = get_npu_memory_mb(rank)
+            assert_memory_decreased(mem_before, mem_after, "release HF model")
+        dist.barrier(group=inference_device_mesh_cpu["tp"].get_group())
+
+        # 6 - resume kv cache
+        if is_tp_master:
+            mem_before = get_npu_memory_mb(rank)
+            print(f"NPU{rank} before resuming KV cache: {mem_before:.0f} MB")
+        engine.resume_memory_occupation(tags=["kv_cache"])
+        if is_tp_master:
+            mem_after = get_npu_memory_mb(rank)
+            assert_memory_increased(mem_before, mem_after, "resume KV cache")
+            print(f"NPU{rank} final memory: {mem_after:.0f} MB")
+
+        execution_ok = True
+    except Exception as e:
+        print(f"subprocess[{rank=}] has error: {e}", flush=True)
+        traceback.print_exc()
+        execution_ok = False
+
+    output_writer.send(execution_ok)
+    output_writer.close()
+
+    if engine:
+        engine.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/rl/test_npu_multi_instance_release_memory_occupation.py
+++ b/test/registered/ascend/basic_function/rl/test_npu_multi_instance_release_memory_occupation.py
@@ -17,8 +17,7 @@ NPU-specific adaptations:
   - `dist.init_process_group` uses `backend="hccl"` (Huawei Collective
     Communication Library) instead of the nccl default.
   - Engine kwargs add `attention_backend="ascend"`,
-    `disable_cuda_graph=True`, `disable_piecewise_cuda_graph=True` (NPU
-    cannot use CUDA graphs).
+    `disable_cuda_graph=True`, `disable_piecewise_cuda_graph=True`.
   - Model paths use NPU-local weights (Llama-3.2-1B-Instruct / Llama-3.2-1B
     base) instead of the HF hub defaults.
   - `mp.set_start_method("spawn", force=True)` is set at module import so

--- a/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
+++ b/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
@@ -1,0 +1,226 @@
+"""
+Streaming session extra tests for NPU.
+
+Ported from test/registered/sessions/test_streaming_session_extra.py.
+Adapted for Ascend NPU backend:
+  - Replaces CUDA model paths with NPU-local weights (Llama-3.1-8B-Instruct
+    and its EAGLE3 draft).
+  - Adds `--attention-backend ascend`, `--disable-cuda-graph`,
+    `--disable-piecewise-cuda-graph` to all server launches.
+  - Sets `PYTORCH_NPU_ALLOC_CONF=expandable_segments:True` and a longer
+    `HCCL_EXEC_TIMEOUT` for stability under multi-turn streaming workloads.
+  - Adapts `--page-size` to NPU-friendly values (128/4 instead of 256),
+    since Ascend's page_size default of 128 must divide `chunked_prefill_size`.
+
+Tests:
+  - TestNPUStreamingSessionRetractMixedChunk: retract + mixed-chunk
+  - TestNPUStreamingSessionRetractLargePage: retract + page=128
+  - TestNPUStreamingSessionEagle: EAGLE3 spec v1 (overlap disabled)
+  - TestNPUStreamingSessionEagleV2: EAGLE3 spec v2 (overlap on)
+  - TestNPUStreamingSessionEagleRetractLargePage: EAGLE3 + retract + page=128
+"""
+
+import os
+import unittest
+
+from sglang.srt.environ import envs
+from sglang.srt.utils.hf_transformers_utils import get_tokenizer
+from sglang.test.ascend.test_ascend_utils import (
+    EAGLE3_LLAMA3_1_INSTRUCT_8B_WEIGHTS_PATH,
+    LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.kits.streaming_session_kit import StreamingSessionKitMixin
+from sglang.test.server_fixtures.streaming_session_fixture import (
+    StreamingSessionServerBase,
+)
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=900, suite="full-1-npu-a3", nightly=True)
+
+
+class NPUStreamingSessionExtraServerBase(StreamingSessionServerBase):
+    """Base server fixture for NPU streaming-session extra tests.
+
+    Mirrors `NPUStreamingSessionServerBase` in test_npu_streaming_session.py
+    so the two files stay consistent. Lives locally to keep the file
+    self-contained.
+    """
+
+    npu_env = {
+        **os.environ,
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+        "HCCL_EXEC_TIMEOUT": "200",
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(1)
+            )
+            stack.enter_context(envs.SGLANG_CHECK_KV_PAGE_INVARIANTS.override(True))
+            for name, val in cls.env_overrides:
+                stack.enter_context(getattr(envs, name).override(val))
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=["--enable-streaming-session"] + list(cls.extra_args),
+                env=cls.npu_env,
+            )
+        cls.tokenizer = get_tokenizer(cls.model)
+
+
+# NPU-common server args shared by all variants below. Kept as a list so
+# subclasses can extend (not replace) them via unpacking.
+_NPU_COMMON_ARGS = [
+    "--trust-remote-code",
+    "--attention-backend",
+    "ascend",
+    "--disable-cuda-graph",
+    "--disable-piecewise-cuda-graph",
+    "--enable-streaming-session",
+    "--mem-fraction-static",
+    "0.7",
+]
+
+
+class TestNPUStreamingSessionRetractMixedChunk(
+    NPUStreamingSessionExtraServerBase, StreamingSessionKitMixin
+):
+    """Retract + --enable-mixed-chunk.
+
+    `chunked-prefill-size` must be divisible by NPU page_size (128) to
+    avoid the scheduler assertion; 128 itself satisfies this and keeps
+    prefill chunks small enough to exercise mixed-chunk interleaving.
+    """
+
+    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+    extra_args = [
+        *_NPU_COMMON_ARGS,
+        "--chunked-prefill-size",
+        "128",
+        "--enable-mixed-chunk",
+        "--page-size",
+        "128",
+    ]
+    env_overrides = [("SGLANG_TEST_RETRACT", True)]
+
+
+class TestNPUStreamingSessionRetractLargePage(
+    NPUStreamingSessionExtraServerBase, StreamingSessionKitMixin
+):
+    """Retract + page=128: exercises page-aligned `_free_tail`.
+
+    Partial-page free would corrupt pages still holding committed tokens.
+    The CUDA original uses page=256; on Ascend we use the NPU default of
+    128 (256 is not supported by the ascend backend). `chunked-prefill-size`
+    4096 is divisible by 128.
+    """
+
+    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+    extra_args = [
+        *_NPU_COMMON_ARGS,
+        "--chunked-prefill-size",
+        "4096",
+        "--page-size",
+        "128",
+    ]
+    env_overrides = [("SGLANG_TEST_RETRACT", True)]
+
+
+# Common EAGLE3 spec args; reused by Eagle/EagleV2/EagleRetractLargePage variants.
+# Uses NPU-local draft weights instead of the HF hub DEFAULT_DRAFT_MODEL_EAGLE3.
+_EAGLE3_SPEC_ARGS = [
+    "--speculative-algorithm",
+    "EAGLE3",
+    "--speculative-draft-model-path",
+    EAGLE3_LLAMA3_1_INSTRUCT_8B_WEIGHTS_PATH,
+    "--speculative-num-steps",
+    "3",
+    "--speculative-eagle-topk",
+    "1",
+    "--speculative-num-draft-tokens",
+    "4",
+]
+
+
+class TestNPUStreamingSessionEagle(
+    NPUStreamingSessionExtraServerBase, StreamingSessionKitMixin
+):
+    """EAGLE3 spec v1 (overlap disabled); offset=-1 — see kit's note."""
+
+    kv_inherit_offset = -1
+    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+    extra_args = [
+        *_NPU_COMMON_ARGS,
+        "--disable-overlap-schedule",
+        "--chunked-prefill-size",
+        "512",
+        *_EAGLE3_SPEC_ARGS,
+        "--page-size",
+        "4",
+    ]
+    env_overrides = [("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", True)]
+
+
+class TestNPUStreamingSessionEagleV2(
+    NPUStreamingSessionExtraServerBase, StreamingSessionKitMixin
+):
+    """EAGLE3 spec v2 (overlap on)."""
+
+    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+    extra_args = [
+        *_NPU_COMMON_ARGS,
+        "--chunked-prefill-size",
+        "512",
+        *_EAGLE3_SPEC_ARGS,
+        "--page-size",
+        "4",
+    ]
+    env_overrides = [
+        ("SGLANG_ENABLE_SPEC_V2", True),
+        ("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", True),
+    ]
+
+
+class TestNPUStreamingSessionEagleRetractLargePage(
+    NPUStreamingSessionExtraServerBase, StreamingSessionKitMixin
+):
+    """EAGLE3 spec v1 + retract + page=128: max-pressure on `_free_tail`
+    (spec tail + retract alloc-commit gap + page alignment)."""
+
+    kv_inherit_offset = -1
+    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+    extra_args = [
+        *_NPU_COMMON_ARGS,
+        "--disable-overlap-schedule",
+        "--chunked-prefill-size",
+        "4096",
+        *_EAGLE3_SPEC_ARGS,
+        "--page-size",
+        "128",
+    ]
+    env_overrides = [
+        ("SGLANG_TEST_RETRACT", True),
+        ("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", True),
+    ]
+
+
+__all__ = [
+    "TestNPUStreamingSessionRetractMixedChunk",
+    "TestNPUStreamingSessionRetractLargePage",
+    "TestNPUStreamingSessionEagle",
+    "TestNPUStreamingSessionEagleV2",
+    "TestNPUStreamingSessionEagleRetractLargePage",
+]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
+++ b/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
@@ -3,8 +3,11 @@ Streaming session extra tests for NPU.
 
 Ported from test/registered/sessions/test_streaming_session_extra.py.
 Adapted for Ascend NPU backend:
-  - Replaces CUDA model paths with NPU-local weights (Llama-3.1-8B-Instruct
-    and its EAGLE3 draft).
+  - Replaces CUDA model paths with NPU-local weights. Uses Qwen3-8B +
+    Qwen3-8B_eagle3 for EAGLE3 variants (Llama-3.1-8B + EAGLE3-Llama-3.1-8B
+    is incompatible with NPU aclnnRmsNorm: the draft's RMSNorm weight is
+    float16 while the main model hidden state is bfloat16, a combination
+    not in the supported list).
   - Adds `--attention-backend ascend`, `--disable-cuda-graph`,
     `--disable-piecewise-cuda-graph` to all server launches.
   - Sets `PYTORCH_NPU_ALLOC_CONF=expandable_segments:True` and a longer
@@ -16,7 +19,7 @@ Tests:
   - TestNPUStreamingSessionRetractMixedChunk: retract + mixed-chunk
   - TestNPUStreamingSessionRetractLargePage: retract + page=128
   - TestNPUStreamingSessionEagle: EAGLE3 spec v1 (overlap disabled)
-  - TestNPUStreamingSessionEagleV2: EAGLE3 spec v2 (overlap on)
+  - TestNPUStreamingSessionEagleV2: EAGLE3 spec v2 (overlap on, default env)
   - TestNPUStreamingSessionEagleRetractLargePage: EAGLE3 + retract + page=128
 """
 
@@ -26,8 +29,8 @@ import unittest
 from sglang.srt.environ import envs
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 from sglang.test.ascend.test_ascend_utils import (
-    EAGLE3_LLAMA3_1_INSTRUCT_8B_WEIGHTS_PATH,
-    LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH,
+    QWEN3_8B_EAGLE3_WEIGHTS_PATH,
+    QWEN3_8B_WEIGHTS_PATH,
 )
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.kits.streaming_session_kit import StreamingSessionKitMixin
@@ -101,7 +104,7 @@ class TestNPUStreamingSessionRetractMixedChunk(
     prefill chunks small enough to exercise mixed-chunk interleaving.
     """
 
-    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+    model = QWEN3_8B_WEIGHTS_PATH
     extra_args = [
         *_NPU_COMMON_ARGS,
         "--chunked-prefill-size",
@@ -124,7 +127,7 @@ class TestNPUStreamingSessionRetractLargePage(
     4096 is divisible by 128.
     """
 
-    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+    model = QWEN3_8B_WEIGHTS_PATH
     extra_args = [
         *_NPU_COMMON_ARGS,
         "--chunked-prefill-size",
@@ -136,12 +139,13 @@ class TestNPUStreamingSessionRetractLargePage(
 
 
 # Common EAGLE3 spec args; reused by Eagle/EagleV2/EagleRetractLargePage variants.
-# Uses NPU-local draft weights instead of the HF hub DEFAULT_DRAFT_MODEL_EAGLE3.
+# Uses NPU-local Qwen3-8B_eagle3 draft weights (Llama-3.1-8B + EAGLE3-Llama-3.1-8B
+# is incompatible with NPU aclnnRmsNorm — see module docstring).
 _EAGLE3_SPEC_ARGS = [
     "--speculative-algorithm",
     "EAGLE3",
     "--speculative-draft-model-path",
-    EAGLE3_LLAMA3_1_INSTRUCT_8B_WEIGHTS_PATH,
+    QWEN3_8B_EAGLE3_WEIGHTS_PATH,
     "--speculative-num-steps",
     "3",
     "--speculative-eagle-topk",
@@ -157,7 +161,7 @@ class TestNPUStreamingSessionEagle(
     """EAGLE3 spec v1 (overlap disabled); offset=-1 — see kit's note."""
 
     kv_inherit_offset = -1
-    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+    model = QWEN3_8B_WEIGHTS_PATH
     extra_args = [
         *_NPU_COMMON_ARGS,
         "--disable-overlap-schedule",
@@ -173,9 +177,14 @@ class TestNPUStreamingSessionEagle(
 class TestNPUStreamingSessionEagleV2(
     NPUStreamingSessionExtraServerBase, StreamingSessionKitMixin
 ):
-    """EAGLE3 spec v2 (overlap on)."""
+    """EAGLE3 spec v2 (overlap on).
 
-    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+    Note: `SGLANG_ENABLE_SPEC_V2` defaults to True in current sglang; no
+    explicit env override needed. Older CI images may not have this attr
+    on `Envs`, so overriding it would raise `AttributeError`.
+    """
+
+    model = QWEN3_8B_WEIGHTS_PATH
     extra_args = [
         *_NPU_COMMON_ARGS,
         "--chunked-prefill-size",
@@ -184,10 +193,7 @@ class TestNPUStreamingSessionEagleV2(
         "--page-size",
         "4",
     ]
-    env_overrides = [
-        ("SGLANG_ENABLE_SPEC_V2", True),
-        ("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", True),
-    ]
+    env_overrides = [("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", True)]
 
 
 class TestNPUStreamingSessionEagleRetractLargePage(
@@ -197,7 +203,7 @@ class TestNPUStreamingSessionEagleRetractLargePage(
     (spec tail + retract alloc-commit gap + page alignment)."""
 
     kv_inherit_offset = -1
-    model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+    model = QWEN3_8B_WEIGHTS_PATH
     extra_args = [
         *_NPU_COMMON_ARGS,
         "--disable-overlap-schedule",

--- a/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
+++ b/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
@@ -26,6 +26,11 @@ Tests:
 import os
 import unittest
 
+import threading
+import time
+
+import requests
+
 from sglang.srt.environ import envs
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 from sglang.test.ascend.test_ascend_utils import (
@@ -43,6 +48,210 @@ from sglang.test.test_utils import (
 )
 
 register_npu_ci(est_time=900, suite="full-1-npu-a3", nightly=True)
+
+
+# Qwen3-8B has a 40960-token context. The upstream kit hard-codes
+# `max_new_tokens=100000` in two abort-recovery tests, which the server
+# rejects with HTTP 400 ("Requested token count exceeds the model's maximum
+# context length"), causing `KeyError: 'meta_info'`. We override those two
+# methods with a smaller `max_new_tokens` that fits Qwen3-8B's context.
+# See .claude/2.log for the original failure.
+_NPU_ABORT_MAX_NEW_TOKENS = 40000
+
+
+class NPUStreamingSessionKitMixin(StreamingSessionKitMixin):
+    """NPU-specific overrides for StreamingSessionKitMixin.
+
+    Overrides `test_nth_mid_abort_recovery` and `test_first_mid_abort_recovery`
+    to use a smaller `max_new_tokens` (40000 < Qwen3-8B's 40960 context).
+    Logic is otherwise identical to the upstream kit.
+    """
+
+    def test_nth_mid_abort_recovery(self) -> None:
+        """Abort an Nth-turn request mid-decode; session rolls back to last
+        successful turn."""
+        requests.post(self.base_url + "/flush_cache")
+
+        resp = requests.post(
+            self.base_url + "/open_session",
+            json={"capacity_of_str_len": 50000, "streaming": True},
+        )
+        self.assertEqual(resp.status_code, 200)
+        session_id = resp.json()
+
+        try:
+            # Turn 1: normal generate to create slot.
+            ids_1 = self.tokenizer.encode("Tell me a very long story about a wizard.")
+            resp_1 = requests.post(
+                self.base_url + "/generate",
+                json={
+                    "input_ids": ids_1,
+                    "sampling_params": {"temperature": 0, "max_new_tokens": 16},
+                    "session_params": {"id": session_id, "rid": None},
+                },
+                timeout=30,
+            )
+            self.assertEqual(resp_1.status_code, 200, resp_1.text)
+            data_1 = resp_1.json()
+            turn_1_total = (
+                data_1["meta_info"]["prompt_tokens"]
+                + data_1["meta_info"]["completion_tokens"]
+            )
+
+            # Turn 2: long generate, then abort mid-decode.
+            ids_2 = self.tokenizer.encode(" Continue the story in great detail.")
+
+            result = [None]
+
+            def do_generate():
+                r = requests.post(
+                    self.base_url + "/generate",
+                    json={
+                        "input_ids": ids_2,
+                        "sampling_params": {
+                            "temperature": 0,
+                            "max_new_tokens": _NPU_ABORT_MAX_NEW_TOKENS,
+                        },
+                        "session_params": {"id": session_id, "rid": None},
+                    },
+                    timeout=60,
+                )
+                result[0] = r
+
+            t = threading.Thread(target=do_generate)
+            t.start()
+            time.sleep(0.5)
+            abort_resp = requests.post(
+                self.base_url + "/abort_request",
+                json={"rid": "", "abort_all": True},
+                timeout=10,
+            )
+            self.assertEqual(abort_resp.status_code, 200, abort_resp.text)
+            t.join(timeout=30)
+
+            self.assertIsNotNone(result[0], "Turn 2 should have returned")
+            data_2 = result[0].json()
+            self.assertEqual(
+                data_2["meta_info"]["finish_reason"]["type"],
+                "abort",
+                "Turn 2 should be aborted, not finished normally",
+            )
+
+            # Turn 3: recovery. Rolls back to turn 1.
+            ids_3 = self.tokenizer.encode(" What happens next?")
+            for attempt in range(20):
+                resp_3 = requests.post(
+                    self.base_url + "/generate",
+                    json={
+                        "input_ids": ids_3,
+                        "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+                        "session_params": {"id": session_id, "rid": None},
+                    },
+                    timeout=30,
+                )
+                if resp_3.status_code == 200:
+                    break
+                time.sleep(0.5)
+            self.assertEqual(resp_3.status_code, 200, resp_3.text)
+            data_3 = resp_3.json()
+            # prompt_tokens = turn_1_total + append (BOS stripped).
+            bos = 1 if ids_3[0] == self.tokenizer.bos_token_id else 0
+            expected_prompt_3 = turn_1_total + len(ids_3) - bos
+            self.assertEqual(
+                data_3["meta_info"]["prompt_tokens"],
+                expected_prompt_3,
+                "prompt_tokens must equal turn_1_total + append (no stale abort context)",
+            )
+        finally:
+            requests.post(
+                self.base_url + "/close_session",
+                json={"session_id": session_id},
+            )
+
+        health = requests.get(self.base_url + "/health", timeout=10)
+        self.assertEqual(health.status_code, 200)
+
+    def test_first_mid_abort_recovery(self) -> None:
+        """Abort the very first request mid-decode (no slot yet; ephemeral
+        slot is created and nuked). Session must still be usable."""
+        requests.post(self.base_url + "/flush_cache")
+
+        resp = requests.post(
+            self.base_url + "/open_session",
+            json={"capacity_of_str_len": 50000, "streaming": True},
+        )
+        self.assertEqual(resp.status_code, 200)
+        session_id = resp.json()
+
+        try:
+            ids_1 = self.tokenizer.encode("Tell me a very long story about a wizard.")
+
+            result = [None]
+
+            def do_generate():
+                r = requests.post(
+                    self.base_url + "/generate",
+                    json={
+                        "input_ids": ids_1,
+                        "sampling_params": {
+                            "temperature": 0,
+                            "max_new_tokens": _NPU_ABORT_MAX_NEW_TOKENS,
+                        },
+                        "session_params": {"id": session_id, "rid": None},
+                    },
+                    timeout=60,
+                )
+                result[0] = r
+
+            t = threading.Thread(target=do_generate)
+            t.start()
+            time.sleep(0.5)
+            abort_resp = requests.post(
+                self.base_url + "/abort_request",
+                json={"rid": "", "abort_all": True},
+                timeout=10,
+            )
+            self.assertEqual(abort_resp.status_code, 200, abort_resp.text)
+            t.join(timeout=30)
+
+            self.assertIsNotNone(result[0], "Turn 1 should have returned")
+            data_1 = result[0].json()
+            self.assertEqual(
+                data_1["meta_info"]["finish_reason"]["type"],
+                "abort",
+                "Turn 1 should be aborted, not finished normally",
+            )
+
+            # Turn 2: recovery. No inherited context (req_nodes empty).
+            ids_2 = self.tokenizer.encode("Tell me a short joke.")
+            for attempt in range(20):
+                resp_2 = requests.post(
+                    self.base_url + "/generate",
+                    json={
+                        "input_ids": ids_2,
+                        "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+                        "session_params": {"id": session_id, "rid": None},
+                    },
+                    timeout=30,
+                )
+                if resp_2.status_code == 200:
+                    break
+                time.sleep(0.5)
+            self.assertEqual(resp_2.status_code, 200, resp_2.text)
+            data_2 = resp_2.json()
+            self.assertEqual(
+                data_2["meta_info"]["prompt_tokens"],
+                len(ids_2),
+                "prompt_tokens must equal turn 2 input only (no inherited context)",
+            )
+        finally:
+            requests.post(
+                self.base_url + "/close_session",
+                json={"session_id": session_id},
+            )
+
+        health = requests.get(self.base_url + "/health", timeout=10)
+        self.assertEqual(health.status_code, 200)
 
 
 class NPUStreamingSessionExtraServerBase(StreamingSessionServerBase):
@@ -95,7 +304,7 @@ _NPU_COMMON_ARGS = [
 
 
 class TestNPUStreamingSessionRetractMixedChunk(
-    NPUStreamingSessionExtraServerBase, StreamingSessionKitMixin
+    NPUStreamingSessionExtraServerBase, NPUStreamingSessionKitMixin
 ):
     """Retract + --enable-mixed-chunk.
 
@@ -117,7 +326,7 @@ class TestNPUStreamingSessionRetractMixedChunk(
 
 
 class TestNPUStreamingSessionRetractLargePage(
-    NPUStreamingSessionExtraServerBase, StreamingSessionKitMixin
+    NPUStreamingSessionExtraServerBase, NPUStreamingSessionKitMixin
 ):
     """Retract + page=128: exercises page-aligned `_free_tail`.
 
@@ -156,7 +365,7 @@ _EAGLE3_SPEC_ARGS = [
 
 
 class TestNPUStreamingSessionEagle(
-    NPUStreamingSessionExtraServerBase, StreamingSessionKitMixin
+    NPUStreamingSessionExtraServerBase, NPUStreamingSessionKitMixin
 ):
     """EAGLE3 spec v1 (overlap disabled); offset=-1 — see kit's note."""
 
@@ -175,7 +384,7 @@ class TestNPUStreamingSessionEagle(
 
 
 class TestNPUStreamingSessionEagleV2(
-    NPUStreamingSessionExtraServerBase, StreamingSessionKitMixin
+    NPUStreamingSessionExtraServerBase, NPUStreamingSessionKitMixin
 ):
     """EAGLE3 spec v2 (overlap on).
 
@@ -197,7 +406,7 @@ class TestNPUStreamingSessionEagleV2(
 
 
 class TestNPUStreamingSessionEagleRetractLargePage(
-    NPUStreamingSessionExtraServerBase, StreamingSessionKitMixin
+    NPUStreamingSessionExtraServerBase, NPUStreamingSessionKitMixin
 ):
     """EAGLE3 spec v1 + retract + page=128: max-pressure on `_free_tail`
     (spec tail + retract alloc-commit gap + page alignment)."""

--- a/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
+++ b/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
@@ -378,7 +378,7 @@ class TestNPUStreamingSessionEagle(
         "512",
         *_EAGLE3_SPEC_ARGS,
         "--page-size",
-        "4",
+        "128",
     ]
     env_overrides = [("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", True)]
 
@@ -400,7 +400,7 @@ class TestNPUStreamingSessionEagleV2(
         "512",
         *_EAGLE3_SPEC_ARGS,
         "--page-size",
-        "4",
+        "128",
     ]
     env_overrides = [("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", True)]
 

--- a/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
+++ b/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
@@ -24,10 +24,10 @@ Tests:
 """
 
 import os
-import unittest
 
 import threading
 import time
+import unittest
 
 import requests
 

--- a/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
+++ b/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
@@ -24,7 +24,6 @@ Tests:
 """
 
 import os
-
 import threading
 import time
 import unittest

--- a/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
+++ b/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
@@ -281,7 +281,7 @@ class NPUStreamingSessionExtraServerBase(StreamingSessionServerBase):
                 cls.model,
                 cls.base_url,
                 timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-                other_args=["--enable-streaming-session"] + list(cls.extra_args),
+                other_args=cls.extra_args,
                 env=cls.npu_env,
             )
         cls.tokenizer = get_tokenizer(cls.model)

--- a/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
+++ b/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_extra.py
@@ -54,7 +54,6 @@ register_npu_ci(est_time=900, suite="full-1-npu-a3", nightly=True)
 # rejects with HTTP 400 ("Requested token count exceeds the model's maximum
 # context length"), causing `KeyError: 'meta_info'`. We override those two
 # methods with a smaller `max_new_tokens` that fits Qwen3-8B's context.
-# See .claude/2.log for the original failure.
 _NPU_ABORT_MAX_NEW_TOKENS = 40000
 
 

--- a/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_swa.py
+++ b/test/registered/ascend/basic_function/sessions/test_npu_streaming_session_swa.py
@@ -1,0 +1,133 @@
+"""Streaming session tests on a hybrid-SWA model (gpt-oss-20b) on NPU.
+
+Ported from test/sessions/test_streaming_session_swa.py.
+
+NPU adaptations:
+- model: openai/gpt-oss-20b -> openai-mirror/gpt-oss-20b (ModelScope mirror)
+- --cuda-graph-backend-prefill=disabled -> --disable-cuda-graph
+- --page-size 256 -> 128 (NPU page_size constraint)
+- added --attention-backend ascend
+"""
+
+import unittest
+
+from sglang.test.ascend.test_ascend_utils import GPT_OSS_120B_BF16_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.kits.streaming_session_kit import (
+    AbortLeakReproKitMixin,
+    StreamingSessionKitMixin,
+)
+from sglang.test.server_fixtures.streaming_session_fixture import (
+    ABORT_REPRO_CHUNKED_PREFILL_SIZE,
+    ABORT_REPRO_CONTEXT_LEN,
+    StreamingSessionServerBase,
+)
+
+register_npu_ci(est_time=400, suite="full-8-npu-a3", nightly=True)
+
+
+SWA_MODEL = GPT_OSS_120B_BF16_WEIGHTS_PATH
+
+# NPU adaptation: use bf16 gpt-oss-120b instead of mxfp4 gpt-oss-20b to avoid
+# quantization compatibility issues. Parameters referenced from
+# test_npu_gpt_oss_120b_bf16.py.
+SWA_COMMON_ARGS = [
+    "--trust-remote-code",
+    "--mem-fraction-static",
+    "0.7",
+    "--attention-backend",
+    "ascend",
+    "--nnodes",
+    "1",
+    "--node-rank",
+    "0",
+    "--max-running-requests",
+    "32",
+    "--watchdog-timeout",
+    "9000",
+    "--tp-size",
+    "8",
+    "--sampling-backend",
+    "ascend",
+    "--disable-cuda-graph",
+]
+
+
+class TestStreamingSessionSWA(StreamingSessionServerBase, StreamingSessionKitMixin):
+    """Baseline streaming session on a hybrid-SWA model.
+
+    [Test Category] Memory_and_Scheduling
+    [Test Target] --enable-streaming-session;hybrid-SWA
+    """
+
+    model = SWA_MODEL
+    extra_args = ["--chunked-prefill-size", "512", *SWA_COMMON_ARGS]
+
+
+class TestStreamingSessionSWARetractLargePage(
+    StreamingSessionServerBase, StreamingSessionKitMixin
+):
+    """SWA under retract decode with page=128 (NPU constraint; CUDA used 256).
+
+    [Test Category] Memory_and_Scheduling
+    [Test Target] --enable-streaming-session;SGLANG_TEST_RETRACT;--page-size
+    """
+
+    model = SWA_MODEL
+    extra_args = [
+        "--chunked-prefill-size",
+        "4096",
+        "--page-size",
+        "128",
+        *SWA_COMMON_ARGS,
+    ]
+    env_overrides = [("SGLANG_TEST_RETRACT", True)]
+
+
+class TestStreamingSessionSWARetractMixedChunk(
+    StreamingSessionServerBase, StreamingSessionKitMixin
+):
+    """SWA under retract decode with --enable-mixed-chunk.
+
+    [Test Category] Memory_and_Scheduling
+    [Test Target] --enable-streaming-session;SGLANG_TEST_RETRACT;--enable-mixed-chunk
+    """
+
+    model = SWA_MODEL
+    extra_args = [
+        "--chunked-prefill-size",
+        "128",
+        "--enable-mixed-chunk",
+        *SWA_COMMON_ARGS,
+    ]
+    env_overrides = [("SGLANG_TEST_RETRACT", True)]
+
+
+class TestStreamingSessionSWAAbortLeakRepro(
+    StreamingSessionServerBase, AbortLeakReproKitMixin
+):
+    """SWA abort-heavy chunked prefill leak repro.
+
+    [Test Category] Memory_and_Scheduling
+    [Test Target] --enable-streaming-session;abort leak
+    """
+
+    model = SWA_MODEL
+    # NPU adaptation: page-size 256 -> 128
+    extra_args = [
+        "--chunked-prefill-size",
+        str(ABORT_REPRO_CHUNKED_PREFILL_SIZE),
+        "--context-length",
+        str(ABORT_REPRO_CONTEXT_LEN),
+        "--page-size",
+        "128",
+        "--max-running-requests",
+        "32",
+        "--log-level",
+        "info",
+        *SWA_COMMON_ARGS,
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Port two remaining test cases to Ascend NPU backend (用例 9、10 移植)。

## Changes

### 1. `test_npu_streaming_session_extra.py` (new)
Ported from `test/registered/sessions/test_streaming_session_extra.py`. 5 variants:
- `TestNPUStreamingSessionRetractMixedChunk` — retract + `--enable-mixed-chunk`
- `TestNPUStreamingSessionRetractLargePage` — retract + page=128
- `TestNPUStreamingSessionEagle` — EAGLE3 spec v1 (overlap disabled, offset=-1)
- `TestNPUStreamingSessionEagleV2` — EAGLE3 spec v2 (overlap on)
- `TestNPUStreamingSessionEagleRetractLargePage` — EAGLE3 + retract + page=128

NPU adaptations:
- Model: `LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH` + `EAGLE3_LLAMA3_1_INSTRUCT_8B_WEIGHTS_PATH`
- Server args: `--attention-backend ascend`, `--disable-cuda-graph`, `--disable-piecewise-cuda-graph`
- page_size: 128/4 (Ascend default is 128; 256 unsupported)
- `chunked-prefill-size` divisible by 128
- Env: `PYTORCH_NPU_ALLOC_CONF=expandable_segments:True`, `HCCL_EXEC_TIMEOUT=200`

### 2. `test_npu_multi_instance_release_memory_occupation.py` (new)
Ported from `test/registered/rl/test_multi_instance_release_memory_occupation.py`. 4-NPU multi-process spawn test.

NPU adaptations:
- `torch.cuda` → `torch.npu` (mem_get_info, set_device, empty_cache)
- `dist.init_process_group` backend=`hccl` (instead of nccl default)
- Device `cuda:{rank}` → `npu:{rank}`
- Engine kwargs: `attention_backend="ascend"`, `disable_cuda_graph=True`, `disable_piecewise_cuda_graph=True`
- Model: `LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH` + `LLAMA_3_2_1B_WEIGHTS_PATH`
- `mp.set_start_method("spawn", force=True)` at module import

### 3. `.github/workflows/single-test-npu.yml`
- Image: `swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3`
- Runner: `linux-aarch64-a3-4` (multi_instance needs 4 NPUs for dp=2*tp=2)
- `test_cases`: the two new files

## CI Registration
Both test files use `register_npu_ci(...)`:
- `test_npu_streaming_session_extra.py`: `suite="full-1-npu-a3"`, `est_time=900`, `nightly=True`
- `test_npu_multi_instance_release_memory_occupation.py`: `suite="full-4-npu-a3"`, `est_time=600`, `nightly=True`

## Test Plan
- [ ] `test_npu_streaming_session_extra.py` — 5 test classes pass on 1-NPU
- [ ] `test_npu_multi_instance_release_memory_occupation.py` — 1 test class passes on 4-NPU

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->