### PR TITLE
Fix Qwen3.5 NPU prefix cache

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -485,6 +485,8 @@ class ModelConfig:
             self.hf_config.num_nextn_predict_layers = 1
 
         if is_draft_model and self.hf_config.architectures[0] in [
+            "Qwen3_5ForCausalLM",
+            "Qwen3_5MoeForCausalLM",
             "Qwen3_5ForConditionalGeneration",
             "Qwen3_5MoeForConditionalGeneration",
             "InternS2PreviewForConditionalGeneration",

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -2106,4 +2106,9 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         )
 
 
-EntryClass = [Qwen3_5MoeForConditionalGeneration, Qwen3_5ForConditionalGeneration]
+EntryClass = [
+    Qwen3_5ForCausalLM,
+    Qwen3_5MoeForCausalLM,
+    Qwen3_5MoeForConditionalGeneration,
+    Qwen3_5ForConditionalGeneration,
+]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2628,6 +2628,9 @@ class ServerArgs:
             "Qwen3MoeForCausalLM",
             "Qwen3VLMoeForConditionalGeneration",
             "Qwen3NextForCausalLM",
+            "Qwen3_5ForCausalLM",
+            "Qwen3_5ForCausalLMMTP",
+            "Qwen3_5MoeForCausalLM",
             "Qwen3_5MoeForConditionalGeneration",
             "InternS2PreviewForConditionalGeneration",
             "Qwen3_5ForConditionalGeneration",
@@ -2656,6 +2659,9 @@ class ServerArgs:
 
             if model_arch in [
                 "Qwen3NextForCausalLM",
+                "Qwen3_5ForCausalLM",
+                "Qwen3_5ForCausalLMMTP",
+                "Qwen3_5MoeForCausalLM",
                 "Qwen3_5MoeForConditionalGeneration",
                 "InternS2PreviewForConditionalGeneration",
                 "Qwen3_5ForConditionalGeneration",
@@ -2796,6 +2802,8 @@ class ServerArgs:
                 "Qwen3MoeForCausalLM",
                 "Qwen3NextForCausalLM",
                 "KimiK25ForConditionalGeneration",
+                "Qwen3_5ForCausalLMMTP",
+                "Qwen3_5MoeForCausalLM",
                 "Qwen3_5MoeForConditionalGeneration",
                 "InternS2PreviewForConditionalGeneration",
                 "Qwen3_5ForConditionalGeneration",
@@ -2850,6 +2858,23 @@ class ServerArgs:
             assert (
                 not self.enable_mamba_extra_buffer()
             ), f"mamba extra_buffer is not supported for {model_arch} model"
+
+        if (
+            is_npu()
+            and self.attention_backend == "ascend"
+            and support_mamba_cache_extra_buffer
+            and not self.disable_radix_cache
+            and self.mamba_scheduler_strategy == "no_buffer"
+            and self.page_size is not None
+            and self.page_size != 1
+        ):
+            logger.warning(
+                f"{model_arch} with Ascend attention uses page_size={self.page_size}, "
+                "while the mamba no_buffer radix cache requires page_size=1. "
+                "Automatically using --mamba-scheduler-strategy extra_buffer "
+                "to keep prefix cache enabled."
+            )
+            self.mamba_scheduler_strategy = "extra_buffer"
 
         if self.enable_mamba_extra_buffer():  # extra_buffer
             if self.disable_radix_cache:

--- a/test/srt/test_server_args_mamba_cache.py
+++ b/test/srt/test_server_args_mamba_cache.py
@@ -1,0 +1,59 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.server_args import ServerArgs
+
+
+class TestMambaCacheServerArgs(unittest.TestCase):
+    def _make_server_args(self, arch):
+        server_args = ServerArgs.__new__(ServerArgs)
+        server_args.model_path = "/models/mock"
+        server_args.page_size = 128
+        server_args.disable_radix_cache = False
+        server_args.disable_overlap_schedule = False
+        server_args.mamba_scheduler_strategy = "no_buffer"
+        server_args.mamba_track_interval = 256
+        server_args.speculative_algorithm = None
+        server_args.speculative_num_draft_tokens = None
+        server_args.attention_backend = "ascend"
+        server_args.enable_flashinfer_allreduce_fusion = False
+        server_args.enforce_disable_flashinfer_allreduce_fusion = False
+        server_args.tp_size = 1
+        server_args.enable_dp_attention = False
+        server_args.nnodes = 1
+        server_args.moe_a2a_backend = "none"
+        server_args.moe_runner_backend = "auto"
+        server_args._quantization_explicitly_unset = False
+        server_args.quantization = None
+        server_args.get_model_config = lambda: SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=[arch])
+        )
+        return server_args
+
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=False)
+    @patch("sglang.srt.server_args.is_sm90_supported", return_value=False)
+    @patch("sglang.srt.server_args.is_npu", return_value=True)
+    def test_qwen35_text_arches_handle_mamba_cache_page_size(
+        self, _mock_npu, _mock_sm90, _mock_sm100
+    ):
+        for arch in [
+            "Qwen3_5ForCausalLM",
+            "Qwen3_5MoeForCausalLM",
+            "Qwen3_5ForCausalLMMTP",
+            "Qwen3_5ForConditionalGeneration",
+            "Qwen3_5MoeForConditionalGeneration",
+        ]:
+            with self.subTest(arch=arch):
+                server_args = self._make_server_args(arch)
+
+                ServerArgs._handle_model_specific_adjustments(server_args)
+
+                self.assertTrue(server_args.uses_mamba_radix_cache)
+                self.assertEqual(server_args.mamba_scheduler_strategy, "extra_buffer")
+                self.assertEqual(server_args.page_size, 128)
+                self.assertFalse(server_args.disable_overlap_schedule)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Support prefix cache for Qwen3.5 on Ascend NPU.

