### PR TITLE
[CI][NPU] Add DSV4-Pro/Flash-0731 A3 testcases (radix cache + LayerSplit)

### DIFF
--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -1,11 +1,11 @@
 name: Full Test (NPU)
 
 on:
-#  pull_request:
-#    branches:
-#      - main
-#    paths:
-#      - ".github/workflows/full-test-npu.yml"
+  pull_request:
+    branches:
+      - testcases-260813
+    paths:
+      - ".github/workflows/full-test-npu.yml"
   workflow_dispatch:
     inputs:
       ref:
@@ -28,6 +28,15 @@ on:
         required: false
         type: string
         default: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3'
+      test_scope:
+        description: 'Test scope: all (every job) / poc (only nightly-poc-single-node-tests matrix) / no_nightly (full suites + poc matrix, skip nighly-test-npu)'
+        required: false
+        type: choice
+        options:
+          - poc
+          - all
+          - no_nightly
+        default: 'poc'
 
 concurrency:
   group: full-test-npu-${{ inputs.ref || github.ref }}
@@ -41,6 +50,7 @@ jobs:
       job_filter: ${{ steps.set-vars.outputs.job_filter }}
       image_a2: ${{ steps.set-vars.outputs.image_a2 }}
       image_a3: ${{ steps.set-vars.outputs.image_a3 }}
+      test_scope: ${{ steps.set-vars.outputs.test_scope }}
     steps:
       # When triggered by PR, no inputs parameters are used. The latest community code is tested by default.
       - name: Set image config
@@ -70,10 +80,18 @@ jobs:
             echo "image_a3=${{ inputs.image_a3 }}" >> $GITHUB_OUTPUT
           fi
 
+          # PR events carry no inputs: default to 'poc' so only the
+          # nightly-poc-single-node-tests matrix (explicitly listed cases) runs.
+          if [ -z "${{ inputs.test_scope }}" ]; then
+            echo "test_scope=poc" >> $GITHUB_OUTPUT
+          else
+            echo "test_scope=${{ inputs.test_scope }}" >> $GITHUB_OUTPUT
+          fi
+
   nighly-test-npu:
     needs: [set-image-config]
     name: nightly-test-npu
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && needs.set-image-config.outputs.test_scope == 'all' }}
     uses: ./.github/workflows/nightly-test-npu.yml
     with:
       ref:  ${{ needs.set-image-config.outputs.ref }}
@@ -83,7 +101,7 @@ jobs:
 
   full-4-npu-a2:
     name: full-4-npu-a2
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -97,7 +115,7 @@ jobs:
 
   full-1-npu-a3:
     name: full-1-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -113,7 +131,7 @@ jobs:
 
   full-2-npu-a3:
     name: full-2-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -129,7 +147,7 @@ jobs:
 
   full-4-npu-a3:
     name: full-4-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -145,7 +163,7 @@ jobs:
 
   full-8-npu-a3:
     name: full-8-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -161,7 +179,7 @@ jobs:
 
   full-16-npu-a3:
     name: full-16-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -177,7 +195,7 @@ jobs:
 
   full-acc-2-npu-a3:
     name: full-acc-2-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -193,7 +211,7 @@ jobs:
 
   full-acc-4-npu-a3:
     name: full-acc-4-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -209,7 +227,7 @@ jobs:
 
   full-acc-16-npu-a3:
     name: full-acc-16-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -225,7 +243,7 @@ jobs:
 
   full-perf-2-npu-a3:
     name: full-perf-2-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -241,7 +259,7 @@ jobs:
 
   full-perf-4-npu-a3:
     name: full-perf-4-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -257,7 +275,7 @@ jobs:
 
   full-perf-8-npu-a3:
     name: full-perf-8-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -273,7 +291,7 @@ jobs:
 
   full-perf-16-npu-a3:
     name: full-perf-16-npu-a3
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -287,10 +305,58 @@ jobs:
       skip_pr_test_health_check: 'true'
     secrets: inherit
 
