### PR TITLE
fix(npu): update a3 runner names to trailing-dash format in full-test-npu and single-node stage

### DIFF
--- a/.github/workflows/_npu-single-node-test-stage.yml
+++ b/.github/workflows/_npu-single-node-test-stage.yml
@@ -6,7 +6,7 @@ on:
       runner:
         required: true
         type: string
-        default: linux-aarch64-a3-16
+        default: linux-aarch64-a3-16-
       test_type:
         required: true
         type: string

--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -102,7 +102,7 @@ jobs:
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
       self_name: full-1-npu-a3
-      runner_config: linux-aarch64-a3-2
+      runner_config: linux-aarch64-a3-2-
       image: ${{ needs.set-image-config.outputs.image_a3 }}
       run_timeout_minutes: '240'
       timeout_per_file: '3600'
@@ -118,7 +118,7 @@ jobs:
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
       self_name: full-2-npu-a3
-      runner_config: linux-aarch64-a3-2
+      runner_config: linux-aarch64-a3-2-
       image: ${{ needs.set-image-config.outputs.image_a3 }}
       run_timeout_minutes: '240'
       timeout_per_file: '3600'
@@ -134,7 +134,7 @@ jobs:
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
       self_name: full-4-npu-a3
-      runner_config: linux-aarch64-a3-4
+      runner_config: linux-aarch64-a3-4-
       image: ${{ needs.set-image-config.outputs.image_a3 }}
       run_timeout_minutes: '240'
       timeout_per_file: '3600'
@@ -150,7 +150,7 @@ jobs:
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
       self_name: full-8-npu-a3
-      runner_config: linux-aarch64-a3-8
+      runner_config: linux-aarch64-a3-8-
       image: ${{ needs.set-image-config.outputs.image_a3 }}
       run_timeout_minutes: '240'
       timeout_per_file: '3600'
@@ -166,7 +166,7 @@ jobs:
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
       self_name: full-16-npu-a3
-      runner_config: linux-aarch64-a3-16
+      runner_config: linux-aarch64-a3-16-
       image: ${{ needs.set-image-config.outputs.image_a3 }}
       run_timeout_minutes: '240'
       timeout_per_file: '3600'


### PR DESCRIPTION
## Motivation

The a3 runner labels have been renamed to the trailing-dash format (`linux-aarch64-a3-{1,2,4,8,16}-`). Some workflows still reference the old labels without the trailing dash (`linux-aarch64-a3-{1,2,4,8,16}`), which will cause job scheduling failures on the new runner pool.

## Modifications

- `.github/workflows/full-test-npu.yml`: update 5 `runner_config` values (`full-1/2-npu-a3`, `full-4-npu-a3`, `full-8-npu-a3`, `full-16-npu-a3`) from `linux-aarch64-a3-{2,2,4,8,16}` to `linux-aarch64-a3-{2,2,4,8,16}-`.
- `.github/workflows/_npu-single-node-test-stage.yml`: update the `runner` input default from `linux-aarch64-a3-16` to `linux-aarch64-a3-16-`.

Note: `linux-aarch64-a3-800t-*` entries are a different naming scheme and intentionally left unchanged.

## Accuracy Tests

Not applicable (CI workflow configuration change only, no model output changes).

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34101301888](https://github.com/Ascend/sglang/actions/runs/34101301888)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34101315211](https://github.com/Ascend/sglang/actions/runs/34101315211)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->