When serving Qwen3.5 with the Ascend attention backend, the NPU backend defaults `page_size` to 128. Qwen3.5 uses the Mamba radix cache path, whose `no_buffer` mode requires `page_size == 1`. This caused scheduler initialization to fail with:

```text
AssertionError: Page size must be 1 for MambaRadixCache v1, got 128
```

Fixes https://github.com/Ascend/sglang/issues/522.

## Modifications

- Recognize Qwen3.5 text architectures in model-specific Mamba radix cache handling.
- Automatically switch Qwen3.5 Ascend NPU runs from `no_buffer` to `extra_buffer` when radix cache is enabled and `page_size != 1`, preserving the Ascend default `page_size=128` while keeping prefix cache enabled.
- Register Qwen3.5 text model entry classes so text checkpoints can resolve to the local implementation.
- Include Qwen3.5 text architectures in draft/MTP architecture rewriting.
- Add a unit test covering Qwen3.5 CausalLM, Moe CausalLM, MTP, and conditional architectures on Ascend NPU page-size handling.

## Accuracy Tests

This change does not modify model forward math or kernels.

Validation performed:

```bash
PYTHONPATH=/data/sglang/python python3 -m pytest /data/sglang/test/srt/test_server_args_mamba_cache.py -q
```

Result:

```text
1 passed, 5 subtests passed
```

NPU smoke test with real weights:

```bash
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cd /data/sglang
export PYTHONPATH=/data/sglang/python:${PYTHONPATH:-}
python3 -m sglang.launch_server \
  --model-path /data/models/Qwen3.5-9B \
  --max-running-requests 8 \
  --mem-fraction-static 0.8 \
  --attention-backend ascend \
  --port 30000
```

Observed:

```text
Qwen3_5ForConditionalGeneration with Ascend attention uses page_size=128 ... Automatically using --mamba-scheduler-strategy extra_buffer to keep prefix cache enabled.
Mamba Cache is allocated.
Tree cache initialized: source=default impl=MambaRadixCache hybrid_swa=False hybrid_ssm=True hierarchical=False streaming_wrapped=False
```

A `/v1/chat/completions` request returned HTTP 200 and generated tokens successfully.

## Speed Tests and Profiling

No speed benchmark was run. The change only adjusts server argument handling for the Ascend NPU Qwen3.5 prefix-cache configuration and adds model architecture registration coverage.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). `git diff --check` passed; full pre-commit was not run.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not required for this bug fix.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Accuracy/speed benchmarks are not applicable; NPU smoke test was provided.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #30085709956](https://github.com/Ascend/sglang/actions/runs/30085709956)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #30085883334](https://github.com/Ascend/sglang/actions/runs/30085883334)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->