+  # Curated POC matrix: only the test cases explicitly listed below run.
+  # Default scope for PR events (test_scope=poc), so a PR touching this
+  # workflow only triggers these cases instead of the full suites.
+  nightly-poc-single-node-tests:
+    name: single-node-poc
+    needs: [ set-image-config ]
+    if: ${{ !cancelled() && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'poc' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        test_config:
+          # DeepSeek-V4-Pro-0813 W4A8 single-node (16 NPUs), radix cache enabled
+          - name: deepseek_v4_pro_w4a8_8p_in128k_out1k
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/npu/performance/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_8p_in128k_out1k.py
+            test_type: 'perf'
+          - name: deepseek_v4_pro_w4a8_8p_in128k_out1k_prefix90
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/npu/performance/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_8p_in128k_out1k_prefix90.py
+            test_type: 'perf'
+          - name: deepseek_v4_pro_w4a8_8p_gpqa
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/npu/accuracy/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_8p_gpqa.py
+            test_type: 'accuracy'
+          # DeepSeek-V4-Flash-0731 W8A8 single-node (16 NPUs), radix cache enabled
+          - name: deepseek_v4_flash_0731_w8a8_8p_in128k_out1k
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_8p_in128k_out1k.py
+            test_type: 'perf'
+          - name: deepseek_v4_flash_0731_w8a8_8p_in128k_out1k_prefix90
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_8p_in128k_out1k_prefix90.py
+            test_type: 'perf'
+          - name: deepseek_v4_flash_0731_w8a8_8p_gpqa
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/npu/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_8p_gpqa.py
+            test_type: 'accuracy'
+    uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
+    with:
+      runner: ${{ matrix.test_config.runner }}
+      test_type: ${{ matrix.test_config.test_type }}
+      test_config_name: ${{ matrix.test_config.name }}
+      test_case: ${{ matrix.test_config.test_case }}
+      image: ${{ needs.set-image-config.outputs.image_a3 }}
+      install_sglang_from_source: false
+      transformers_version: ''
+
   full-poc-multi-node-tests:
     name: multi-node-poc
     needs: [ set-image-config ]
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -377,7 +443,7 @@ jobs:
 
   full-poc-multi-node-mix-tests:
     name: multi-node-mix-poc
-    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') }}
+    if: ${{ (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (needs.set-image-config.outputs.test_scope == 'all' || needs.set-image-config.outputs.test_scope == 'no_nightly') }}
     needs: [set-image-config]
     strategy:
       fail-fast: false
@@ -423,6 +489,7 @@ jobs:
       - full-perf-4-npu-a3
       - full-perf-8-npu-a3
       - full-perf-16-npu-a3
+      - nightly-poc-single-node-tests
       - full-poc-multi-node-tests
       - full-poc-multi-node-mix-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -75,7 +75,7 @@ jobs:
           fi
 
           if [ -z "${{ inputs.image_a3 }}" ]; then
-            echo "image_a3=swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3" >> $GITHUB_OUTPUT
+            echo "image_a3=swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:cann9.1.0-a3-20260904" >> $GITHUB_OUTPUT
           else
             echo "image_a3=${{ inputs.image_a3 }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/nightly-test-npu-e2e-single-node.yml
+++ b/.github/workflows/nightly-test-npu-e2e-single-node.yml
@@ -1,0 +1,257 @@
+name: 'Nightly Test (NPU) Single Node Template'
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+        default: linux-aarch64-a3-16
+      test_type:
+        required: false
+        type: string
+        default: perf
+        description: perf or accuracy
+      test_config_name:
+        required: true
+        type: string
+        description: test config name
+      test_case:
+        required: true
+        type: string
+        description: path of test case file
+      image:
+        required: false
+        type: string
+        description: image for pods
+        default: "swr.cn-southwest-2.myhuaweicloud.com/base_image/dockerhub/lmsysorg/sglang:main-cann9.0.0-a3"
+      install_sglang_from_source:
+        required: false
+        type: boolean
+        default: false
+        description: use sglang from source code or from docker image
+      install_sglang_deps:
+        required: false
+        type: boolean
+        default: false
+        description: install sglang dependencies (e.g. PyTorch, CANN packages) when using source installation
+      device_type_for_deps:
+        required: false
+        type: string
+        default: 'a3'
+        description: device type for dependency installation (a3 or 910b)
+      transformers_version:
+        required: false
+        type: string
+        default: ""
+        description: "The transformers version number for running sglang. Use default version in image if keep empty."
+
+concurrency:
+  group: ascend-nightly-e2e-singlenode-${{ github.workflow_ref }}-${{ github.ref }}-${{ inputs.test_config_name }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: ${{ inputs.test_config_name }}
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check npu info
+        run: |
+          npu-smi info
+
+      - name: Install sglang dependencies
+        if: ${{ inputs.install_sglang_deps == true }}
+        shell: bash
+        env:
+          TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+          PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+          UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+          GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+          RUSTUP_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local:8082"
+        run: |
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host "${CACHING_URL}"
+          bash scripts/ci/npu/npu_ci_install_dependency.sh ${{ inputs.device_type_for_deps }}
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+
+      - name: Run test
+        timeout-minutes: 300
+        env:
+          SGLANG_USE_MODELSCOPE: true
+          HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_IS_IN_CI: true
+          TRANSFORMERS_VERBOSITY: "error"
+          GDN_ATTN_BACKEND_TRITON: 1
+          SGLANG_TEST_METRICS_OUTPUT: /root/.cache/tests/output/metrics/metrics
+        shell: bash
+        run: |
+          sglang_source_path=$(pwd)
+          echo "Source code path: ${sglang_source_path}"
+          ln -sf ${sglang_source_path} /root/sglang
+
+          test_case=${{ inputs.test_case }}
+          if [ ! -f "${sglang_source_path}/${test_case}" ]; then
+            echo "The testcase does not exit: ${sglang_source_path}/${test_case}"
+            exit 1
+          fi
+
+          # prepare for output data
+          current_date=$(date +%Y%m%d)
+          test_data_output_path=/root/.cache/tests/output/${{ inputs.test_type }}/${current_date}
+          mkdir -p ${test_data_output_path}
+          tc_name=${test_case##*/}
+          tc_name=${tc_name%.*}
+          export METRICS_DATA_FILE=${test_data_output_path}/${tc_name}
+          mkdir -p ${METRICS_DATA_FILE}
+          echo "Metrics file path: ${METRICS_DATA_FILE}"
+
+          # copy required file from our daily cache
+          cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp
+          curl -o /tmp/test.jsonl -L https://gh-proxy.test.osinfra.cn/https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl
+
+          export TRANSFORMERS_VERSION_FOR_SGLANG="${{ inputs.transformers_version }}"
+          PYTHON_FOR_SGLANG="python"
+          PIP_FOR_SGLANG="pip"
+          if [ -n "${TRANSFORMERS_VERSION_FOR_SGLANG}" ];then
+            echo "===== Install transformers for sglang - Begin ====="
+            TRANSFORMERS_PKG_PATH_SOURCE=/root/.cache/.cache/transformers/${TRANSFORMERS_VERSION_FOR_SGLANG}
+            if [ ! -d "${TRANSFORMERS_PKG_PATH_SOURCE}" ]; then
+              echo "The dependent transformers package does not exist: ${TRANSFORMERS_PKG_PATH_SOURCE}."
+              echo "Install transformers ${TRANSFORMERS_VERSION_FOR_SGLANG} online."
+              pip install transformers=="${TRANSFORMERS_VERSION_FOR_SGLANG}" -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
+            else
+              echo "Install transformers ${TRANSFORMERS_VERSION_FOR_SGLANG} locally."
+              TRANSFORMERS_PKG_PATH_TARGET=/tmp/transformers/${TRANSFORMERS_VERSION_FOR_SGLANG}
+              mkdir -p "${TRANSFORMERS_PKG_PATH_TARGET}"
+              cp "${TRANSFORMERS_PKG_PATH_SOURCE}/*" "${TRANSFORMERS_PKG_PATH_TARGET}/"
+              pip install --no-index --find-links="${TRANSFORMERS_PKG_PATH_TARGET}" transformers=="${TRANSFORMERS_VERSION_FOR_SGLANG}"
+            fi
+            echo "===== Install transformers for sglang in virtual env - End ====="
+          fi
+          echo "Transformers version for sglang: $(${PIP_FOR_SGLANG} show transformers | grep Version | cut -d: -f2)"
+
+          echo "scaling_governor performance num: \
+            $(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor | grep performance | wc -l)"
+          echo "swappiness: $(cat /proc/sys/vm/swappiness)"
+          echo "numa_balancing: $(cat /proc/sys/kernel/numa_balancing)"
+          echo "sched_migration_cost_ns: $(cat /proc/sys/kernel/sched_migration_cost_ns)"
+
+          export SGLANG_TEST_MAX_RETRY=0
+          export SGLANG_SET_CPU_AFFINITY=1
+          echo "SGLANG_SET_CPU_AFFINITY: $SGLANG_SET_CPU_AFFINITY"
+
+          install_sglang_from_source=${{ inputs.install_sglang_from_source }}
+          if [ "$install_sglang_from_source" = "true" ] || [ "$install_sglang_from_source" = "True" ];then
+            echo "Install sglang from source"
+            commit_id=${{ github.sha }}
+            echo "commit id: ${commit_id}" > ${test_data_output_path}/commit_id
+            export PYTHONPATH=${sglang_source_path}/python:$PYTHONPATH
+          else
+            echo "Use sglang from image: ${{ inputs.image }}"
+            sglang_pkg_path=/sgl-workspace/sglang/python
+            ascend_test_util_path=${sglang_pkg_path}/sglang/test/ascend
+            mkdir -p ${ascend_test_util_path}
+            mv ${ascend_test_util_path} ${ascend_test_util_path}_bak
+            cp -r ${sglang_source_path}/python/sglang/test/ascend ${ascend_test_util_path}
+          fi
+
+          source /usr/local/Ascend/cann/set_env.sh || true
+          source /usr/local/Ascend/nnal/atb/set_env.sh || true
+          source /usr/local/Ascend/ascend-toolkit/latest/opp/vendors/customize/bin/set_env.bash || true
+          source /usr/local/Ascend/ascend-toolkit/latest/opp/vendors/custom_transformer/bin/set_env.bash || true
+
+          # Set environment of cann
+          log_path="/root/.cache/tests/logs/log/${current_date}/${tc_name}/${HOSTNAME}"
+          rm -rf ${log_path}
+          mkdir -p ${log_path}
+          echo "Log path: ${log_path}"
+
+          echo "Running test case ${test_case}"
+          test_exit_code=0
+          ${PYTHON_FOR_SGLANG} -u ${test_case} 2>&1 | tee /tmp/test_output.log || test_exit_code=$?
+          echo "Finished test case ${test_case}"
+
+          if [ "${test_exit_code}" = "0" ]; then
+            test_status="pass"
+            status_icon="✅"
+          else
+            test_status="fail"
+            status_icon="❌"
+          fi
+
+          echo "test_status=${test_status}" >> $GITHUB_ENV
+          echo "tc_name=${tc_name}" >> $GITHUB_ENV
+          export test_status tc_name
+
+          echo "## ${tc_name}  ${status_icon} ${test_status}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          metric_count=$(grep -c '\[METRIC\]' /tmp/test_output.log 2>/dev/null || echo 0)
+          if [ "${metric_count}" -gt 0 ]; then
+            echo "| Metric | Value | Pass |" >> $GITHUB_STEP_SUMMARY
+            echo "|--------|-------|------|" >> $GITHUB_STEP_SUMMARY
+            grep '\[METRIC\]' /tmp/test_output.log | while IFS= read -r line; do
+              metric_name=$(echo "$line" | sed -E 's/.*\[METRIC\] ([^=]+)=.*/\1/')
+              metric_value=$(echo "$line" | sed -E 's/.*\[METRIC\] [^=]+=([^ ]+).*/\1/')
+              echo "| ${metric_name} | ${metric_value} | ${status_icon} |" >> $GITHUB_STEP_SUMMARY
+            done
+          else
+            echo "No metrics collected (test may have failed before producing results)." >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "import json, re, os" > /tmp/dump_metrics.py
+          echo "tc = os.environ.get('tc_name', 'unknown')" >> /tmp/dump_metrics.py
+          echo "st = os.environ.get('test_status', 'unknown')" >> /tmp/dump_metrics.py
+          echo "tp = '${{ inputs.test_type }}'" >> /tmp/dump_metrics.py
+          echo "metrics = {}" >> /tmp/dump_metrics.py
+          echo "with open('/tmp/test_output.log') as f:" >> /tmp/dump_metrics.py
+          echo "    for line in f:" >> /tmp/dump_metrics.py
+          echo "        m = re.match(r'\[METRIC\] (\S+)=(\S+)', line)" >> /tmp/dump_metrics.py
+          echo "        if m:" >> /tmp/dump_metrics.py
+          echo "            v = m.group(2)" >> /tmp/dump_metrics.py
+          echo "            try:" >> /tmp/dump_metrics.py
+          echo "                v = float(v)" >> /tmp/dump_metrics.py
+          echo "            except ValueError:" >> /tmp/dump_metrics.py
+          echo "                pass" >> /tmp/dump_metrics.py
+          echo "            metrics[m.group(1)] = v" >> /tmp/dump_metrics.py
+          echo "baselines = {}" >> /tmp/dump_metrics.py
+          echo "for k, v in list(metrics.items()):" >> /tmp/dump_metrics.py
+          echo "    if k.endswith('_baseline'):" >> /tmp/dump_metrics.py
+          echo "        baselines[k[:-9]] = v" >> /tmp/dump_metrics.py
+          echo "        del metrics[k]" >> /tmp/dump_metrics.py
+          echo "with open('/tmp/metrics.json', 'w') as f:" >> /tmp/dump_metrics.py
+          echo "    json.dump({'test_case': tc, 'test_type': tp, 'status': st, 'metrics': metrics, 'baselines': baselines}, f)" >> /tmp/dump_metrics.py
+          python3 /tmp/dump_metrics.py
+          exit ${test_exit_code}
+
+      - name: Upload metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: metrics-${{ inputs.test_config_name }}
+          path: /tmp/metrics.json
+          retention-days: 7
+
+      - name: Backup plog
+        if: always()
+        shell: bash
+        run: |
+          plog_path="/root/ascend/log/debug/plog"
+          if [ -d "$plog_path" ];then
+            echo "Plog files found. Begin to backup them."
+            tc_name=${{ inputs.test_case }}
+            tc_name=${tc_name##*/}
+            tc_name=${tc_name%.*}
+            target_plog_path="/root/.cache/tests/logs/plog/${tc_name}/${HOSTNAME}"
+            echo "Save path: ${target_plog_path}"
+            rm -rf ${target_plog_path}
+            mkdir -p ${target_plog_path}
+            cp ${plog_path}/* ${target_plog_path}
+          fi

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -180,6 +180,16 @@ QWEN3_5_397B_W8A8_MODEL_PATH = (
 DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH = (
     "/root/.cache/modelscope/hub/models/Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp"
 )
+# DeepSeek-V4-Pro-0813 W4A8 weights (already available in the A3 environment).
+DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH = (
+    "/root/.cache/modelscope/hub/models/Eco-Tech/DeepSeek-V4-Pro-0813-w4a8"
+)
+# DeepSeek-V4-Flash-0731 W8A8 weights. Not preinstalled in the environment:
+# download them to this path (or adjust the constant) before running the
+# 0731 testcases.
+DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH = (
+    "/root/.cache/modelscope/hub/models/Eco-Tech/DeepSeek-V4-Flash-0731-w8a8"
+)
 QWEN3_5_397B_W4A8_MODEL_PATH = (
     "/root/.cache/modelscope/hub/models/Eco-Tech/Qwen3.5-397B-A17B-w4a8-mtp"
 )

--- a/test/registered/npu/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_1p1d_16p_gpqa.py
+++ b/test/registered/npu/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_1p1d_16p_gpqa.py
@@ -1,0 +1,236 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_accuracy_utils import (
+    TestNpuAccuracyMultiNodePdSepTestCaseBase,
+)
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=3600,
+    suite="",
+    nightly=True,
+    disabled="accuracy testcase",
+)
+
+# Environment variables shared by prefill/decode nodes, ported from
+# scripts_shell/pd/flash_1p1d/dsv4_flash_pd.sh.
+# FORCE_DRAFT_MODEL_NON_QUANT is intentionally NOT set: the bundled DSPARK
+# draft weights are modelslim-quantized.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_COMMON_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "INF_NAN_MODE_FORCE_DISABLE": "1",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "USE_NPU_MOE_GATING_TOP_K": "1",
+    "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
+    "SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT": "60",
+    # skip gpu branch
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "SGLANG_DSV4_FP4_EXPERTS": "False",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+}
+
+# Prefill node environment variables for DSV4-Flash-0731 PD-Sep deployment.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ENVS = {
+    **DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_COMMON_ENVS,
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "1024",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "8192",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "8",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
+    "HCCL_BUFFSIZE": "2048",
+    "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "0",
+    "SGLANG_ENABLE_WAR_BARRIER": "1",
+    "SGLANG_FORCE_COARSE_WAR_BARRIER": "1",
+    # send cached prefix to decode early for radix-cache hits
+    "SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX": "1",
+}
+
+# Decode node environment variables for DSV4-Flash-0731 PD-Sep deployment.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ENVS = {
+    **DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_COMMON_ENVS,
+    "HCCL_BUFFSIZE": "1200",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "8",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "2048",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "128",
+    "SGLANG_NPU_USE_MULTI_STREAM": "0",
+    "SGLANG_NPU_SPLIT_SHARED_EXPERT_OVERLAP": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Prefill node (1 node x 16 NPUs, TP16 DP8) launch arguments.
+# Radix cache is intentionally ENABLED on prefill (no --disable-radix-cache).
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "dsv4",
+    "--watchdog-timeout",
+    9000,
+    "--disaggregation-mode",
+    "prefill",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--disaggregation-bootstrap-port",
+    8998,
+    "--mem-fraction-static",
+    0.62,
+    "--prefill-max-requests",
+    6,
+    "--max-prefill-tokens",
+    140000,
+    "--chunked-prefill-size",
+    65536,
+    "--max-running-requests",
+    128,
+    "--dp-size",
+    8,
+    "--enable-dp-attention",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "normal",
+    "--quantization",
+    "modelslim",
+    "--enable-dp-lm-head",
+    "--kv-cache-dtype",
+    "bfloat16",
+    "--context-length",
+    140000,
+    "--disable-cuda-graph",
+    "--load-balance-method",
+    "round_robin",
+]
+
+# Decode node (1 node x 16 NPUs, TP16 DP16) launch arguments.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "dsv4",
+    "--watchdog-timeout",
+    9000,
+    "--mem-fraction-static",
+    0.7,
+    "--disaggregation-mode",
+    "decode",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--max-running-requests",
+    256,
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "low_latency",
+    "--quantization",
+    "modelslim",
+    "--enable-dp-lm-head",
+    "--kv-cache-dtype",
+    "bfloat16",
+    "--context-length",
+    140000,
+    "--load-balance-method",
+    "round_robin",
+    "--cuda-graph-bs",
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    # DSPARK speculative decoding with the bundled W8A8 draft.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+    # Radix cache enabled on decode for the cache-hit scenario.
+    "--disaggregation-decode-enable-radix-cache",
+]
+
+# Model config for DSV4-Flash-0731 W8A8 1P+1D PD-Sep deployment.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_MODEL_CONFIG = {
+    "model_path": DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    "prefill_args": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ARGS,
+    "decode_args": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ARGS,
+    "prefill_envs": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ENVS,
+    "decode_envs": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ENVS,
+    "router_args": ["--policy", "cache_aware"],
+    "router_envs": {},
+}
+
+# Generation config for Think High mode (thinking=true, reasoning_effort=high).
+DEEPSEEK_V4_FLASH_0731_W8A8_GENERATION_CONFIG_HIGH = {
+    "max_tokens": 125000,
+    "top_p": 1,
+    "temperature": 1,
+    "n": 1,
+    "extra_body": {
+        "chat_template_kwargs": {"thinking": True, "reasoning_effort": "high"}
+    },
+}
+
+
+class TestNPUDeepSeekV4Flash0731W8A8PDSEPGPQAHigh(
+    TestNpuAccuracyMultiNodePdSepTestCaseBase
+):
+    """Test NPU accuracy for DSV4-Flash-0731 W8A8 PD-Sep GPQA High mode.
+
+    Requirement: DSV4_Flash_Radix_Cache_0 (step 2, 1P1D PD separation with
+    radix cache enabled).
+    """
+
+    model_config = DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_MODEL_CONFIG
+    # TODO: calibrate the baseline on the first successful run
+    # (reference: Flash W8A8 GPQA Diamond baseline is 0.874).
+    accuracy = 0.85
+    datasets = ["gpqa_diamond"]
+    generation_config = DEEPSEEK_V4_FLASH_0731_W8A8_GENERATION_CONFIG_HIGH
+    eval_batch_size = 128
+
+    def test_npu_deepseek_v4_flash_0731_w8a8_pd_sep_gpqa_high(self):
+        """Run NPU accuracy test for DSV4-Flash-0731 PD-Sep GPQA High mode."""
+        self.run_accuracy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_8p_gpqa.py
+++ b/test/registered/npu/accuracy/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_8p_gpqa.py
@@ -1,0 +1,157 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_accuracy_utils import (
+    BENCHMARK_TOOL_DEFAULT,
+    TestNpuAccuracyTestCaseBase,
+)
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=3600,
+    suite="nightly-acc-16-npu-a3",
+    nightly=True,
+)
+
+# Environment variables for DSV4-Flash-0731 single-node PD-mix deployment,
+# ported from scripts_shell/dspark-with-radix-cache/dsv4_flash_single.sh.
+# FORCE_DRAFT_MODEL_NON_QUANT is intentionally NOT set: the bundled DSPARK
+# draft weights are modelslim-quantized.
+DEEPSEEK_V4_FLASH_0731_W8A8_8P_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "INF_NAN_MODE_FORCE_DISABLE": "1",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "HCCL_BUFFSIZE": "1200",
+    # deepep
+    "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "16",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "2048",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "256",
+    # skip gpu branch
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "SGLANG_DSV4_FP4_EXPERTS": "False",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Server launch arguments for DSV4-Flash-0731 W8A8 single-node 16p PD-mix.
+# Radix cache is intentionally ENABLED (no --disable-radix-cache).
+DEEPSEEK_V4_FLASH_0731_W8A8_8P_OTHER_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "dsv4",
+    "--watchdog-timeout",
+    9000,
+    "--mem-fraction-static",
+    0.65,
+    "--prefill-max-requests",
+    16,
+    "--max-prefill-tokens",
+    204800,
+    "--chunked-prefill-size",
+    65536,
+    "--max-running-requests",
+    160,
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--quantization",
+    "modelslim",
+    "--kv-cache-dtype",
+    "bfloat16",
+    "--context-length",
+    140000,
+    "--cuda-graph-bs",
+    1,
+    2,
+    4,
+    8,
+    10,
+    "--skip-server-warmup",
+    "--disable-piecewise-cuda-graph",
+    # DSPARK speculative decoding with the bundled W8A8 draft.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+]
+
+# Generation config for Think High mode (thinking=true, reasoning_effort=high).
+DEEPSEEK_V4_FLASH_0731_W8A8_GENERATION_CONFIG_HIGH = {
+    "max_tokens": 125000,
+    "top_p": 1,
+    "temperature": 1,
+    "n": 1,
+    "extra_body": {
+        "chat_template_kwargs": {"thinking": True, "reasoning_effort": "high"}
+    },
+}
+
+
+class TestNPUDeepSeekV4Flash0731W8A88PGPQAHigh(TestNpuAccuracyTestCaseBase):
+    """Test NPU accuracy for DeepSeek-V4-Flash-0731 W8A8 16p GPQA High mode.
+
+    Requirement: DSV4_Flash_Radix_Cache_1 (step 2, single-node, radix on).
+    """
+
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    model = DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH
+    other_args = DEEPSEEK_V4_FLASH_0731_W8A8_8P_OTHER_ARGS
+    envs = DEEPSEEK_V4_FLASH_0731_W8A8_8P_ENVS
+    # TODO: calibrate the baseline on the first successful run
+    # (reference: Flash W8A8 GPQA Diamond baseline is 0.874).
+    accuracy = 0.85
+    datasets = ["gpqa_diamond"]
+    few_shot_num = 0
+    generation_config = DEEPSEEK_V4_FLASH_0731_W8A8_GENERATION_CONFIG_HIGH
+    eval_batch_size = 128
+    stream = True
+    timeout = 6000
+    seed = 1
+
+    def test_npu_deepseek_v4_flash_0731_w8a8_8p_gpqa_high(self):
+        """Run NPU accuracy test for DSV4-Flash-0731 W8A8 16p GPQA High mode."""
+        self.run_accuracy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/accuracy/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_1p1d_layersplit_gpqa.py
+++ b/test/registered/npu/accuracy/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_1p1d_layersplit_gpqa.py
@@ -1,0 +1,240 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_accuracy_utils import (
+    TestNpuAccuracyMultiNodePdSepTestCaseBase,
+)
+from sglang.test.ascend.e2e.test_npu_multi_node_utils import NIC_NAME
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=4800,
+    suite="",
+    nightly=True,
+    disabled="accuracy testcase",
+)
+
+# NOTE (known blocker, verify before running): in the current codebase
+# `--enable-dsa-cache-layer-split` is rejected for DeepseekV4ForCausalLM by
+# the generic arch check in server_args.py (is_deepseek_dsa only covers
+# V3/V32/GLM/Longcat archs). DeepSeek-V4 has its own prefill-CP support
+# (validate_deepseek_v4_cp: interleave-only, dp_size == 1, tp_size <= 8).
+# Make sure the deployed sglang version extends the layer-split arch check
+# to DeepseekV4 before enabling this testcase.
+
+# Common environment variables shared by prefill/decode nodes, ported from
+# scripts_shell/pd/pro_1p1d(2+2)/dsv4_pro_pd.sh.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS = {
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "TRANSFORMERS_VERBOSITY": "error",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "HCCL_CONNECT_TIMEOUT": "300",
+    "HCCL_EXEC_TIMEOUT": "68",
+    "SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT": "1200",
+    "SGLANG_DISAGGREGATION_WAITING_TIMEOUT": "1200",
+    # skip gpu branch
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "FORCE_DRAFT_MODEL_NON_QUANT": "1",
+    "SGLANG_DSV4_FP4_EXPERTS": "True",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "HCCL_SOCKET_IFNAME": NIC_NAME,
+    "GLOO_SOCKET_IFNAME": NIC_NAME,
+}
+
+# Prefill node environment variables for the LayerSplit deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_LS_PREFILL_ENVS = {
+    **DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS,
+    "DEEPEP_HCCL_BUFFSIZE": "2048",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "64",
+    # memory fabric for PD KV transfer
+    "MF_HYBM_USE_VMM_SEGMENT": "1",
+    "ASCEND_MF_TRANSFER_PROTOCOL": "device_urma",
+    "ASCEND_MF_STORE_URL": "tcp://127.0.0.1:24667",
+}
+
+# Decode node environment variables for the LayerSplit deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_LS_DECODE_ENVS = {
+    **DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS,
+    "DEEPEP_HCCL_BUFFSIZE": "900",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "30",
+    "SGLANG_NPU_USE_MULTI_STREAM": "1",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Prefill node (1 node x 8 NPUs, TP8, prefill-CP attn-cp 8) launch args.
+# V4 prefill CP constraints (validate_deepseek_v4_cp): dp_size == 1 and
+# tp_size <= 8, so attn-cp 8 forces a single-node TP8 prefill topology.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_LS_PREFILL_ARGS = [
+    "--disaggregation-mode",
+    "prefill",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--disaggregation-bootstrap-port",
+    8998,
+    "--tp-size",
+    8,
+    "--nnodes",
+    1,
+    "--trust-remote-code",
+    "--attention-backend",
+    "ascend",
+    "--device",
+    "npu",
+    "--watchdog-timeout",
+    9000,
+    "--max-running-requests",
+    64,
+    "--mem-fraction-static",
+    0.83,
+    "--quantization",
+    "modelslim",
+    "--max-prefill-tokens",
+    2048000,
+    "--chunked-prefill-size",
+    65536,
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--context-length",
+    133120,
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--disable-cuda-graph",
+    # LayerSplit (requirement DSV4_Pro_LayerSplit_0):
+    # --enable-dsa-cache-layer-split --attn-cp-size 8 --cp-strategy interleave
+    "--enable-prefill-cp",
+    "--cp-strategy",
+    "interleave",
+    "--attn-cp-size",
+    8,
+    "--enable-dsa-cache-layer-split",
+]
+
+# Decode node (2 nodes x 8 NPUs, TP16 DP4) launch arguments.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_LS_DECODE_ARGS = [
+    "--disaggregation-mode",
+    "decode",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--tp-size",
+    16,
+    "--nnodes",
+    2,
+    "--dp-size",
+    4,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--load-balance-method",
+    "round_robin",
+    "--trust-remote-code",
+    "--attention-backend",
+    "ascend",
+    "--device",
+    "npu",
+    "--watchdog-timeout",
+    9000,
+    "--max-running-requests",
+    256,
+    "--mem-fraction-static",
+    0.86,
+    "--quantization",
+    "modelslim",
+    "--max-prefill-tokens",
+    2048000,
+    "--chunked-prefill-size",
+    16384,
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--context-length",
+    133120,
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--cuda-graph-bs",
+    1,
+    2,
+    4,
+    8,
+    "--tokenizer-worker-num",
+    8,
+    # DSPARK speculative decoding with the bundled draft weights.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+]
+
+# Model config for DSV4-Pro W4A8 LayerSplit PD-Sep deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_LS_MODEL_CONFIG = {
+    "model_path": DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    "prefill_args": DEEPSEEK_V4_PRO_W4A8_PD_SEP_LS_PREFILL_ARGS,
+    "decode_args": DEEPSEEK_V4_PRO_W4A8_PD_SEP_LS_DECODE_ARGS,
+    "prefill_envs": DEEPSEEK_V4_PRO_W4A8_PD_SEP_LS_PREFILL_ENVS,
+    "decode_envs": DEEPSEEK_V4_PRO_W4A8_PD_SEP_LS_DECODE_ENVS,
+    "router_args": ["--policy", "round_robin"],
+    "router_envs": {},
+}
+
+# Generation config for Think High mode (thinking=true, reasoning_effort=high).
+DEEPSEEK_V4_PRO_W4A8_GENERATION_CONFIG_HIGH = {
+    "max_tokens": 125000,
+    "top_p": 1,
+    "temperature": 1,
+    "n": 1,
+    "extra_body": {
+        "chat_template_kwargs": {"thinking": True, "reasoning_effort": "high"}
+    },
+}
+
+
+class TestNPUDeepSeekV4ProW4A8PDSepLayerSplitGPQAHigh(
+    TestNpuAccuracyMultiNodePdSepTestCaseBase
+):
+    """Test NPU accuracy for DSV4-Pro-0813 W4A8 PD-Sep prefill LayerSplit.
+
+    Requirement: DSV4_Pro_LayerSplit_0 (1P1D PD separation, prefill with
+    --enable-dsa-cache-layer-split --attn-cp-size 8 --cp-strategy interleave,
+    GPQA accuracy within tolerance).
+    """
+
+    model_config = DEEPSEEK_V4_PRO_W4A8_PD_SEP_LS_MODEL_CONFIG
+    # TODO: calibrate the baseline on the first successful run.
+    accuracy = 0.85
+    datasets = ["gpqa_diamond"]
+    generation_config = DEEPSEEK_V4_PRO_W4A8_GENERATION_CONFIG_HIGH
+    eval_batch_size = 64
+
+    def test_npu_deepseek_v4_pro_w4a8_pd_sep_layersplit_gpqa_high(self):
+        """Run NPU accuracy test for DSV4-Pro W4A8 PD-Sep LayerSplit GPQA."""
+        self.run_accuracy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/accuracy/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_2p2d_16p_gpqa.py
+++ b/test/registered/npu/accuracy/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_2p2d_16p_gpqa.py
@@ -1,0 +1,238 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_accuracy_utils import (
+    TestNpuAccuracyMultiNodePdSepTestCaseBase,
+)
+from sglang.test.ascend.e2e.test_npu_multi_node_utils import NIC_NAME
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=4800,
+    suite="",
+    nightly=True,
+    disabled="accuracy testcase",
+)
+
+# Common environment variables shared by prefill/decode nodes, ported from
+# scripts_shell/pd/pro_1p1d(2+2)/dsv4_pro_pd.sh.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS = {
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "TRANSFORMERS_VERBOSITY": "error",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "HCCL_CONNECT_TIMEOUT": "300",
+    "HCCL_EXEC_TIMEOUT": "68",
+    "SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT": "1200",
+    "SGLANG_DISAGGREGATION_WAITING_TIMEOUT": "1200",
+    # skip gpu branch
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "FORCE_DRAFT_MODEL_NON_QUANT": "1",
+    "SGLANG_DSV4_FP4_EXPERTS": "True",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "HCCL_SOCKET_IFNAME": NIC_NAME,
+    "GLOO_SOCKET_IFNAME": NIC_NAME,
+}
+
+# Prefill node environment variables for DSV4-Pro PD-Sep deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ENVS = {
+    **DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS,
+    "DEEPEP_HCCL_BUFFSIZE": "2048",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "64",
+    # memory fabric for PD KV transfer
+    "MF_HYBM_USE_VMM_SEGMENT": "1",
+    "ASCEND_MF_TRANSFER_PROTOCOL": "device_urma",
+    "ASCEND_MF_STORE_URL": "tcp://127.0.0.1:24667",
+    # prefill delay
+    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "200",
+    # send cached prefix to decode early for radix-cache hits
+    "SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX": "1",
+}
+
+# Decode node environment variables for DSV4-Pro PD-Sep deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ENVS = {
+    **DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS,
+    "DEEPEP_HCCL_BUFFSIZE": "900",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "30",
+    "SGLANG_NPU_USE_MULTI_STREAM": "1",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Prefill node (2 nodes x 8 NPUs, TP16 DP4) launch arguments.
+# Radix cache is intentionally ENABLED on prefill (no --disable-radix-cache).
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ARGS = [
+    "--disaggregation-mode",
+    "prefill",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--disaggregation-bootstrap-port",
+    8998,
+    "--tp-size",
+    16,
+    "--nnodes",
+    2,
+    "--dp-size",
+    4,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--load-balance-method",
+    "round_robin",
+    "--trust-remote-code",
+    "--attention-backend",
+    "ascend",
+    "--device",
+    "npu",
+    "--watchdog-timeout",
+    9000,
+    "--max-running-requests",
+    64,
+    "--mem-fraction-static",
+    0.83,
+    "--quantization",
+    "modelslim",
+    "--max-prefill-tokens",
+    2048000,
+    "--chunked-prefill-size",
+    65536,
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--context-length",
+    133120,
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--disable-cuda-graph",
+    "--enable-dynamic-batch-tokenizer",
+    "--tokenizer-worker-num",
+    16,
+]
+
+# Decode node (2 nodes x 8 NPUs, TP16 DP4) launch arguments.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ARGS = [
+    "--disaggregation-mode",
+    "decode",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--tp-size",
+    16,
+    "--nnodes",
+    2,
+    "--dp-size",
+    4,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--load-balance-method",
+    "round_robin",
+    "--trust-remote-code",
+    "--attention-backend",
+    "ascend",
+    "--device",
+    "npu",
+    "--watchdog-timeout",
+    9000,
+    "--max-running-requests",
+    256,
+    "--mem-fraction-static",
+    0.86,
+    "--quantization",
+    "modelslim",
+    "--max-prefill-tokens",
+    2048000,
+    "--chunked-prefill-size",
+    16384,
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--context-length",
+    133120,
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--cuda-graph-bs",
+    1,
+    2,
+    4,
+    8,
+    "--tokenizer-worker-num",
+    8,
+    # DSPARK speculative decoding with the bundled draft weights.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+    # Radix cache enabled on decode for the cache-hit scenario.
+    "--disaggregation-decode-enable-radix-cache",
+]
+
+# Model config for DSV4-Pro W4A8 2P+2D PD-Sep deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_MODEL_CONFIG = {
+    "model_path": DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    "prefill_args": DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ARGS,
+    "decode_args": DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ARGS,
+    "prefill_envs": DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ENVS,
+    "decode_envs": DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ENVS,
+    "router_args": ["--policy", "cache_aware"],
+    "router_envs": {},
+}
+
+# Generation config for Think High mode (thinking=true, reasoning_effort=high).
+DEEPSEEK_V4_PRO_W4A8_GENERATION_CONFIG_HIGH = {
+    "max_tokens": 125000,
+    "top_p": 1,
+    "temperature": 1,
+    "n": 1,
+    "extra_body": {
+        "chat_template_kwargs": {"thinking": True, "reasoning_effort": "high"}
+    },
+}
+
+
+class TestNPUDeepSeekV4ProW4A8PDSEPGPQAHigh(
+    TestNpuAccuracyMultiNodePdSepTestCaseBase
+):
+    """Test NPU accuracy for DeepSeek-V4-Pro-0813 W4A8 PD-Sep GPQA High mode.
+
+    Requirement: DSV4_Pro_Radix_Cache_0 (step 2, 1P1D PD separation with
+    radix cache enabled).
+    """
+
+    model_config = DEEPSEEK_V4_PRO_W4A8_PD_SEP_MODEL_CONFIG
+    # TODO: calibrate the baseline on the first successful run.
+    accuracy = 0.85
+    datasets = ["gpqa_diamond"]
+    generation_config = DEEPSEEK_V4_PRO_W4A8_GENERATION_CONFIG_HIGH
+    eval_batch_size = 64
+
+    def test_npu_deepseek_v4_pro_w4a8_pd_sep_gpqa_high(self):
+        """Run NPU accuracy test for DSV4-Pro W4A8 PD-Sep GPQA High mode."""
+        self.run_accuracy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/accuracy/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_8p_gpqa.py
+++ b/test/registered/npu/accuracy/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_8p_gpqa.py
@@ -1,0 +1,148 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_accuracy_utils import (
+    BENCHMARK_TOOL_DEFAULT,
+    TestNpuAccuracyTestCaseBase,
+)
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=4800,
+    suite="nightly-acc-16-npu-a3",
+    nightly=True,
+)
+
+# Environment variables for DSV4-Pro-0813 single-node PD-mix deployment,
+# ported from scripts_shell/dspark-with-radix-cache/dsv4_pro_2mix.sh.
+DEEPSEEK_V4_PRO_W4A8_8P_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "HCCL_CONNECT_TIMEOUT": "300",
+    "HCCL_EXEC_TIMEOUT": "68",
+    "DEEPEP_HCCL_BUFFSIZE": "1536",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "30",
+    # skip gpu branch
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "FORCE_DRAFT_MODEL_NON_QUANT": "1",
+    "SGLANG_DSV4_FP4_EXPERTS": "True",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "TRANSFORMERS_VERBOSITY": "error",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Server launch arguments for DSV4-Pro W4A8 single-node 16p PD-mix.
+# Radix cache is intentionally ENABLED (no --disable-radix-cache).
+DEEPSEEK_V4_PRO_W4A8_8P_OTHER_ARGS = [
+    "--tp-size",
+    16,
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "ascend",
+    "--watchdog-timeout",
+    9000,
+    "--max-running-requests",
+    160,
+    "--mem-fraction-static",
+    0.86,
+    "--quantization",
+    "modelslim",
+    "--max-prefill-tokens",
+    2048000,
+    "--chunked-prefill-size",
+    65536,
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--moe-dense-tp-size",
+    1,
+    "--context-length",
+    133120,
+    "--cuda-graph-bs",
+    1,
+    4,
+    "--load-balance-method",
+    "round_robin",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    # DSPARK speculative decoding with the bundled draft weights.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+]
+
+# Generation config for Think High mode (thinking=true, reasoning_effort=high).
+DEEPSEEK_V4_PRO_W4A8_GENERATION_CONFIG_HIGH = {
+    "max_tokens": 125000,
+    "top_p": 1,
+    "temperature": 1,
+    "n": 1,
+    "extra_body": {
+        "chat_template_kwargs": {"thinking": True, "reasoning_effort": "high"}
+    },
+}
+
+
+class TestNPUDeepSeekV4ProW4A88PGPQAHigh(TestNpuAccuracyTestCaseBase):
+    """Test NPU accuracy for DeepSeek-V4-Pro-0813 W4A8 16p GPQA High mode.
+
+    Requirement: DSV4_Pro_Radix_Cache_1 (step 2, single-node, radix cache on).
+    """
+
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    model = DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH
+    other_args = DEEPSEEK_V4_PRO_W4A8_8P_OTHER_ARGS
+    envs = DEEPSEEK_V4_PRO_W4A8_8P_ENVS
+    # TODO: calibrate the baseline on the first successful run
+    # (reference: Flash W8A8 GPQA Diamond baseline is 0.874).
+    accuracy = 0.85
+    datasets = ["gpqa_diamond"]
+    few_shot_num = 0
+    generation_config = DEEPSEEK_V4_PRO_W4A8_GENERATION_CONFIG_HIGH
+    eval_batch_size = 64
+    stream = True
+    timeout = 7200
+    seed = 1
+
+    def test_npu_deepseek_v4_pro_w4a8_8p_gpqa_high(self):
+        """Run NPU accuracy test for DeepSeek-V4-Pro W4A8 16p GPQA High mode."""
+        self.run_accuracy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_1p1d_16p_in128k_out1k.py
+++ b/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_1p1d_16p_in128k_out1k.py
@@ -1,0 +1,232 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    AISBENCHMARK_DATASET_DEFAULT,
+    BENCHMARK_TOOL_DEFAULT,
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    TestNpuPerfMultiNodePdSepTestCaseBase,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=3600,
+    suite="",
+    nightly=True,
+    disabled="performance testcase",
+)
+
+# Environment variables shared by prefill/decode nodes, ported from
+# scripts_shell/pd/flash_1p1d/dsv4_flash_pd.sh.
+# FORCE_DRAFT_MODEL_NON_QUANT is intentionally NOT set: the bundled DSPARK
+# draft weights are modelslim-quantized.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_COMMON_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "INF_NAN_MODE_FORCE_DISABLE": "1",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "USE_NPU_MOE_GATING_TOP_K": "1",
+    "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
+    "SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT": "60",
+    # skip gpu branch
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "SGLANG_DSV4_FP4_EXPERTS": "False",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+}
+
+# Prefill node environment variables for DSV4-Flash-0731 PD-Sep deployment.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ENVS = {
+    **DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_COMMON_ENVS,
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "1024",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "8192",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "8",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
+    "HCCL_BUFFSIZE": "2048",
+    "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "0",
+    "SGLANG_ENABLE_WAR_BARRIER": "1",
+    "SGLANG_FORCE_COARSE_WAR_BARRIER": "1",
+    # send cached prefix to decode early for radix-cache hits
+    "SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX": "1",
+}
+
+# Decode node environment variables for DSV4-Flash-0731 PD-Sep deployment.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ENVS = {
+    **DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_COMMON_ENVS,
+    "HCCL_BUFFSIZE": "1200",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "8",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "2048",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "128",
+    "SGLANG_NPU_USE_MULTI_STREAM": "0",
+    "SGLANG_NPU_SPLIT_SHARED_EXPERT_OVERLAP": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Prefill node (1 node x 16 NPUs, TP16 DP8) launch arguments.
+# Radix cache is intentionally ENABLED on prefill (no --disable-radix-cache).
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "dsv4",
+    "--watchdog-timeout",
+    9000,
+    "--disaggregation-mode",
+    "prefill",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--disaggregation-bootstrap-port",
+    8998,
+    "--mem-fraction-static",
+    0.62,
+    "--prefill-max-requests",
+    6,
+    "--max-prefill-tokens",
+    140000,
+    "--chunked-prefill-size",
+    65536,
+    "--max-running-requests",
+    128,
+    "--dp-size",
+    8,
+    "--enable-dp-attention",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "normal",
+    "--quantization",
+    "modelslim",
+    "--enable-dp-lm-head",
+    "--kv-cache-dtype",
+    "bfloat16",
+    "--context-length",
+    140000,
+    "--disable-cuda-graph",
+    "--load-balance-method",
+    "round_robin",
+]
+
+# Decode node (1 node x 16 NPUs, TP16 DP16) launch arguments.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "dsv4",
+    "--watchdog-timeout",
+    9000,
+    "--mem-fraction-static",
+    0.7,
+    "--disaggregation-mode",
+    "decode",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--max-running-requests",
+    256,
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "low_latency",
+    "--quantization",
+    "modelslim",
+    "--enable-dp-lm-head",
+    "--kv-cache-dtype",
+    "bfloat16",
+    "--context-length",
+    140000,
+    "--load-balance-method",
+    "round_robin",
+    "--cuda-graph-bs",
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    # DSPARK speculative decoding with the bundled W8A8 draft.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+    # Radix cache enabled on decode for the cache-hit scenario.
+    "--disaggregation-decode-enable-radix-cache",
+]
+
+# Model config for DSV4-Flash-0731 W8A8 1P+1D PD-Sep deployment.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_MODEL_CONFIG = {
+    "model_path": DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    "prefill_args": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ARGS,
+    "decode_args": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ARGS,
+    "prefill_envs": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ENVS,
+    "decode_envs": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ENVS,
+    "router_args": ["--policy", "cache_aware"],
+    "router_envs": {},
+}
+
+
+class TestNPUDeepSeekV4Flash0731W8A8PDSEPIn128kOut1k(
+    TestNpuPerfMultiNodePdSepTestCaseBase
+):
+    """Test NPU perf for DeepSeek-V4-Flash-0731 W8A8 PD-Sep 1P+1D in128k.
+
+    Requirement: DSV4_Flash_Radix_Cache_0 (step 3, PD separation random 128k
+    benchserving, radix cache on).
+    """
+
+    model_config = DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_MODEL_CONFIG
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    dataset_type = AISBENCHMARK_DATASET_DEFAULT
+    dataset_name = "random"
+    input_len = 131072
+    output_len = 1024
+    num_prompts = 40
+    max_concurrency = 40
+    random_range_ratio = 1
+    warmup_requests = 0
+    request_rate = float("inf")
+    seed = 1
+    # TODO: calibrate tpot / output_token_throughput baselines on the first
+    # successful run, then set them here to enable regression assertions.
+
+    def test_npu_deepseek_v4_flash_0731_w8a8_pd_sep_in128k_out1k(self):
+        """Run NPU perf test for DSV4-Flash-0731 PD-Sep in128k out1k."""
+        self.run_throughput()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_1p1d_16p_in128k_out1k_prefix90.py
+++ b/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_1p1d_16p_in128k_out1k_prefix90.py
@@ -1,0 +1,238 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    AISBENCHMARK_DATASET_DEFAULT,
+    BENCHMARK_TOOL_DEFAULT,
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    TestNpuPerfMultiNodePdSepTestCaseBase,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=3600,
+    suite="",
+    nightly=True,
+    disabled="performance testcase",
+)
+
+# Environment variables shared by prefill/decode nodes, ported from
+# scripts_shell/pd/flash_1p1d/dsv4_flash_pd.sh.
+# FORCE_DRAFT_MODEL_NON_QUANT is intentionally NOT set: the bundled DSPARK
+# draft weights are modelslim-quantized.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_COMMON_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "INF_NAN_MODE_FORCE_DISABLE": "1",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "USE_NPU_MOE_GATING_TOP_K": "1",
+    "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
+    "SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT": "60",
+    # skip gpu branch
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "SGLANG_DSV4_FP4_EXPERTS": "False",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+}
+
+# Prefill node environment variables for DSV4-Flash-0731 PD-Sep deployment.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ENVS = {
+    **DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_COMMON_ENVS,
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "1024",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "8192",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "8",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
+    "HCCL_BUFFSIZE": "2048",
+    "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "0",
+    "SGLANG_ENABLE_WAR_BARRIER": "1",
+    "SGLANG_FORCE_COARSE_WAR_BARRIER": "1",
+    # send cached prefix to decode early for radix-cache hits
+    "SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX": "1",
+}
+
+# Decode node environment variables for DSV4-Flash-0731 PD-Sep deployment.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ENVS = {
+    **DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_COMMON_ENVS,
+    "HCCL_BUFFSIZE": "1200",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "8",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "2048",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "128",
+    "SGLANG_NPU_USE_MULTI_STREAM": "0",
+    "SGLANG_NPU_SPLIT_SHARED_EXPERT_OVERLAP": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Prefill node (1 node x 16 NPUs, TP16 DP8) launch arguments.
+# Radix cache is intentionally ENABLED on prefill (no --disable-radix-cache).
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "dsv4",
+    "--watchdog-timeout",
+    9000,
+    "--disaggregation-mode",
+    "prefill",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--disaggregation-bootstrap-port",
+    8998,
+    "--mem-fraction-static",
+    0.62,
+    "--prefill-max-requests",
+    6,
+    "--max-prefill-tokens",
+    140000,
+    "--chunked-prefill-size",
+    65536,
+    "--max-running-requests",
+    128,
+    "--dp-size",
+    8,
+    "--enable-dp-attention",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "normal",
+    "--quantization",
+    "modelslim",
+    "--enable-dp-lm-head",
+    "--kv-cache-dtype",
+    "bfloat16",
+    "--context-length",
+    140000,
+    "--disable-cuda-graph",
+    "--load-balance-method",
+    "round_robin",
+]
+
+# Decode node (1 node x 16 NPUs, TP16 DP16) launch arguments.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "dsv4",
+    "--watchdog-timeout",
+    9000,
+    "--mem-fraction-static",
+    0.7,
+    "--disaggregation-mode",
+    "decode",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--max-running-requests",
+    256,
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "low_latency",
+    "--quantization",
+    "modelslim",
+    "--enable-dp-lm-head",
+    "--kv-cache-dtype",
+    "bfloat16",
+    "--context-length",
+    140000,
+    "--load-balance-method",
+    "round_robin",
+    "--cuda-graph-bs",
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    # DSPARK speculative decoding with the bundled W8A8 draft.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+    # Radix cache enabled on decode for the cache-hit scenario.
+    "--disaggregation-decode-enable-radix-cache",
+]
+
+# Model config for DSV4-Flash-0731 W8A8 1P+1D PD-Sep deployment.
+DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_MODEL_CONFIG = {
+    "model_path": DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    "prefill_args": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ARGS,
+    "decode_args": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ARGS,
+    "prefill_envs": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_PREFILL_ENVS,
+    "decode_envs": DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_DECODE_ENVS,
+    "router_args": ["--policy", "cache_aware"],
+    "router_envs": {},
+}
+
+
+class TestNPUDeepSeekV4Flash0731W8A8PDSEPIn128kOut1kPrefix90(
+    TestNpuPerfMultiNodePdSepTestCaseBase
+):
+    """Test NPU perf for DSV4-Flash-0731 W8A8 PD-Sep 1P+1D in128k prefix90.
+
+    Requirement: DSV4_Flash_Radix_Cache_0 (step 4, PD separation 128k input
+    with 90% radix-cache hit rate). The shared-prefix dataset makes 90% of
+    each input length a repeated prefix, so radix cache hits should reduce
+    TTFT noticeably compared with the random-input test above.
+    """
+
+    model_config = DEEPSEEK_V4_FLASH_0731_W8A8_PD_SEP_MODEL_CONFIG
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    dataset_type = AISBENCHMARK_DATASET_DEFAULT
+    dataset_name = "generated-shared-prefix"
+    repeat_rate = 0.9
+    input_len = 131072
+    output_len = 1024
+    num_prompts = 40
+    max_concurrency = 40
+    random_range_ratio = 1
+    warmup_requests = 0
+    request_rate = float("inf")
+    seed = 1
+    temperature = 0.6
+    top_p = 0.95
+    # TODO: calibrate tpot / output_token_throughput / ttft baselines on the
+    # first successful run, then set them here to enable regression assertions.
+    pop_sglang_is_in_ci_for_gsp = True
+
+    def test_npu_deepseek_v4_flash_0731_w8a8_pd_sep_in128k_out1k_prefix90(self):
+        """Run NPU perf test for DSV4-Flash-0731 PD-Sep in128k prefix90."""
+        self.run_throughput()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_8p_in128k_out1k.py
+++ b/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_8p_in128k_out1k.py
@@ -1,0 +1,151 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    AISBENCHMARK_DATASET_DEFAULT,
+    BENCHMARK_TOOL_DEFAULT,
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    TestNpuPerformanceTestCaseBase,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=3600,
+    suite="nightly-perf-16-npu-a3",
+    nightly=True,
+)
+
+# Environment variables for DSV4-Flash-0731 single-node PD-mix deployment,
+# ported from scripts_shell/dspark-with-radix-cache/dsv4_flash_single.sh.
+# FORCE_DRAFT_MODEL_NON_QUANT is intentionally NOT set: the bundled DSPARK
+# draft weights are modelslim-quantized.
+DEEPSEEK_V4_FLASH_0731_W8A8_8P_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "INF_NAN_MODE_FORCE_DISABLE": "1",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "HCCL_BUFFSIZE": "1200",
+    # deepep
+    "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "16",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "2048",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "256",
+    # skip gpu branch
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "SGLANG_DSV4_FP4_EXPERTS": "False",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Server launch arguments for DSV4-Flash-0731 W8A8 single-node 16p PD-mix.
+# Radix cache is intentionally ENABLED (no --disable-radix-cache).
+DEEPSEEK_V4_FLASH_0731_W8A8_8P_OTHER_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "dsv4",
+    "--watchdog-timeout",
+    9000,
+    "--mem-fraction-static",
+    0.65,
+    "--prefill-max-requests",
+    16,
+    "--max-prefill-tokens",
+    204800,
+    "--chunked-prefill-size",
+    65536,
+    "--max-running-requests",
+    160,
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--quantization",
+    "modelslim",
+    "--kv-cache-dtype",
+    "bfloat16",
+    "--context-length",
+    140000,
+    "--cuda-graph-bs",
+    1,
+    2,
+    4,
+    8,
+    10,
+    "--skip-server-warmup",
+    "--disable-piecewise-cuda-graph",
+    # DSPARK speculative decoding with the bundled W8A8 draft.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+]
+
+
+class TestNPUDeepSeekV4Flash0731W8A88PIn128kOut1k(
+    TestNpuPerformanceTestCaseBase
+):
+    """Test NPU performance for DeepSeek-V4-Flash-0731 W8A8 16p in128k out1k.
+
+    Requirement: DSV4_Flash_Radix_Cache_1 (step 3, single-node random 128k
+    benchserving, radix cache on).
+    """
+
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    dataset_type = AISBENCHMARK_DATASET_DEFAULT
+    model = DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH
+    other_args = DEEPSEEK_V4_FLASH_0731_W8A8_8P_OTHER_ARGS
+    envs = DEEPSEEK_V4_FLASH_0731_W8A8_8P_ENVS
+    dataset_name = "random"
+    input_len = 131072
+    output_len = 1024
+    num_prompts = 40
+    max_concurrency = 40
+    random_range_ratio = 1
+    warmup_requests = 0
+    request_rate = float("inf")
+    seed = 1
+    # TODO: calibrate tpot / output_token_throughput baselines on the first
+    # successful run, then set them here to enable regression assertions.
+    max_attempts = 3
+
+    def test_npu_deepseek_v4_flash_0731_w8a8_8p_in128k_out1k(self):
+        """Run NPU perf test for DSV4-Flash-0731 W8A8 16p in128k out1k."""
+        self.run_throughput()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_8p_in128k_out1k_prefix90.py
+++ b/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_0731_w8a8_8p_in128k_out1k_prefix90.py
@@ -1,0 +1,157 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    AISBENCHMARK_DATASET_DEFAULT,
+    BENCHMARK_TOOL_DEFAULT,
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    TestNpuPerformanceTestCaseBase,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=3600,
+    suite="nightly-perf-16-npu-a3",
+    nightly=True,
+)
+
+# Environment variables for DSV4-Flash-0731 single-node PD-mix deployment,
+# ported from scripts_shell/dspark-with-radix-cache/dsv4_flash_single.sh.
+# FORCE_DRAFT_MODEL_NON_QUANT is intentionally NOT set: the bundled DSPARK
+# draft weights are modelslim-quantized.
+DEEPSEEK_V4_FLASH_0731_W8A8_8P_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "INF_NAN_MODE_FORCE_DISABLE": "1",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "HCCL_BUFFSIZE": "1200",
+    # deepep
+    "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
+    "DEEPEP_NORMAL_LONG_SEQ_ROUND": "16",
+    "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS": "2048",
+    "DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ": "1",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "256",
+    # skip gpu branch
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "SGLANG_DSV4_FP4_EXPERTS": "False",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Server launch arguments for DSV4-Flash-0731 W8A8 single-node 16p PD-mix.
+# Radix cache is intentionally ENABLED (no --disable-radix-cache).
+DEEPSEEK_V4_FLASH_0731_W8A8_8P_OTHER_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "dsv4",
+    "--watchdog-timeout",
+    9000,
+    "--mem-fraction-static",
+    0.65,
+    "--prefill-max-requests",
+    16,
+    "--max-prefill-tokens",
+    204800,
+    "--chunked-prefill-size",
+    65536,
+    "--max-running-requests",
+    160,
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--quantization",
+    "modelslim",
+    "--kv-cache-dtype",
+    "bfloat16",
+    "--context-length",
+    140000,
+    "--cuda-graph-bs",
+    1,
+    2,
+    4,
+    8,
+    10,
+    "--skip-server-warmup",
+    "--disable-piecewise-cuda-graph",
+    # DSPARK speculative decoding with the bundled W8A8 draft.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+]
+
+
+class TestNPUDeepSeekV4Flash0731W8A88PIn128kOut1kPrefix90(
+    TestNpuPerformanceTestCaseBase
+):
+    """Test NPU perf for DSV4-Flash-0731 W8A8 16p in128k out1k prefix90.
+
+    Requirement: DSV4_Flash_Radix_Cache_1 (step 4, single-node 128k input
+    with 90% radix-cache hit rate). The shared-prefix dataset makes 90% of
+    each input length a repeated prefix, so radix cache hits should reduce
+    TTFT noticeably compared with the random-input test above.
+    """
+
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    dataset_type = AISBENCHMARK_DATASET_DEFAULT
+    model = DEEPSEEK_V4_FLASH_0731_W8A8_MODEL_PATH
+    other_args = DEEPSEEK_V4_FLASH_0731_W8A8_8P_OTHER_ARGS
+    envs = DEEPSEEK_V4_FLASH_0731_W8A8_8P_ENVS
+    dataset_name = "generated-shared-prefix"
+    warmup_requests = 0
+    max_concurrency = 40
+    num_prompts = 40
+    repeat_rate = 0.9
+    input_len = 131072
+    output_len = 1024
+    random_range_ratio = 1
+    seed = 1
+    temperature = 0.6
+    top_p = 0.95
+    request_rate = float("inf")
+    # TODO: calibrate tpot / output_token_throughput / ttft baselines on the
+    # first successful run, then set them here to enable regression assertions.
+    max_attempts = 3
+    pop_sglang_is_in_ci_for_gsp = True
+
+    def test_npu_deepseek_v4_flash_0731_w8a8_8p_in128k_out1k_prefix90(self):
+        """Run NPU perf test for DSV4-Flash-0731 W8A8 16p in128k prefix90."""
+        self.run_throughput()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/performance/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_2p2d_16p_in128k_out1k.py
+++ b/test/registered/npu/performance/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_2p2d_16p_in128k_out1k.py
@@ -1,0 +1,235 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_multi_node_utils import NIC_NAME
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    AISBENCHMARK_DATASET_DEFAULT,
+    BENCHMARK_TOOL_DEFAULT,
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    TestNpuPerfMultiNodePdSepTestCaseBase,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=4800,
+    suite="",
+    nightly=True,
+    disabled="performance testcase",
+)
+
+# Common environment variables shared by prefill/decode nodes, ported from
+# scripts_shell/pd/pro_1p1d(2+2)/dsv4_pro_pd.sh.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS = {
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "TRANSFORMERS_VERBOSITY": "error",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "HCCL_CONNECT_TIMEOUT": "300",
+    "HCCL_EXEC_TIMEOUT": "68",
+    "SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT": "1200",
+    "SGLANG_DISAGGREGATION_WAITING_TIMEOUT": "1200",
+    # skip gpu branch
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "FORCE_DRAFT_MODEL_NON_QUANT": "1",
+    "SGLANG_DSV4_FP4_EXPERTS": "True",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "HCCL_SOCKET_IFNAME": NIC_NAME,
+    "GLOO_SOCKET_IFNAME": NIC_NAME,
+}
+
+# Prefill node environment variables for DSV4-Pro PD-Sep deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ENVS = {
+    **DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS,
+    "DEEPEP_HCCL_BUFFSIZE": "2048",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "64",
+    # memory fabric for PD KV transfer
+    "MF_HYBM_USE_VMM_SEGMENT": "1",
+    "ASCEND_MF_TRANSFER_PROTOCOL": "device_urma",
+    "ASCEND_MF_STORE_URL": "tcp://127.0.0.1:24667",
+    # prefill delay
+    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "200",
+    # send cached prefix to decode early for radix-cache hits
+    "SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX": "1",
+}
+
+# Decode node environment variables for DSV4-Pro PD-Sep deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ENVS = {
+    **DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS,
+    "DEEPEP_HCCL_BUFFSIZE": "900",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "30",
+    "SGLANG_NPU_USE_MULTI_STREAM": "1",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Prefill node (2 nodes x 8 NPUs, TP16 DP4) launch arguments.
+# Radix cache is intentionally ENABLED on prefill (no --disable-radix-cache).
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ARGS = [
+    "--disaggregation-mode",
+    "prefill",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--disaggregation-bootstrap-port",
+    8998,
+    "--tp-size",
+    16,
+    "--nnodes",
+    2,
+    "--dp-size",
+    4,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--load-balance-method",
+    "round_robin",
+    "--trust-remote-code",
+    "--attention-backend",
+    "ascend",
+    "--device",
+    "npu",
+    "--watchdog-timeout",
+    9000,
+    "--max-running-requests",
+    64,
+    "--mem-fraction-static",
+    0.83,
+    "--quantization",
+    "modelslim",
+    "--max-prefill-tokens",
+    2048000,
+    "--chunked-prefill-size",
+    65536,
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--context-length",
+    133120,
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--disable-cuda-graph",
+    "--enable-dynamic-batch-tokenizer",
+    "--tokenizer-worker-num",
+    16,
+]
+
+# Decode node (2 nodes x 8 NPUs, TP16 DP4) launch arguments.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ARGS = [
+    "--disaggregation-mode",
+    "decode",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--tp-size",
+    16,
+    "--nnodes",
+    2,
+    "--dp-size",
+    4,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--load-balance-method",
+    "round_robin",
+    "--trust-remote-code",
+    "--attention-backend",
+    "ascend",
+    "--device",
+    "npu",
+    "--watchdog-timeout",
+    9000,
+    "--max-running-requests",
+    256,
+    "--mem-fraction-static",
+    0.86,
+    "--quantization",
+    "modelslim",
+    "--max-prefill-tokens",
+    2048000,
+    "--chunked-prefill-size",
+    16384,
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--context-length",
+    133120,
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--cuda-graph-bs",
+    1,
+    2,
+    4,
+    8,
+    "--tokenizer-worker-num",
+    8,
+    # DSPARK speculative decoding with the bundled draft weights.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+    # Radix cache enabled on decode for the cache-hit scenario.
+    "--disaggregation-decode-enable-radix-cache",
+]
+
+# Model config for DSV4-Pro W4A8 2P+2D PD-Sep deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_MODEL_CONFIG = {
+    "model_path": DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    "prefill_args": DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ARGS,
+    "decode_args": DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ARGS,
+    "prefill_envs": DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ENVS,
+    "decode_envs": DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ENVS,
+    "router_args": ["--policy", "cache_aware"],
+    "router_envs": {},
+}
+
+
+class TestNPUDeepSeekV4ProW4A8PDSEPIn128kOut1k(
+    TestNpuPerfMultiNodePdSepTestCaseBase
+):
+    """Test NPU performance for DeepSeek-V4-Pro W4A8 PD-Sep 2P+2D in128k out1k.
+
+    Requirement: DSV4_Pro_Radix_Cache_0 (step 3, PD separation random 128k
+    benchserving, radix cache on).
+    """
+
+    model_config = DEEPSEEK_V4_PRO_W4A8_PD_SEP_MODEL_CONFIG
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    dataset_type = AISBENCHMARK_DATASET_DEFAULT
+    dataset_name = "random"
+    input_len = 131072
+    output_len = 1024
+    num_prompts = 32
+    max_concurrency = 32
+    random_range_ratio = 1
+    warmup_requests = 0
+    request_rate = float("inf")
+    seed = 1
+    # TODO: calibrate tpot / output_token_throughput baselines on the first
+    # successful run, then set them here to enable regression assertions.
+
+    def test_npu_deepseek_v4_pro_w4a8_pd_sep_in128k_out1k(self):
+        """Run NPU perf test for DeepSeek-V4-Pro W4A8 PD-Sep in128k out1k."""
+        self.run_throughput()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/performance/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_2p2d_16p_in128k_out1k_prefix90.py
+++ b/test/registered/npu/performance/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_2p2d_16p_in128k_out1k_prefix90.py
@@ -1,0 +1,241 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_multi_node_utils import NIC_NAME
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    AISBENCHMARK_DATASET_DEFAULT,
+    BENCHMARK_TOOL_DEFAULT,
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    TestNpuPerfMultiNodePdSepTestCaseBase,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=4800,
+    suite="",
+    nightly=True,
+    disabled="performance testcase",
+)
+
+# Common environment variables shared by prefill/decode nodes, ported from
+# scripts_shell/pd/pro_1p1d(2+2)/dsv4_pro_pd.sh.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS = {
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "TRANSFORMERS_VERBOSITY": "error",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "HCCL_CONNECT_TIMEOUT": "300",
+    "HCCL_EXEC_TIMEOUT": "68",
+    "SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT": "1200",
+    "SGLANG_DISAGGREGATION_WAITING_TIMEOUT": "1200",
+    # skip gpu branch
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "FORCE_DRAFT_MODEL_NON_QUANT": "1",
+    "SGLANG_DSV4_FP4_EXPERTS": "True",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "HCCL_SOCKET_IFNAME": NIC_NAME,
+    "GLOO_SOCKET_IFNAME": NIC_NAME,
+}
+
+# Prefill node environment variables for DSV4-Pro PD-Sep deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ENVS = {
+    **DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS,
+    "DEEPEP_HCCL_BUFFSIZE": "2048",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "64",
+    # memory fabric for PD KV transfer
+    "MF_HYBM_USE_VMM_SEGMENT": "1",
+    "ASCEND_MF_TRANSFER_PROTOCOL": "device_urma",
+    "ASCEND_MF_STORE_URL": "tcp://127.0.0.1:24667",
+    # prefill delay
+    "SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE": "1",
+    "SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES": "200",
+    # send cached prefix to decode early for radix-cache hits
+    "SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX": "1",
+}
+
+# Decode node environment variables for DSV4-Pro PD-Sep deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ENVS = {
+    **DEEPSEEK_V4_PRO_W4A8_PD_SEP_COMMON_ENVS,
+    "DEEPEP_HCCL_BUFFSIZE": "900",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "30",
+    "SGLANG_NPU_USE_MULTI_STREAM": "1",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Prefill node (2 nodes x 8 NPUs, TP16 DP4) launch arguments.
+# Radix cache is intentionally ENABLED on prefill (no --disable-radix-cache).
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ARGS = [
+    "--disaggregation-mode",
+    "prefill",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--disaggregation-bootstrap-port",
+    8998,
+    "--tp-size",
+    16,
+    "--nnodes",
+    2,
+    "--dp-size",
+    4,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--load-balance-method",
+    "round_robin",
+    "--trust-remote-code",
+    "--attention-backend",
+    "ascend",
+    "--device",
+    "npu",
+    "--watchdog-timeout",
+    9000,
+    "--max-running-requests",
+    64,
+    "--mem-fraction-static",
+    0.83,
+    "--quantization",
+    "modelslim",
+    "--max-prefill-tokens",
+    2048000,
+    "--chunked-prefill-size",
+    65536,
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--context-length",
+    133120,
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--disable-cuda-graph",
+    "--enable-dynamic-batch-tokenizer",
+    "--tokenizer-worker-num",
+    16,
+]
+
+# Decode node (2 nodes x 8 NPUs, TP16 DP4) launch arguments.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ARGS = [
+    "--disaggregation-mode",
+    "decode",
+    "--disaggregation-transfer-backend",
+    "ascend",
+    "--tp-size",
+    16,
+    "--nnodes",
+    2,
+    "--dp-size",
+    4,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--load-balance-method",
+    "round_robin",
+    "--trust-remote-code",
+    "--attention-backend",
+    "ascend",
+    "--device",
+    "npu",
+    "--watchdog-timeout",
+    9000,
+    "--max-running-requests",
+    256,
+    "--mem-fraction-static",
+    0.86,
+    "--quantization",
+    "modelslim",
+    "--max-prefill-tokens",
+    2048000,
+    "--chunked-prefill-size",
+    16384,
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--context-length",
+    133120,
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--cuda-graph-bs",
+    1,
+    2,
+    4,
+    8,
+    "--tokenizer-worker-num",
+    8,
+    # DSPARK speculative decoding with the bundled draft weights.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+    # Radix cache enabled on decode for the cache-hit scenario.
+    "--disaggregation-decode-enable-radix-cache",
+]
+
+# Model config for DSV4-Pro W4A8 2P+2D PD-Sep deployment.
+DEEPSEEK_V4_PRO_W4A8_PD_SEP_MODEL_CONFIG = {
+    "model_path": DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    "prefill_args": DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ARGS,
+    "decode_args": DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ARGS,
+    "prefill_envs": DEEPSEEK_V4_PRO_W4A8_PD_SEP_PREFILL_ENVS,
+    "decode_envs": DEEPSEEK_V4_PRO_W4A8_PD_SEP_DECODE_ENVS,
+    "router_args": ["--policy", "cache_aware"],
+    "router_envs": {},
+}
+
+
+class TestNPUDeepSeekV4ProW4A8PDSEPIn128kOut1kPrefix90(
+    TestNpuPerfMultiNodePdSepTestCaseBase
+):
+    """Test NPU perf for DeepSeek-V4-Pro W4A8 PD-Sep 2P+2D in128k prefix90.
+
+    Requirement: DSV4_Pro_Radix_Cache_0 (step 4, PD separation 128k input
+    with 90% radix-cache hit rate). The shared-prefix dataset makes 90% of
+    each input length a repeated prefix, so radix cache hits should reduce
+    TTFT noticeably compared with the random-input test above.
+    """
+
+    model_config = DEEPSEEK_V4_PRO_W4A8_PD_SEP_MODEL_CONFIG
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    dataset_type = AISBENCHMARK_DATASET_DEFAULT
+    dataset_name = "generated-shared-prefix"
+    repeat_rate = 0.9
+    input_len = 131072
+    output_len = 1024
+    num_prompts = 32
+    max_concurrency = 32
+    random_range_ratio = 1
+    warmup_requests = 0
+    request_rate = float("inf")
+    seed = 1
+    temperature = 0.6
+    top_p = 0.95
+    # TODO: calibrate tpot / output_token_throughput / ttft baselines on the
+    # first successful run, then set them here to enable regression assertions.
+    pop_sglang_is_in_ci_for_gsp = True
+
+    def test_npu_deepseek_v4_pro_w4a8_pd_sep_in128k_out1k_prefix90(self):
+        """Run NPU perf test for DSV4-Pro W4A8 PD-Sep in128k prefix90."""
+        self.run_throughput()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/performance/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_8p_in128k_out1k.py
+++ b/test/registered/npu/performance/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_8p_in128k_out1k.py
@@ -1,0 +1,140 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    AISBENCHMARK_DATASET_DEFAULT,
+    BENCHMARK_TOOL_DEFAULT,
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    TestNpuPerformanceTestCaseBase,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=3600,
+    suite="nightly-perf-16-npu-a3",
+    nightly=True,
+)
+
+# Environment variables for DSV4-Pro-0813 single-node PD-mix deployment,
+# ported from scripts_shell/dspark-with-radix-cache/dsv4_pro_2mix.sh.
+DEEPSEEK_V4_PRO_W4A8_8P_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "HCCL_CONNECT_TIMEOUT": "300",
+    "HCCL_EXEC_TIMEOUT": "68",
+    "DEEPEP_HCCL_BUFFSIZE": "1536",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "30",
+    # skip gpu branch
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "FORCE_DRAFT_MODEL_NON_QUANT": "1",
+    "SGLANG_DSV4_FP4_EXPERTS": "True",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "TRANSFORMERS_VERBOSITY": "error",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Server launch arguments for DSV4-Pro W4A8 single-node 16p PD-mix.
+# Radix cache is intentionally ENABLED (no --disable-radix-cache).
+DEEPSEEK_V4_PRO_W4A8_8P_OTHER_ARGS = [
+    "--tp-size",
+    16,
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "ascend",
+    "--watchdog-timeout",
+    9000,
+    "--max-running-requests",
+    160,
+    "--mem-fraction-static",
+    0.86,
+    "--quantization",
+    "modelslim",
+    "--max-prefill-tokens",
+    2048000,
+    "--chunked-prefill-size",
+    65536,
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--moe-dense-tp-size",
+    1,
+    "--context-length",
+    133120,
+    "--cuda-graph-bs",
+    1,
+    4,
+    "--load-balance-method",
+    "round_robin",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    # DSPARK speculative decoding with the bundled draft weights.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+]
+
+
+class TestNPUDeepSeekV4ProW4A88PIn128kOut1k(TestNpuPerformanceTestCaseBase):
+    """Test NPU performance for DeepSeek-V4-Pro W4A8 16p in128k out1k.
+
+    Requirement: DSV4_Pro_Radix_Cache_1 (step 3, single-node random 128k
+    benchserving, radix cache on).
+    """
+
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    dataset_type = AISBENCHMARK_DATASET_DEFAULT
+    model = DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH
+    other_args = DEEPSEEK_V4_PRO_W4A8_8P_OTHER_ARGS
+    envs = DEEPSEEK_V4_PRO_W4A8_8P_ENVS
+    dataset_name = "random"
+    input_len = 131072
+    output_len = 1024
+    num_prompts = 32
+    max_concurrency = 32
+    random_range_ratio = 1
+    warmup_requests = 0
+    request_rate = float("inf")
+    seed = 1
+    # TODO: calibrate tpot / output_token_throughput baselines on the first
+    # successful run, then set them here to enable regression assertions.
+    max_attempts = 3
+
+    def test_npu_deepseek_v4_pro_w4a8_8p_in128k_out1k(self):
+        """Run NPU performance test for DeepSeek-V4-Pro W4A8 16p in128k out1k."""
+        self.run_throughput()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/performance/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_8p_in128k_out1k_prefix90.py
+++ b/test/registered/npu/performance/deepseek_v4_pro/test_npu_deepseek_v4_pro_w4a8_8p_in128k_out1k_prefix90.py
@@ -1,0 +1,148 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    AISBENCHMARK_DATASET_DEFAULT,
+    BENCHMARK_TOOL_DEFAULT,
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    TestNpuPerformanceTestCaseBase,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=3600,
+    suite="nightly-perf-16-npu-a3",
+    nightly=True,
+)
+
+# Environment variables for DSV4-Pro-0813 single-node PD-mix deployment,
+# ported from scripts_shell/dspark-with-radix-cache/dsv4_pro_2mix.sh.
+DEEPSEEK_V4_PRO_W4A8_8P_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "SGLANG_SET_CPU_AFFINITY": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "HCCL_CONNECT_TIMEOUT": "300",
+    "HCCL_EXEC_TIMEOUT": "68",
+    "DEEPEP_HCCL_BUFFSIZE": "1536",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "30",
+    # skip gpu branch
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "FORCE_DRAFT_MODEL_NON_QUANT": "1",
+    "SGLANG_DSV4_FP4_EXPERTS": "True",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "TRANSFORMERS_VERBOSITY": "error",
+    # MTP (DSPARK)
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    # dspark correctness-first setup
+    "SGLANG_RAGGED_VERIFY_MODE": "static",
+    "SGLANG_DSPARK_FAST_KERNEL": "0",
+    "SGLANG_DSPARK_FAST_SAMPLING": "0",
+    "SGLANG_DSPARK_ENABLE_MULTI_STREAM": "0",
+    "SGLANG_DSPARK_QUANT_AUDIT": "1",
+    "SGLANG_DSPARK_QUANT_AUDIT_STRICT": "0",
+}
+
+# Server launch arguments for DSV4-Pro W4A8 single-node 16p PD-mix.
+# Radix cache is intentionally ENABLED (no --disable-radix-cache).
+DEEPSEEK_V4_PRO_W4A8_8P_OTHER_ARGS = [
+    "--tp-size",
+    16,
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--attention-backend",
+    "ascend",
+    "--watchdog-timeout",
+    9000,
+    "--max-running-requests",
+    160,
+    "--mem-fraction-static",
+    0.86,
+    "--quantization",
+    "modelslim",
+    "--max-prefill-tokens",
+    2048000,
+    "--chunked-prefill-size",
+    65536,
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--moe-dense-tp-size",
+    1,
+    "--context-length",
+    133120,
+    "--cuda-graph-bs",
+    1,
+    4,
+    "--load-balance-method",
+    "round_robin",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    # DSPARK speculative decoding with the bundled draft weights.
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH,
+    "--speculative-draft-model-quantization",
+    "modelslim",
+    "--speculative-draft-attention-backend",
+    "ascend",
+    "--speculative-num-draft-tokens",
+    6,
+]
+
+
+class TestNPUDeepSeekV4ProW4A88PIn128kOut1kPrefix90(
+    TestNpuPerformanceTestCaseBase
+):
+    """Test NPU performance for DeepSeek-V4-Pro W4A8 16p in128k out1k prefix90.
+
+    Requirement: DSV4_Pro_Radix_Cache_1 (step 4, single-node 128k input with
+    90% radix-cache hit rate). The shared-prefix dataset makes 90% of each
+    input length a repeated prefix, so radix cache hits should reduce TTFT
+    noticeably compared with the random-input test above.
+    """
+
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    dataset_type = AISBENCHMARK_DATASET_DEFAULT
+    model = DEEPSEEK_V4_PRO_0813_W4A8_MODEL_PATH
+    other_args = DEEPSEEK_V4_PRO_W4A8_8P_OTHER_ARGS
+    envs = DEEPSEEK_V4_PRO_W4A8_8P_ENVS
+    dataset_name = "generated-shared-prefix"
+    warmup_requests = 0
+    max_concurrency = 32
+    num_prompts = 32
+    repeat_rate = 0.9
+    input_len = 131072
+    output_len = 1024
+    random_range_ratio = 1
+    seed = 1
+    temperature = 0.6
+    top_p = 0.95
+    request_rate = float("inf")
+    # TODO: calibrate tpot / output_token_throughput / ttft baselines on the
+    # first successful run, then set them here to enable regression assertions.
+    max_attempts = 3
+    pop_sglang_is_in_ci_for_gsp = True
+
+    def test_npu_deepseek_v4_pro_w4a8_8p_in128k_out1k_prefix90(self):
+        """Run NPU perf test for DeepSeek-V4-Pro W4A8 16p in128k prefix90."""
+        self.run_throughput()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add DeepSeek-V4-Pro-0813 W4A8 and DeepSeek-V4-Flash-0731 W8A8 A3 testcases covering the radix-cache and LayerSplit requirements, and control the CI scope with a POC matrix.

## Testcases

**DSV4-Pro-0813 W4A8** (single-node 16p + PD-Sep 2P+2D):
- GPQA accuracy (Think High mode), radix cache enabled
- Random 128k input benchserving
- 128k input with 90% shared-prefix (radix cache hit)
- Prefill LayerSplit accuracy (TP8 + CP8, disabled pending arch-check support)

**DSV4-Flash-0731 W8A8** (single-node + PD-Sep 1P+1D):
- Same three single-node cases + three PD-Sep cases (disabled pending multi-node env)

## CI scope control

- Add `nightly-test-npu-e2e-single-node.yml` reusable workflow (from the `testcases` branch) that runs a single testcase file with metric collection
- `full-test-npu.yml`: add `test_scope` input (all/poc/no_nightly, default `poc`). PR events default to `poc` so only the new `nightly-poc-single-node-tests` matrix (the 6 explicitly listed single-node DSV4 cases) runs; full-*/nightly suites and multi-node jobs are gated off unless `test_scope=all/no_nightly`

## Model weights

- `Eco-Tech/DeepSeek-V4-Pro-0813-w4a8` (already available in the environment)
- `Eco-Tech/DeepSeek-V4-Flash-0731-w8a8` (needs to be downloaded to the constant path before the Flash cases run)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34272453150](https://github.com/Ascend/sglang/actions/runs/34272453150)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34272464962](https://github.com/Ascend/sglang/actions/runs/34272464962)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34272453158](https://github.com/Ascend/sglang/actions/runs/34272453158)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->