### PR TITLE
test(npu): diagnose Kimi K2.6 ZBAL graph failure

### DIFF
--- a/.github/workflows/nightly-test-npu-zbal-debug.yml
+++ b/.github/workflows/nightly-test-npu-zbal-debug.yml
@@ -1,0 +1,56 @@
+name: Nightly Test (NPU) - ZBAL Graph Off
+
+on:
+  pull_request:
+    branches:
+      - testcases-260813
+    paths:
+      - ".github/workflows/nightly-test-npu-zbal-debug.yml"
+
+concurrency:
+  group: nightly-test-npu-zbal-debug-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  set-image-config:
+    runs-on: ubuntu-latest
+    outputs:
+      image_a3: ${{ steps.set-vars.outputs.image_a3 }}
+      run_start_metadata: ${{ steps.set-vars.outputs.run_start_metadata }}
+    steps:
+      - name: Set image config
+        id: set-vars
+        run: |
+          echo "image_a3=swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260820" >> "$GITHUB_OUTPUT"
+          echo 'run_start_metadata={"branch_label":"zbal-graph-off","workflow_name":"nightly-test-npu-zbal-debug","create_time":""}' >> "$GITHUB_OUTPUT"
+
+  nightly-poc-multi-node-tests:
+    name: multi-node-poc
+    if: ${{ !cancelled() }}
+    needs: [set-image-config]
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        test_config:
+          - name: kimi_k2_6_w4a8_1p1d_16p_in128k_out1k_prefix90_100ms_zbal_graph_off
+            prefill_size: 1
+            decode_size: 1
+            router_size: 1
+            test_case: test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_1p1d_16p_in128k_out1k_prefix90_100ms.py
+            test_type: perf
+            prefill_decode_deployment: separation
+    uses: ./.github/workflows/nightly-test-npu-e2e-multi-node.yml
+    with:
+      runner: linux-amd64-cpu-4
+      test_type: ${{ matrix.test_config.test_type }}
+      test_config_name: ${{ matrix.test_config.name }}
+      prefill_size: ${{ matrix.test_config.prefill_size }}
+      decode_size: ${{ matrix.test_config.decode_size }}
+      router_size: ${{ matrix.test_config.router_size }}
+      test_case: ${{ matrix.test_config.test_case }}
+      image: ${{ needs.set-image-config.outputs.image_a3 }}
+      install_sglang_from_source: false
+      prefill_decode_deployment: ${{ matrix.test_config.prefill_decode_deployment }}
+      transformers_version: ''
+      run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: <测试用例描述>
+# Diagnose Kimi K2.6 128K prefill with ZBAL graph disabled.
 
 on:
   pull_request:
