### PR TITLE
fix: update full-4-npu-a2 runner label to linux-aarch64-a2b3-4

### DIFF
--- a/.github/workflows/full-test-npu.yml
+++ b/.github/workflows/full-test-npu.yml
@@ -87,7 +87,7 @@ jobs:
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
-      runner: linux-aarch64-a2-4
+      runner: linux-aarch64-a2b3-4
       test_type: 'perf'
       test_suite: full-4-npu-a2
       is_nightly_pipeline_job: true


### PR DESCRIPTION
## Problem

The A2 self-hosted runner was renamed from linux-aarch64-a2-4 to linux-aarch64-a2b3-4. The full-4-npu-a2 job still uses the old label, so no runner picks it up and it gets cancelled after queuing for 24h.

## Change

- .github/workflows/full-test-npu.yml: runner linux-aarch64-a2-4 -> linux-aarch64-a2b3-4

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34308172925](https://github.com/Ascend/sglang/actions/runs/34308172925)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34308179591](https://github.com/Ascend/sglang/actions/runs/34308179591)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->