### PR TITLE
Add DSV4-Flash unified radix cache evict->unevict model test

### DIFF
--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -18,6 +18,7 @@ jobs:
     name: single-node-poc (${{ matrix.image }})
     runs-on: linux-aarch64-a3-16
     strategy:
+      fail-fast: false
       matrix:
         image:
           # Daily build from upstream main: contains sgl-project/sglang#37091

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -21,11 +21,11 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          # Daily build from upstream main: contains sgl-project/sglang#37091
-          # (merged 2026-08-30) -> expected to hit the evict->unevict TypeError (RED).
-          - swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
-          # 2026-08-28 snapshot: predates #37091 -> expected GREEN (control).
-          - swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:20260828-cann9.0.0-a3
+          # 2026-08-28 snapshot + CANN 9.1.0: has the aclnnHcPre (HcPre) op that
+          # DSV4 mHC pre-norm requires (cann9.0.0 lacks it), and does NOT contain
+          # #37091. The bundled sglang is overridden via PYTHONPATH to upstream
+          # main below, so #37091 runs on top of a runnable DSV4 CANN runtime.
+          - swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260828
     container:
       image: ${{ matrix.image }}
     steps:

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -1,5 +1,5 @@
 name: Single Test (NPU)
-# test round 1: <测试用例描述>
+# test round: DSV4-Flash unified radix cache evict->unevict (#37091 regression)
 
 on:
   pull_request:
@@ -15,10 +15,15 @@ concurrency:
 
 jobs:
   single-node-poc:
-    name: single-node-poc
+    name: single-node-poc (${{ matrix.image }})
     runs-on: linux-aarch64-a3-2
