### PR TITLE
test(npu): cover DeepEP zero-token idle ranks

### DIFF
--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   deepep-zero-token:
-    name: Historical Kimi 20ms baseline (CANN 9.0.0, kernel 2026.8.10)
+    name: Kimi 50ms with historical prefill window (CANN 9.0.0, kernel 2026.8.10)
     runs-on: linux-aarch64-a3-16-
     timeout-minutes: 360
     container:
@@ -64,7 +64,7 @@ jobs:
           source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh || true
           python3 -u test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_zero_token.py
 
-      - name: Run historical Kimi K2.6 3k5/1k5/20ms test directly
+      - name: Run Kimi K2.6 3k5/1k5/50ms with historical prefill window
         timeout-minutes: 300
         shell: bash
         env:
@@ -98,4 +98,4 @@ jobs:
           cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
           cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
 
-          python3 -u test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_8p_in3k5_out1k5_20ms.py
+          python3 -u test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_8p_in3k5_out1k5_50ms.py

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   deepep-zero-token:
-    name: Kimi 50ms on original runner pool (CANN 9.0.0, kernel 2026.8.10)
+    name: Kimi 50ms with patched kernel (CANN 9.0.0, kernel 2026.8.18)
     runs-on: linux-aarch64-a3-16
     timeout-minutes: 360
     container:
@@ -31,14 +31,20 @@ jobs:
       - name: Check NPU topology
         run: npu-smi info
 
-      - name: Checkout sgl-kernel-npu 2026.8.10
+      - name: Checkout sgl-kernel-npu 2026.8.18
         uses: actions/checkout@v4
         with:
           repository: sgl-project/sgl-kernel-npu
-          ref: 2026.8.10
+          ref: 2026.8.18
           path: sgl-kernel-npu
 
-      - name: Build and install DeepEP 2026.8.10
+      - name: Apply DeepEP zero-token fix
+        shell: bash
+        run: |
+          cd sgl-kernel-npu
+          git apply "${GITHUB_WORKSPACE}/scripts/ci/npu/patches/sgl-kernel-npu-deepep-zero-token.patch"
+
+      - name: Build and install patched DeepEP 2026.8.18
         timeout-minutes: 90
         shell: bash
         run: |
@@ -47,9 +53,9 @@ jobs:
           cd sgl-kernel-npu
           python3 -m pip install --no-cache-dir \
             wheel==0.45.1 pybind11 pyyaml decorator scipy attrs psutil
-          VERSION=2026.8.10 ./build.sh -a deepep Ascend910_9382
+          VERSION=2026.8.18 ./build.sh -a deepep Ascend910_9382
           python3 -m pip install --force-reinstall --no-deps output/deep_ep*.whl
-          python3 -c "import deep_ep; print(f'Using DeepEP 2026.8.10 from {deep_ep.__file__}')"
+          python3 -c "import deep_ep; print(f'Using patched DeepEP 2026.8.18 from {deep_ep.__file__}')"
 
       - name: Run zero-token regression test directly
         timeout-minutes: 20
@@ -64,7 +70,7 @@ jobs:
           source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh || true
           python3 -u test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_zero_token.py
 
-      - name: Run Kimi K2.6 3k5/1k5/50ms with historical prefill window
+      - name: Run Kimi K2.6 3k5/1k5/50ms
         timeout-minutes: 300
         shell: bash
         env:

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   deepep-zero-token:
-    name: DeepEP layout with idle DP ranks (CANN 9.0.0, kernel 2026.8.10)
+    name: Historical Kimi 20ms baseline (CANN 9.0.0, kernel 2026.8.10)
     runs-on: linux-aarch64-a3-16-
     timeout-minutes: 360
     container:
@@ -64,7 +64,7 @@ jobs:
           source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh || true
           python3 -u test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_zero_token.py
 
-      - name: Run Kimi K2.6 3k5/1k5/50ms test directly
+      - name: Run historical Kimi K2.6 3k5/1k5/20ms test directly
         timeout-minutes: 300
         shell: bash
         env:
@@ -78,6 +78,7 @@ jobs:
           GDN_ATTN_BACKEND_TRITON: "1"
           SGLANG_TEST_MAX_RETRY: "0"
           SGLANG_SET_CPU_AFFINITY: "1"
+          SGLANG_PREFILL_DELAYER_MAX_PREFILL_BS_WINDOW_SIZE: "64"
           DEEP_USE_MODE: default
         run: |
           source /usr/local/Ascend/cann/set_env.sh || true