@@ -14,87 +14,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  single-node-poc:
-    name: single-node-poc
-    runs-on: linux-aarch64-a3-2
-    container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Check npu info
-        run: |
-          npu-smi info
-
-      - name: Run test
-        timeout-minutes: 120
-        env:
-          SGLANG_USE_MODELSCOPE: true
-          HF_ENDPOINT: https://hf-mirror.com
-          SGLANG_IS_IN_CI: true
-        shell: bash
-        run: |
-          sglang_source_path=$(pwd)
-          echo "Source code path: ${sglang_source_path}"
-          ln -sf ${sglang_source_path} /root/sglang
-
-          # Test cases - 使用时替换为实际的测试用例路径
-          test_cases=(
-            "test/registered/npu/llm_models/test_npu_deepseek_v3_2_w8a8.py"
-          )
-
-          for test_case in "${test_cases[@]}"; do
-            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
-              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
-              exit 1
-            fi
-          done
-
-          # copy required file from our daily cache
-          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
-          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
-
-          echo "scaling_governor performance num: \
-            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
-          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
-          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
-          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
-
-          export SGLANG_TEST_MAX_RETRY=0
-          export SGLANG_SET_CPU_AFFINITY=1
-          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
-
-          echo "Use sglang from image"
-          sglang_pkg_path=/sgl-workspace/sglang/python
-          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
-          mkdir -p ${ascend_test_util_path}
-          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
-          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
-
-          # Set environment of cann
-          source /usr/local/Ascend/cann/set_env.sh || true
-          source /usr/local/Ascend/nnal/atb/set_env.sh || true
-
-          current_date=$(date +%Y%m%d)
-          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
-          rm -rf ${log_path}
-          mkdir -p ${log_path}
-          echo "Log path: ${log_path}"
-
-          for test_case in "${test_cases[@]}"; do
-            tc_name=$(basename ${test_case} .py)
-            echo "Running test case ${test_case}"
-            python -u ${sglang_source_path}/${test_case}
-            echo "Finished test case ${test_case}"
-          done
-
-          plog_path="/root/ascend/log/debug/plog"
-          if [ -d "$plog_path" ];then
-            echo "Plog files found. Begin to backup them."
-            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
-            echo "Save path: ${target_plog_path}"
-            rm -rf ${target_plog_path}
-            mkdir -p ${target_plog_path}
-            cp ${plog_path}/* ${target_plog_path}
-          fi
+  kimi-k2-6-zbal-graph-off:
+    name: kimi-k2-6-zbal-graph-off
+    uses: ./.github/workflows/nightly-test-npu-e2e-multi-node.yml
+    with:
+      runner: linux-amd64-cpu-4
+      test_type: perf
+      test_config_name: kimi_k2_6_w4a8_1p1d_16p_in128k_out1k_prefix90_100ms_zbal_graph_off
+      prefill_size: 1
+      decode_size: 1
+      router_size: 1
+      test_case: test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_1p1d_16p_in128k_out1k_prefix90_100ms.py
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260820
+      install_sglang_from_source: false
+      prefill_decode_deployment: separation
+      transformers_version: ''
+      run_start_metadata: '{"branch_label":"zbal-graph-off","workflow_name":"single-test-npu","create_time":""}'
+    secrets: inherit

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# Diagnose Kimi K2.6 128K prefill with ZBAL graph disabled.
+# test round 1: <测试用例描述>
 
 on:
   pull_request:
@@ -14,20 +14,87 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  kimi-k2-6-zbal-graph-off:
-    name: kimi-k2-6-zbal-graph-off
-    uses: ./.github/workflows/nightly-test-npu-e2e-multi-node.yml
-    with:
-      runner: linux-amd64-cpu-4
-      test_type: perf
-      test_config_name: kimi_k2_6_w4a8_1p1d_16p_in128k_out1k_prefix90_100ms_zbal_graph_off
-      prefill_size: 1
-      decode_size: 1
-      router_size: 1
-      test_case: test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_1p1d_16p_in128k_out1k_prefix90_100ms.py
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260820
-      install_sglang_from_source: false
-      prefill_decode_deployment: separation
-      transformers_version: ''
-      run_start_metadata: '{"branch_label":"zbal-graph-off","workflow_name":"single-test-npu","create_time":""}'
-    secrets: inherit
+  single-node-poc:
+    name: single-node-poc
+    runs-on: linux-aarch64-a3-2
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Run test
+        timeout-minutes: 120
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          # Test cases - 使用时替换为实际的测试用例路径
+          test_cases=(
+            "test/registered/npu/llm_models/test_npu_deepseek_v3_2_w8a8.py"
+          )
+
+          for test_case in "${test_cases[@]}"; do
+            if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+              echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+              exit 1
+            fi
+          done
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          cp ~/.cache/modelscope/hub/datasets/tmp/test.jsonl /tmp
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          echo "Use sglang from image"
+          sglang_pkg_path=/sgl-workspace/sglang/python
+          ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+          mkdir -p ${ascend_test_util_path}
+          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          # Set environment of cann
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+
+          current_date=$(date +%Y%m%d)
+          log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          for test_case in "${test_cases[@]}"; do
+            tc_name=$(basename ${test_case} .py)
+            echo "Running test case ${test_case}"
+            python -u ${sglang_source_path}/${test_case}
+            echo "Finished test case ${test_case}"
+          done
+
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            target_plog_path="/root/.cache/tests/logs/plog/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/python/sglang/test/ascend/e2e/run_npu_testcase.sh
+++ b/python/sglang/test/ascend/e2e/run_npu_testcase.sh
@@ -154,3 +154,12 @@ if [ -d "$source_plog_path" ];then
     mkdir -p "${target_plog_path}"
     cp ${source_plog_path}/* "${target_plog_path}"
 fi
+
+echo "ZBAL/AI Core diagnostic matches:"
+diagnostic_paths=("${log_path}")
+if [ -d "${target_plog_path:-}" ]; then
+    diagnostic_paths+=("${target_plog_path}")
+fi
+grep -RniE -B 20 -A 40 \
+    "intranode_dispatch|507057|EZ9999|aivec error|invalid GM address|cross-device memory access" \
+    "${diagnostic_paths[@]}" 2>/dev/null || true

--- a/test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_1p1d_16p_in128k_out1k_prefix90_100ms.py
+++ b/test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_1p1d_16p_in128k_out1k_prefix90_100ms.py
@@ -27,7 +27,7 @@ PREFILL_ENVS = {
     "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "0",
     "ZBAL_NPU_ALLOC_CONF": "use_vmm_for_static_memory:True",
     "SGLANG_ZBAL_BOOTSTRAP_URL": "tcp://127.0.0.1:24699",
-    "ZBAL_ENABLE_GRAPH": "1",
+    "ZBAL_ENABLE_GRAPH": "0",
 }
 
 DECODE_ENVS = {


### PR DESCRIPTION
## Purpose

Diagnose the Kimi K2.6 W4A8 1P1D TP16 128K prefill failure seen in [job 97611817062](https://github.com/Ascend/sglang/actions/runs/32706800774/job/97611817062).

The first device-side failure is in `zbal_buffer.py::intranode_dispatch` with NPU error `507057`, followed by `EZ9999` / AI Vector Core MTE invalid GM address or cross-device access timeout.

## Changes

- Set Prefill `ZBAL_ENABLE_GRAPH=0` in only the affected testcase.
- Configure `Single Test (NPU)` to invoke only this 1P1D testcase through the existing multi-node reusable workflow; this does not use `run_suite.py`.
- Print matching ZBAL/AI Core context from the testcase log and plog after execution. The existing CI test utility is patched into `/sgl-workspace/sglang/python` by the multi-node runner.
- Keep the original `cann9.1.0-a3-20260820` image and 1 prefill + 1 decode + 1 router topology.

## Expected observation

Check whether `intranode_dispatch`, `507057`, `EZ9999`, `aivec error`, or invalid GM/cross-device errors still occur with ZBAL graph disabled.

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32825988819](https://github.com/Ascend/sglang/actions/runs/32825988819)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32826000879](https://github.com/Ascend/sglang/actions/runs/32826000879)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->