+    strategy:
+      matrix:
+        image:
+          - swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260828
+          - swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:20260828-cann9.0.0-a3
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.0.0-a3-20260622
+      image: ${{ matrix.image }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,7 +46,7 @@ jobs:
 
           # Test cases - 使用时替换为实际的测试用例路径
           test_cases=(
-            "test/registered/npu/llm_models/test_npu_deepseek_v3_2_w8a8.py"
+            "test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_radix_cache_evict_unevict.py"
           )
 
           for test_case in "${test_cases[@]}"; do

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -100,6 +100,14 @@ jobs:
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true
           source /usr/local/Ascend/nnal/atb/set_env.sh || true
+          # DSV4 mHC fused ops (aclnnHcPre etc.) ship in the custom_transformer /
+          # customize operator packages (see sgl-project/sglang#29794). Source them so
+          # torch.ops.custom.npu_hc_pre resolves; without this capture_decode_graph
+          # fails with 'aclnnHcPre not in libopapi.so'.
+          source /usr/local/Ascend/ascend-toolkit/latest/opp/vendors/customize/bin/set_env.bash || true
+          source /usr/local/Ascend/ascend-toolkit/latest/opp/vendors/custom_transformer/bin/set_env.bash || true
+          echo "--- opp vendors dir ---"
+          ls -la /usr/local/Ascend/ascend-toolkit/latest/opp/vendors/ 2>&1 || true
 
           current_date=$(date +%Y%m%d)
           log_path="/root/.cache/tests/logs/log/${current_date}/${HOSTNAME}"

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -16,11 +16,14 @@ concurrency:
 jobs:
   single-node-poc:
     name: single-node-poc (${{ matrix.image }})
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-16
     strategy:
       matrix:
         image:
-          - swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260828
+          # Daily build from upstream main: contains sgl-project/sglang#37091
+          # (merged 2026-08-30) -> expected to hit the evict->unevict TypeError (RED).
+          - swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3
+          # 2026-08-28 snapshot: predates #37091 -> expected GREEN (control).
           - swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:20260828-cann9.0.0-a3
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/single-test-npu.yml
+++ b/.github/workflows/single-test-npu.yml
@@ -74,12 +74,28 @@ jobs:
           export SGLANG_SET_CPU_AFFINITY=1
           echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
 
-          echo "Use sglang from image"
-          sglang_pkg_path=/sgl-workspace/sglang/python
+          # Checkout upstream community sglang main and run the test against it
+          # via PYTHONPATH, so sgl-project/sglang#37091 (the recover_after_unevict
+          # `result` param) is exercised on top of the image's CANN runtime,
+          # instead of the image's bundled sglang.
+          upstream_sglang_path=/root/upstream-sglang
+          if [ ! -d "${upstream_sglang_path}/.git" ]; then
+            git clone --depth 1 https://github.com/sgl-project/sglang.git ${upstream_sglang_path}
+          fi
+          echo "Using upstream sglang main from: ${upstream_sglang_path}"
+
+          # Overlay the Ascend-side test utils (test/ascend) from the PR checkout
+          # into the upstream source so ascend-specific helpers (e.g.
+          # DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH) remain importable.
+          sglang_pkg_path=${upstream_sglang_path}/python
           ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
-          mkdir -p ${ascend_test_util_path}
-          mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          if [ -d ${ascend_test_util_path} ]; then
+            mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+          fi
+          mkdir -p $(dirname ${ascend_test_util_path})
           cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+
+          export PYTHONPATH=${sglang_pkg_path}:${PYTHONPATH}
 
           # Set environment of cann
           source /usr/local/Ascend/cann/set_env.sh || true

--- a/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_radix_cache_evict_unevict.py
+++ b/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_radix_cache_evict_unevict.py
@@ -83,8 +83,6 @@ DEEPSEEK_V4_FLASH_W8A8_8P_RADIX_CACHE_ARGS = [
     "--enable-hierarchical-cache",
     "--hicache-ratio",
     1.2,
-    "--hicache-storage-backend",
-    "memory",
     "--enable-cache-report",
     "--prefill-max-requests",
     2,

--- a/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_radix_cache_evict_unevict.py
+++ b/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_radix_cache_evict_unevict.py
@@ -1,0 +1,219 @@
+import logging
+import unittest
+
+import requests
+
+from sglang.benchmark.utils import get_tokenizer
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=1200, suite="base-c-test-perf-16-npu-a3")
+register_npu_ci(est_time=1200, suite="nightly-perf-16-npu-a3", nightly=True)
+
+# Environment variables for DSV4-Flash single-node PD-mix deployment.
+# Identical to the 8p performance case; the radix cache flag is the only
+# difference.
+DEEPSEEK_V4_FLASH_W8A8_8P_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "INF_NAN_MODE_FORCE_DISABLE": "1",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    # deepep
+    "DEEPEP_HCCL_BUFFSIZE": "1000",
+    "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "16",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "2048",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
+    # skip gpu branch
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "FORCE_DRAFT_MODEL_NON_QUANT": "1",
+    "SGLANG_DSV4_FP4_EXPERTS": "False",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    # MTP (EAGLE) related envs
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+}
+
+# Server launch arguments for DSV4-Flash W8A8 single-node 8p with the unified
+# radix cache ENABLED.
+#
+# Note: the 8p performance case passes `--disable-radix-cache`. That flag is
+# intentionally omitted here so the evict -> unevict path of the unified radix
+# cache is exercised. DeepSeek-V4 auto-registers a sidecar component into the
+# unified radix cache; when the cache fills up and later re-inserts an evicted
+# prefix, the tree walk hits `recover_after_unevict` / `update_component_on_insert_overlap`.
+DEEPSEEK_V4_FLASH_W8A8_8P_RADIX_CACHE_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "dsv4",
+    "--watchdog-timeout",
+    9000,
+    "--mem-fraction-static",
+    0.6,
+    "--prefill-max-requests",
+    2,
+    "--chunked-prefill-size",
+    -1,
+    "--max-running-requests",
+    160,
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--quantization",
+    "modelslim",
+    "--enable-dp-lm-head",
+    "--kv-cache-dtype",
+    "bfloat16",
+    "--cuda-graph-bs",
+    1,
+    2,
+    4,
+    8,
+    10,
+    # MTP (EAGLE) configuration.
+    "--speculative-algorithm",
+    "EAGLE",
+    "--speculative-num-steps",
+    2,
+    "--speculative-eagle-topk",
+    1,
+    "--speculative-num-draft-tokens",
+    3,
+]
+
+# Filler used to build long, distinct prefixes. Each prefix is tagged with a
+# unique marker so that different requests occupy different radix-tree branches
+# (a shared prefix would defeat the "fill the cache" step by reusing nodes).
+_FILLER = "The quick brown fox jumps over the lazy dog. "
+
+
+class TestNPUDeepSeekV4FlashW8A8RadixCacheEvictUnevict(CustomTestCase):
+    """Functional model test: DSV4-Flash unified radix cache evict -> unevict.
+
+    Covers the scenario described in sgl-project/sglang#37091, where a cache
+    contract change ("Unified Cache][1/N]") added a required ``result``
+    parameter to :meth:`TreeComponent.recover_after_unevict` /
+    :meth:`TreeComponent.update_component_on_insert_overlap`. A sidecar
+    component that overrides the old signature then raises ``TypeError`` on the
+    evict -> unevict path.
+
+    This case deliberately keeps the unified radix cache on and drives enough
+    distinct long prefixes through the server to force LRU eviction, then
+    re-sends the evicted anchor prefix to trigger the unevict path. The core
+    assertion is that every request succeeds (no server-side crash / TypeError);
+    ``cached_tokens`` is logged for diagnostics.
+    """
+
+    model = DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH
+    base_url = DEFAULT_URL_FOR_TEST
+
+    # Tunable knobs. `fill_count * fill_tokens` must exceed the residual KV-cache
+    # budget left after the 16-rank model weights are loaded (mem-fraction 0.6).
+    anchor_tokens = 8000
+    fill_tokens = 8000
+    fill_count = 32
+    max_new_tokens = 1
+
+    @classmethod
+    def setUpClass(cls):
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=DEEPSEEK_V4_FLASH_W8A8_8P_RADIX_CACHE_ARGS,
+            env=DEEPSEEK_V4_FLASH_W8A8_8P_ENVS,
+        )
+        cls.tokenizer = get_tokenizer(cls.model)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def _gen_prompt(self, num_tokens: int, tag: str) -> str:
+        """Build a ~num_tokens prompt with a unique leading marker."""
+        text = f"### {tag} ### " + _FILLER
+        while len(self.tokenizer.encode(text)) < num_tokens:
+            text += _FILLER
+        encoded = self.tokenizer.encode(text)
+        return self.tokenizer.decode(encoded[:num_tokens])
+
+    def _generate(self, prompt: str) -> dict:
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": self.max_new_tokens,
+                },
+            },
+            timeout=600,
+        )
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"generate failed with status {response.status_code}: {response.text}",
+        )
+        return response.json()
+
+    @staticmethod
+    def _cached_tokens(response_json: dict) -> int:
+        return int(response_json.get("meta_info", {}).get("cached_tokens", 0))
+
+    def test_radix_cache_evict_then_unevict(self):
+        anchor_prompt = self._gen_prompt(self.anchor_tokens, "anchor")
+
+        # 1) Populate the cache with the anchor prefix.
+        first = self._generate(anchor_prompt)
+        first_cached = self._cached_tokens(first)
+        logging.warning("anchor first request cached_tokens=%d", first_cached)
+        self.assertEqual(first_cached, 0, "first anchor request should not hit cache")
+
+        # 2) Fill the cache with distinct long prefixes to force LRU eviction of
+        #    the anchor (and earlier fill) nodes.
+        for i in range(self.fill_count):
+            fill_prompt = self._gen_prompt(self.fill_tokens, f"fill-{i}")
+            self._generate(fill_prompt)
+
+        # 3) Re-send the anchor prefix. If it was evicted, the tree walk hits the
+        #    unevict path (recover_after_unevict). A TypeError here would surface
+        #    the #37091 regression; only a successful response is asserted.
+        second = self._generate(anchor_prompt)
+        second_cached = self._cached_tokens(second)
+        logging.warning(
+            "anchor re-send request cached_tokens=%d (evict->unevict path)",
+            second_cached,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_radix_cache_evict_unevict.py
+++ b/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_radix_cache_evict_unevict.py
@@ -74,6 +74,18 @@ DEEPSEEK_V4_FLASH_W8A8_8P_RADIX_CACHE_ARGS = [
     9000,
     "--mem-fraction-static",
     0.6,
+    # Hierarchical cache: when the device tier fills up, evicted prefixes are
+    # offloaded to the host tier (the node stays in the tree with FULL.device
+    # value set to None -> `node.evicted == True`). Re-hitting such a prefix
+    # runs the unevict path (TreeComponent._unevict_node_on_insert +
+    # recover_after_unevict), which is exactly where #37091's missing `result`
+    # param on C128SidecarComponent should surface as a TypeError.
+    "--enable-hierarchical-cache",
+    "--hicache-ratio",
+    1.2,
+    "--hicache-storage-backend",
+    "memory",
+    "--enable-cache-report",
     "--prefill-max-requests",
     2,
     "--chunked-prefill-size",
@@ -212,6 +224,14 @@ class TestNPUDeepSeekV4FlashW8A8RadixCacheEvictUnevict(CustomTestCase):
         logging.warning(
             "anchor re-send request cached_tokens=%d (evict->unevict path)",
             second_cached,
+        )
+        # The anchor must have been offloaded (not hard-deleted) and re-hit so
+        # the unevict path actually runs. cached_tokens==0 means the scenario was
+        # not constructed and would let the #37091 regression pass silently.
+        self.assertGreater(
+            second_cached,
+            0,
+            "anchor re-send hit 0 cached tokens: evict->unevict was not exercised",
         )
 
 


### PR DESCRIPTION
## Summary

Add a functional NPU model test covering the unified radix cache **evict -> unevict** path for DeepSeek-V4-Flash (W8A8, 8p PD-mix), to reproduce the contract-change regression from [sgl-project/sglang#37091](https://github.com/sgl-project/sglang/pull/37091).

## Background

#37091 ("Unified Cache [1/N]") added a required `result` parameter to `TreeComponent.recover_after_unevict` / `update_component_on_insert_overlap`. The NPU DeepSeek-V4 sidecar component overrides the old signature, so the evict -> unevict path raises `TypeError`.

## Changes

- `test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_radix_cache_evict_unevict.py`
  - Reuses the DSV4-Flash W8A8 8p config but keeps the unified radix cache **enabled** (the perf case passes `--disable-radix-cache`; this one omits it).
  - Sends a long anchor prefix, fills the cache with distinct long prefixes to force LRU eviction, then re-sends the anchor to hit the unevict path. Core assertion: every request succeeds (no server-side `TypeError`).
- `.github/workflows/single-test-npu.yml`
  - Point `test_cases` at the new case.
  - Run against the cann9.1.0-a3 and cann9.0.0-a3 20260828 images via matrix.

## Note on the images

Both images are built 2026-08-28, while #37091 merged 2026-08-30, so neither image contains the regression code. This case is expected to be **green** now; it will turn red once the branch/images catch up with #37091.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33599390890](https://github.com/Ascend/sglang/actions/runs/33599390890)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33599390686](https://github.com/Ascend/sglang/actions/runs/33599390686)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33599391035](https://github.com/Ascend/sglang/actions/runs/33599391035)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->