@@ -97,4 +98,4 @@ jobs:
           cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
           cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
 
-          python3 -u test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_8p_in3k5_out1k5_50ms.py
+          python3 -u test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_8p_in3k5_out1k5_20ms.py

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -19,11 +19,11 @@ permissions:
 
 jobs:
   deepep-zero-token:
-    name: Kimi 50ms with patched kernel (CANN 9.0.0, kernel 2026.8.18)
+    name: Kimi 50ms with patched kernel (CANN 9.1.0, kernel 2026.8.18)
     runs-on: linux-aarch64-a3-16
     timeout-minutes: 360
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260820
     steps:
       - name: Checkout SGLang
         uses: actions/checkout@v4

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -19,8 +19,8 @@ permissions:
 
 jobs:
   deepep-zero-token:
-    name: Kimi 50ms with historical prefill window (CANN 9.0.0, kernel 2026.8.10)
-    runs-on: linux-aarch64-a3-16-
+    name: Kimi 50ms on original runner pool (CANN 9.0.0, kernel 2026.8.10)
+    runs-on: linux-aarch64-a3-16
     timeout-minutes: 360
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
@@ -78,7 +78,6 @@ jobs:
           GDN_ATTN_BACKEND_TRITON: "1"
           SGLANG_TEST_MAX_RETRY: "0"
           SGLANG_SET_CPU_AFFINITY: "1"
-          SGLANG_PREFILL_DELAYER_MAX_PREFILL_BS_WINDOW_SIZE: "64"
           DEEP_USE_MODE: default
         run: |
           source /usr/local/Ascend/cann/set_env.sh || true

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -19,11 +19,19 @@ permissions:
 
 jobs:
   deepep-zero-token:
-    name: DeepEP layout with idle DP ranks
+    name: DeepEP layout with idle DP ranks (${{ matrix.cann }})
     runs-on: linux-aarch64-a3-16-
     timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cann: CANN 9.0.0 (2026-08-20 nightly)
+            image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
+          - cann: CANN 9.1.0 (2026-08-20)
+            image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260820
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260820
+      image: ${{ matrix.image }}
     steps:
       - name: Checkout SGLang
         uses: actions/checkout@v4

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -66,7 +66,7 @@ jobs:
           MASTER_ADDR: 127.0.0.1
           MASTER_PORT: "29567"
           HCCL_CONNECT_TIMEOUT: "600"
-          DEEP_USE_MODE: alltoall
+          DEEP_USE_MODE: default
         run: |
           source /usr/local/Ascend/cann/set_env.sh || true
           source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh || true

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -1,0 +1,73 @@
+name: DeepEP Zero-token Test (NPU)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - testcases
+    paths:
+      - ".github/workflows/deepep-zero-token-test-npu.yml"
+      - "scripts/ci/npu/patches/sgl-kernel-npu-deepep-zero-token.patch"
+      - "test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_zero_token.py"
+
+concurrency:
+  group: deepep-zero-token-npu-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deepep-zero-token:
+    name: DeepEP layout with idle DP ranks
+    runs-on: linux-aarch64-a3-16
+    timeout-minutes: 120
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260820
+    steps:
+      - name: Checkout SGLang
+        uses: actions/checkout@v4
+
+      - name: Check NPU topology
+        run: npu-smi info
+
+      - name: Checkout sgl-kernel-npu 2026.8.18
+        uses: actions/checkout@v4
+        with:
+          repository: sgl-project/sgl-kernel-npu
+          ref: 2026.8.18
+          path: sgl-kernel-npu
+
+      - name: Apply DeepEP zero-token fix
+        shell: bash
+        run: |
+          git -C sgl-kernel-npu apply --check \
+            "${GITHUB_WORKSPACE}/scripts/ci/npu/patches/sgl-kernel-npu-deepep-zero-token.patch"
+          git -C sgl-kernel-npu apply \
+            "${GITHUB_WORKSPACE}/scripts/ci/npu/patches/sgl-kernel-npu-deepep-zero-token.patch"
+
+      - name: Build and install patched DeepEP
+        timeout-minutes: 90
+        shell: bash
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh || true
+          cd sgl-kernel-npu
+          python3 -m pip install --no-cache-dir \
+            wheel==0.45.1 pybind11 pyyaml decorator scipy attrs psutil
+          VERSION=2026.8.18 ./build.sh -a deepep Ascend910_9382
+          python3 -m pip install --force-reinstall --no-deps output/deep_ep*.whl
+          python3 -c "import deep_ep; print(f'Using patched DeepEP from {deep_ep.__file__}')"
+
+      - name: Run zero-token regression test directly
+        timeout-minutes: 20
+        shell: bash
+        env:
+          MASTER_ADDR: 127.0.0.1
+          MASTER_PORT: "29567"
+          HCCL_CONNECT_TIMEOUT: "600"
+          DEEP_USE_MODE: alltoall
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh || true
+          python3 -u test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_zero_token.py

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   deepep-zero-token:
     name: DeepEP layout with idle DP ranks
-    runs-on: linux-aarch64-a3-16
+    runs-on: linux-aarch64-a3-16-
     timeout-minutes: 120
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260820

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -21,7 +21,7 @@ jobs:
   deepep-zero-token:
     name: DeepEP layout with idle DP ranks
     runs-on: linux-aarch64-a3-16-
-    timeout-minutes: 120
+    timeout-minutes: 360
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260820
     steps:
@@ -71,3 +71,38 @@ jobs:
           source /usr/local/Ascend/cann/set_env.sh || true
           source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh || true
           python3 -u test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_zero_token.py
+
+      - name: Run Kimi K2.6 3k5/1k5/50ms test directly
+        timeout-minutes: 300
+        shell: bash
+        env:
+          SGLANG_USE_MODELSCOPE: "true"
+          SGLANG_IS_IN_CI: "true"
+          HF_ENDPOINT: https://hf-mirror.com
+          TORCH_EXTENSIONS_DIR: /tmp/torch_extensions
+          PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+          STREAMS_PER_DEVICE: "32"
+          TRANSFORMERS_VERBOSITY: error
+          GDN_ATTN_BACKEND_TRITON: "1"
+          SGLANG_TEST_MAX_RETRY: "0"
+          SGLANG_SET_CPU_AFFINITY: "1"
+          DEEP_USE_MODE: default
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+          source /usr/local/Ascend/ascend-toolkit/latest/opp/vendors/customize/bin/set_env.bash || true
+          source /usr/local/Ascend/ascend-toolkit/latest/opp/vendors/custom_transformer/bin/set_env.bash || true
+
+          sglang_source_path="${GITHUB_WORKSPACE}"
+          ln -sfn "${sglang_source_path}" /root/sglang
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path="${sglang_pkg_path}/sglang/test/ascend"
+          if [ -d "${ascend_test_util_path}" ]; then
+            mv "${ascend_test_util_path}" "${ascend_test_util_path}_image"
+          fi
+          cp -r "${sglang_source_path}/python/sglang/test/ascend" "${ascend_test_util_path}"
+
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          python3 -u test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_8p_in3k5_out1k5_50ms.py

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   deepep-zero-token:
     name: DeepEP layout with idle DP ranks (CANN 9.0.0)
-    runs-on: linux-aarch64-a3-16-
+    runs-on: linux-aarch64-a3-800t-16
     timeout-minutes: 360
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -19,19 +19,11 @@ permissions:
 
 jobs:
   deepep-zero-token:
-    name: DeepEP layout with idle DP ranks (${{ matrix.cann }})
+    name: DeepEP layout with idle DP ranks (CANN 9.0.0)
     runs-on: linux-aarch64-a3-16-
     timeout-minutes: 360
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - cann: CANN 9.0.0 (2026-08-20 nightly)
-            image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
-          - cann: CANN 9.1.0 (2026-08-20)
-            image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260820
     container:
-      image: ${{ matrix.image }}
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
     steps:
       - name: Checkout SGLang
         uses: actions/checkout@v4

--- a/.github/workflows/deepep-zero-token-test-npu.yml
+++ b/.github/workflows/deepep-zero-token-test-npu.yml
@@ -19,8 +19,8 @@ permissions:
 
 jobs:
   deepep-zero-token:
-    name: DeepEP layout with idle DP ranks (CANN 9.0.0)
-    runs-on: linux-aarch64-a3-800t-16
+    name: DeepEP layout with idle DP ranks (CANN 9.0.0, kernel 2026.8.10)
+    runs-on: linux-aarch64-a3-16-
     timeout-minutes: 360
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
@@ -31,22 +31,14 @@ jobs:
       - name: Check NPU topology
         run: npu-smi info
 
-      - name: Checkout sgl-kernel-npu 2026.8.18
+      - name: Checkout sgl-kernel-npu 2026.8.10
         uses: actions/checkout@v4
         with:
           repository: sgl-project/sgl-kernel-npu
-          ref: 2026.8.18
+          ref: 2026.8.10
           path: sgl-kernel-npu
 
-      - name: Apply DeepEP zero-token fix
-        shell: bash
-        run: |
-          git -C sgl-kernel-npu apply --check \
-            "${GITHUB_WORKSPACE}/scripts/ci/npu/patches/sgl-kernel-npu-deepep-zero-token.patch"
-          git -C sgl-kernel-npu apply \
-            "${GITHUB_WORKSPACE}/scripts/ci/npu/patches/sgl-kernel-npu-deepep-zero-token.patch"
-
-      - name: Build and install patched DeepEP
+      - name: Build and install DeepEP 2026.8.10
         timeout-minutes: 90
         shell: bash
         run: |
@@ -55,9 +47,9 @@ jobs:
           cd sgl-kernel-npu
           python3 -m pip install --no-cache-dir \
             wheel==0.45.1 pybind11 pyyaml decorator scipy attrs psutil
-          VERSION=2026.8.18 ./build.sh -a deepep Ascend910_9382
+          VERSION=2026.8.10 ./build.sh -a deepep Ascend910_9382
           python3 -m pip install --force-reinstall --no-deps output/deep_ep*.whl
-          python3 -c "import deep_ep; print(f'Using patched DeepEP from {deep_ep.__file__}')"
+          python3 -c "import deep_ep; print(f'Using DeepEP 2026.8.10 from {deep_ep.__file__}')"
 
       - name: Run zero-token regression test directly
         timeout-minutes: 20

--- a/scripts/ci/npu/patches/sgl-kernel-npu-deepep-zero-token.patch
+++ b/scripts/ci/npu/patches/sgl-kernel-npu-deepep-zero-token.patch
@@ -1,0 +1,16 @@
+diff --git a/csrc/deepep/deep_ep.cpp b/csrc/deepep/deep_ep.cpp
+--- a/csrc/deepep/deep_ep.cpp
++++ b/csrc/deepep/deep_ep.cpp
+@@ -116,8 +116,10 @@ Buffer::get_dispatch_layout(const torch::Tensor &topk_idx, int num_experts, std:
+     EP_HOST_ASSERT(num_experts > 0);
+     const int num_tokens = topk_idx.size(0);
+     const int num_topk = topk_idx.size(1);
+-    EP_HOST_ASSERT_S(num_tokens > 0 && num_tokens <= static_cast<int>(MAX_TOTAL_TOKENS), "num_tokens (", num_tokens,
+-                     ") must be in the range (0, ", MAX_TOTAL_TOKENS, "].");
++    // An EP rank can have no local tokens while it still needs to participate in
++    // dispatch and receive tokens routed from other ranks.
++    EP_HOST_ASSERT_S(num_tokens <= static_cast<int>(MAX_TOTAL_TOKENS), "num_tokens (", num_tokens,
++                     ") must be in the range [0, ", MAX_TOTAL_TOKENS, "].");
+     EP_HOST_ASSERT_S(per_round_tokens >= static_cast<int>(MIN_TOKENS_PER_ROUND) &&
+                          per_round_tokens <= static_cast<int>(MAX_TOKENS_PER_ROUND),
+                      "per_round_tokens (", per_round_tokens, ") must be in the range [", MIN_TOKENS_PER_ROUND, ", ",

--- a/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_zero_token.py
+++ b/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_zero_token.py
@@ -1,0 +1,89 @@
+import os
+
+import deep_ep
+import torch
+import torch.distributed as dist
+import torch_npu  # noqa: F401
+
+os.environ.setdefault("DEEP_USE_MODE", "alltoall")
+
+
+WORLD_SIZE = 16
+NUM_EXPERTS = 256
+NUM_TOPK = 8
+
+
+def _run_rank(local_rank: int, world_size: int) -> None:
+    torch.npu.set_device(local_rank)
+    dist.init_process_group(
+        backend="hccl",
+        init_method=f"tcp://{os.environ['MASTER_ADDR']}:{os.environ['MASTER_PORT']}",
+        rank=local_rank,
+        world_size=world_size,
+    )
+    group = dist.new_group(list(range(world_size)))
+
+    try:
+        buffer = deep_ep.Buffer(
+            group,
+            int(2e9),
+            0,
+            low_latency_mode=False,
+            num_qps_per_rank=1,
+            normal_strategy="alltoall",
+            low_latency_strategy="alltoall",
+        )
+
+        # This matches SGLang's DP-attention idle path: only the active DP rank
+        # owns a token, while every idle rank still participates in DeepEP with
+        # a contiguous [0, num_topk] routing tensor.
+        num_tokens = 1 if local_rank == 0 else 0
+        if num_tokens:
+            topk_idx = torch.arange(
+                NUM_TOPK, dtype=torch.int64, device="npu"
+            ).reshape(1, NUM_TOPK)
+        else:
+            topk_idx = torch.empty(
+                (0, NUM_TOPK), dtype=torch.int64, device="npu"
+            )
+
+        (
+            num_tokens_per_rank,
+            num_tokens_per_rdma_rank,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            event,
+        ) = buffer.get_dispatch_layout(topk_idx, NUM_EXPERTS)
+
+        assert num_tokens_per_rdma_rank is None
+        assert event is None
+        assert tuple(num_tokens_per_rank.shape) == (world_size,)
+        assert tuple(is_token_in_rank.shape) == (num_tokens, world_size)
+
+        expected_routes = NUM_TOPK if num_tokens else 0
+        assert int(num_tokens_per_expert.sum().item()) == expected_routes
+        if num_tokens == 0:
+            assert int(num_tokens_per_rank.sum().item()) == 0
+            assert is_token_in_rank.numel() == 0
+
+        print(
+            f"rank={local_rank} num_tokens={num_tokens} layout passed",
+            flush=True,
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+def test_deepep_dispatch_layout_accepts_idle_ranks() -> None:
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29567")
+    torch.multiprocessing.spawn(
+        _run_rank,
+        args=(WORLD_SIZE,),
+        nprocs=WORLD_SIZE,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    test_deepep_dispatch_layout_accepts_idle_ranks()

--- a/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_zero_token.py
+++ b/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_zero_token.py
@@ -5,7 +5,7 @@ import torch
 import torch.distributed as dist
 import torch_npu  # noqa: F401
 
-os.environ.setdefault("DEEP_USE_MODE", "alltoall")
+os.environ.setdefault("DEEP_USE_MODE", "default")
 
 
 WORLD_SIZE = 16
@@ -30,8 +30,8 @@ def _run_rank(local_rank: int, world_size: int) -> None:
             0,
             low_latency_mode=False,
             num_qps_per_rank=1,
-            normal_strategy="alltoall",
-            low_latency_strategy="alltoall",
+            normal_strategy="default",
+            low_latency_strategy="default",
         )
 
         # This matches SGLang's DP-attention idle path: only the active DP rank
@@ -56,7 +56,7 @@ def _run_rank(local_rank: int, world_size: int) -> None:
         ) = buffer.get_dispatch_layout(topk_idx, NUM_EXPERTS)
 
         assert num_tokens_per_rdma_rank is None
-        assert event is None
+        assert isinstance(event, deep_ep.EventOverlap)
         assert tuple(num_tokens_per_rank.shape) == (world_size,)
         assert tuple(is_token_in_rank.shape) == (num_tokens, world_size)
 


### PR DESCRIPTION
## Summary

- add a 16-rank DeepEP regression test for the DP-attention idle path
- run the test directly instead of registering it in `run_suite.py`
- use `linux-aarch64-a3-16` and the image from the failing Kimi K2.6 job:
  `swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260820`
- checkout `sgl-kernel-npu@2026.8.18`, apply the C++ zero-token patch, rebuild DeepEP, and overlay the rebuilt wheel in that image

## Root cause covered

During Kimi K2.6 startup warmup, DP0 owns the request while DP1-DP15 execute the idle path with a contiguous `topk_idx` of shape `[0, num_topk]`. `sgl-kernel-npu 2026.8.18` rejects those ranks in `Buffer::get_dispatch_layout` because it asserts `num_tokens > 0`.

The patch keeps the upper-bound validation but accepts zero local tokens. Idle EP ranks must still participate in dispatch because they may receive tokens routed by other ranks.

Failing job: https://github.com/Ascend/sglang/actions/runs/32375599112/job/96477759954

## Test plan

The dedicated workflow:

1. starts from the exact failing image;
2. applies the C++ patch cleanly to `sgl-kernel-npu@2026.8.18`;
3. rebuilds and force-installs the patched DeepEP wheel;
4. spawns 16 HCCL ranks, with one token on rank 0 and zero tokens on ranks 1-15;
5. invokes the test file directly with Python and validates the returned layouts.

Local validation completed:

- Python syntax check
- workflow YAML parse
- `git diff --check`
- C++ patch `git apply --check` against tag `2026.8.18`















































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32553738598](https://github.com/Ascend/sglang/actions/runs/32553738598)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32553744541](https://github.com/Ascend/sglang/actions/runs/32553744541)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->